### PR TITLE
Feature/mender install button

### DIFF
--- a/.plans/mender-install-button.md
+++ b/.plans/mender-install-button.md
@@ -1,0 +1,240 @@
+# Plan: Mender Install Button for Device-Initiated OTA
+
+## Goal
+Add an "Install Software" button to retina-gui that allows the device to pull and install the retina-node artifact from Mender, using the device's existing authentication.
+
+## Context
+- Device already has mender-auth running, which stores a JWT token locally
+- Mender Device API allows listing and downloading artifacts
+- Button should only appear when `retina_node_version` is None (not yet installed)
+
+## User Flow
+```
+┌─────────────────────────────────────────────────────┐
+│  Retina Node                           [Home|Config]│
+├─────────────────────────────────────────────────────┤
+│  [Install Software]  ← Only shown if not installed  │
+│  ─────────────────────────────────────────────────  │
+│  Services (greyed out until installed)              │
+│  • blah2 - Passive Radar                            │
+│  • tar1090 - ADS-B Map                              │
+├─────────────────────────────────────────────────────┤
+│  node123 • owl-os: v0.5.0 • retina-node: Not installed │
+└─────────────────────────────────────────────────────┘
+```
+
+After clicking Install:
+- Spinner + "Installing... this may take a few minutes"
+- On success: page refresh shows services, footer shows version
+- On error: show error message
+
+## Artifact Version Selection
+- Artifacts named like: `retina-node-v0.3.2`
+- Must filter out release candidates (e.g., `retina-node-v0.3.2-rc1`)
+- Auto-select latest stable version (no user selection needed)
+
+```python
+import re
+
+def parse_retina_node_version(artifact_name):
+    """Extract version from 'retina-node-v0.3.2' format. Returns None if not stable."""
+    match = re.match(r'^retina-node-v(\d+\.\d+\.\d+)$', artifact_name)
+    if match:
+        return tuple(int(x) for x in match.group(1).split('.'))
+    return None  # Not a stable version (has suffix like -rc1)
+```
+
+## Technical Approach
+
+### 1. Backend Functions (app.py)
+
+```python
+# Mender configuration
+MENDER_SERVER_URL = os.environ.get('MENDER_SERVER_URL', 'https://hosted.mender.io')
+MENDER_AUTH_TOKEN_PATH = '/var/lib/mender/authtoken'
+
+def get_mender_jwt():
+    """Read device's Mender JWT token from mender-auth."""
+    try:
+        with open(MENDER_AUTH_TOKEN_PATH) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return None
+
+def get_available_artifacts():
+    """List artifacts available for this device from Mender."""
+    jwt = get_mender_jwt()
+    if not jwt:
+        return None, "Device not authenticated with Mender"
+
+    try:
+        resp = requests.get(
+            f"{MENDER_SERVER_URL}/api/devices/v1/deployments/artifacts",
+            headers={"Authorization": f"Bearer {jwt}"},
+            timeout=30
+        )
+        if resp.status_code != 200:
+            return None, f"Mender API error: {resp.status_code}"
+        return resp.json(), None
+    except Exception as e:
+        return None, str(e)
+
+def install_artifact(artifact_id):
+    """Download and install artifact via mender-update."""
+    jwt = get_mender_jwt()
+    if not jwt:
+        return False, "Device not authenticated with Mender"
+
+    # Get download URL for artifact
+    try:
+        resp = requests.get(
+            f"{MENDER_SERVER_URL}/api/devices/v1/deployments/artifacts/{artifact_id}/download",
+            headers={"Authorization": f"Bearer {jwt}"},
+            timeout=30
+        )
+        if resp.status_code != 200:
+            return False, f"Failed to get download URL: {resp.status_code}"
+
+        download_url = resp.json().get('uri')
+        if not download_url:
+            return False, "No download URL in response"
+
+        # Install via mender-update
+        result = subprocess.run(
+            ['mender-update', 'install', download_url],
+            capture_output=True, text=True, timeout=600  # 10 min timeout
+        )
+
+        if result.returncode != 0:
+            return False, result.stderr or "Install failed"
+
+        return True, None
+    except subprocess.TimeoutExpired:
+        return False, "Installation timed out"
+    except Exception as e:
+        return False, str(e)
+```
+
+### 2. API Endpoint (app.py)
+
+```python
+@app.route('/mender/install', methods=['POST'])
+def mender_install():
+    """Install retina-node artifact from Mender."""
+    # Check if already installed
+    _, retina_node_version = get_mender_versions()
+    if retina_node_version:
+        return jsonify({"success": False, "error": "Already installed"})
+
+    # Get available artifacts
+    artifacts, error = get_available_artifacts()
+    if error:
+        return jsonify({"success": False, "error": error})
+
+    # Find retina-node artifact
+    retina_artifact = None
+    for artifact in artifacts:
+        if 'retina-node' in artifact.get('artifact_name', ''):
+            retina_artifact = artifact
+            break
+
+    if not retina_artifact:
+        return jsonify({"success": False, "error": "No retina-node artifact found"})
+
+    # Install it
+    success, error = install_artifact(retina_artifact['id'])
+    if not success:
+        return jsonify({"success": False, "error": error})
+
+    return jsonify({"success": True})
+```
+
+### 3. UI (index.html)
+
+Add install button section (only shown when not installed):
+
+```html
+{% if not retina_node_version %}
+<div class="alert alert-info mb-4">
+    <h5>Welcome to Retina Node</h5>
+    <p>Click below to download and install the radar software.</p>
+    <button type="button" class="btn btn-primary" id="installBtn">
+        Install Software
+    </button>
+    <span id="installStatus" class="ms-2"></span>
+</div>
+
+<script>
+document.getElementById('installBtn').addEventListener('click', function() {
+    const btn = this;
+    const status = document.getElementById('installStatus');
+
+    if (btn.disabled) return;
+
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Installing...';
+    status.textContent = 'This may take a few minutes';
+
+    fetch('/mender/install', { method: 'POST' })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                status.className = 'text-success';
+                status.textContent = 'Installed! Reloading...';
+                setTimeout(() => location.reload(), 2000);
+            } else {
+                status.className = 'text-danger';
+                status.textContent = data.error || 'Installation failed';
+                btn.disabled = false;
+                btn.textContent = 'Install Software';
+            }
+        })
+        .catch(e => {
+            status.className = 'text-danger';
+            status.textContent = 'Error: ' + e.message;
+            btn.disabled = false;
+            btn.textContent = 'Install Software';
+        });
+});
+</script>
+{% endif %}
+```
+
+## Files to Modify
+
+1. **retina-gui/app.py**
+   - Add `requests` import (if not already)
+   - Add Mender config constants
+   - Add `get_mender_jwt()` function
+   - Add `get_available_artifacts()` function
+   - Add `install_artifact()` function
+   - Add `/mender/install` endpoint
+
+2. **retina-gui/templates/index.html**
+   - Add install button section (conditional on `retina_node_version`)
+   - Add JavaScript for install button
+
+3. **retina-gui/requirements.txt** (if needed)
+   - Ensure `requests` is listed
+
+## Testing
+
+### Local (dev environment)
+- Button should appear (no mender-update)
+- Click should fail gracefully with "Device not authenticated" or similar
+- Services section should be visible (for testing layout)
+
+### On Device
+1. Flash fresh owl-os image
+2. Connect to retina.local
+3. Verify footer shows "retina-node: Not installed"
+4. Click "Install Software"
+5. Wait for installation (may take several minutes)
+6. Page should refresh, footer shows version
+7. Services should now be accessible
+8. Config page should unlock
+
+## Open Questions
+- [ ] Verify JWT token path on actual device (`/var/lib/mender/authtoken` or different?)
+- [ ] Confirm artifact filtering logic (name contains 'retina-node'?)
+- [ ] Need to add `requests` to requirements.txt?

--- a/app.py
+++ b/app.py
@@ -1,8 +1,10 @@
 from flask import Flask, render_template, request, redirect, url_for, jsonify
+import json
 import os
 import re
 import subprocess
 import tempfile
+from datetime import datetime, timedelta
 import yaml
 import requests
 
@@ -32,6 +34,49 @@ mender = MenderClient(
     release_name=os.environ.get('MENDER_RELEASE_NAME', 'retina-node'),
     device_type=os.environ.get('MENDER_DEVICE_TYPE', 'pi5-v3-arm64'),
 )
+
+# Install lock file to prevent concurrent installs
+INSTALL_LOCK_FILE = os.path.join(DATA_DIR, "install.lock")
+
+
+def is_install_locked() -> tuple[bool, dict | None]:
+    """Check if install is in progress.
+
+    Returns (is_locked, lock_info) where lock_info contains version and started_at.
+    Stale locks (>30 min) are automatically cleared.
+    """
+    if not os.path.exists(INSTALL_LOCK_FILE):
+        return False, None
+    try:
+        with open(INSTALL_LOCK_FILE) as f:
+            lock = json.load(f)
+        # Check for stale lock (30 min timeout)
+        started = datetime.fromisoformat(lock["started_at"])
+        if datetime.now() - started > timedelta(minutes=30):
+            os.remove(INSTALL_LOCK_FILE)
+            return False, None
+        return True, lock
+    except Exception:
+        return False, None
+
+
+def acquire_install_lock(version: str) -> bool:
+    """Try to acquire install lock. Returns False if already locked."""
+    locked, _ = is_install_locked()
+    if locked:
+        return False
+    lock = {"version": version, "started_at": datetime.now().isoformat()}
+    os.makedirs(os.path.dirname(INSTALL_LOCK_FILE), exist_ok=True)
+    with open(INSTALL_LOCK_FILE, "w") as f:
+        json.dump(lock, f)
+    return True
+
+
+def release_install_lock():
+    """Release install lock."""
+    if os.path.exists(INSTALL_LOCK_FILE):
+        os.remove(INSTALL_LOCK_FILE)
+
 
 # Valid SSH key types (exact match to prevent prefix tricks)
 VALID_KEY_TYPES = (
@@ -256,6 +301,12 @@ def index():
                            node_id=node_id,
                            owl_os_version=owl_os_version,
                            retina_node_version=retina_node_version)
+
+
+@app.route("/eula")
+def eula():
+    """Display EULA page."""
+    return render_template("eula.html")
 
 
 def parse_tar1090_adsb_source(config):
@@ -587,6 +638,32 @@ def apply_config():
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+@app.route("/mender/check")
+def mender_check():
+    """Check for available updates and install status."""
+    _, current = mender.get_versions()
+
+    # Check if install in progress
+    locked, lock_info = is_install_locked()
+    if locked:
+        return jsonify({
+            "installing": True,
+            "version": lock_info["version"],
+            "started_at": lock_info["started_at"]
+        })
+
+    latest, error = get_latest_stable_from_github()
+    if error:
+        return jsonify({"error": error})
+
+    return jsonify({
+        "installing": False,
+        "latest_version": latest,
+        "current_version": current,
+        "update_available": current is None or latest != current
+    })
+
+
 @app.route("/mender/install", methods=["POST"])
 def mender_install():
     """Install latest stable retina-node artifact from Mender."""
@@ -595,33 +672,48 @@ def mender_install():
     if retina_node_version:
         return jsonify({"success": False, "error": "Already installed"})
 
+    # Check lock
+    locked, lock_info = is_install_locked()
+    if locked:
+        return jsonify({
+            "success": False,
+            "error": f"Install already in progress ({lock_info['version']})"
+        })
+
     # Get latest stable version from GitHub releases
     version_tag, error = get_latest_stable_from_github()
     if error:
         return jsonify({"success": False, "error": f"Failed to get version: {error}"})
 
-    # Query Mender for that specific release
+    # Acquire lock
     release_name = f"retina-node-{version_tag}"
-    artifacts, error = mender.list_artifacts(release_name=release_name)
-    if error:
-        return jsonify({"success": False, "error": error})
+    if not acquire_install_lock(release_name):
+        return jsonify({"success": False, "error": "Install already in progress"})
 
-    if not artifacts:
-        return jsonify({"success": False, "error": f"No artifact found for {release_name}"})
+    try:
+        # Query Mender for that specific release
+        artifacts, error = mender.list_artifacts(release_name=release_name)
+        if error:
+            return jsonify({"success": False, "error": error})
 
-    artifact = artifacts[0]  # Should be exactly one for this release/device
+        if not artifacts:
+            return jsonify({"success": False, "error": f"No artifact found for {release_name}"})
 
-    # Get download URL
-    url, error = mender.get_download_url(artifact["id"])
-    if error:
-        return jsonify({"success": False, "error": error})
+        artifact = artifacts[0]  # Should be exactly one for this release/device
 
-    # Install
-    success, error = mender.install_from_url(url)
-    if not success:
-        return jsonify({"success": False, "error": error})
+        # Get download URL
+        url, error = mender.get_download_url(artifact["id"])
+        if error:
+            return jsonify({"success": False, "error": error})
 
-    return jsonify({"success": True, "installed_version": release_name})
+        # Install
+        success, error = mender.install_from_url(url)
+        if not success:
+            return jsonify({"success": False, "error": error})
+
+        return jsonify({"success": True, "installed_version": release_name})
+    finally:
+        release_install_lock()
 
 
 if __name__ == "__main__":

--- a/mender.py
+++ b/mender.py
@@ -1,0 +1,190 @@
+"""Mender client for device-initiated OTA updates."""
+import re
+import subprocess
+
+import requests
+
+
+class MenderClient:
+    """Client for pulling artifacts from Mender.
+
+    Supports device-initiated OTA updates by listing available artifacts
+    from the Mender server and installing them via mender-update.
+    """
+
+    def __init__(
+        self,
+        server_url: str = "https://hosted.mender.io",
+        release_name: str = "retina-node",
+        device_type: str = "pi5-v3-arm64",
+    ):
+        self.server_url = server_url
+        self.release_name = release_name
+        self.device_type = device_type
+
+    def get_jwt(self) -> tuple[str, str] | tuple[None, None]:
+        """Get device JWT via D-Bus from mender-auth.
+
+        Returns (token, server_url) tuple, or (None, None) if not authenticated.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "busctl",
+                    "call",
+                    "io.mender.AuthenticationManager",
+                    "/io/mender/AuthenticationManager",
+                    "io.mender.Authentication1",
+                    "GetJwtToken",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode != 0:
+                return None, None
+
+            # Output format: ss "token" "server_url"
+            output = result.stdout.strip()
+            if not output.startswith("ss "):
+                return None, None
+
+            # Extract the two quoted strings
+            parts = output[3:].split('" "')
+            if len(parts) != 2:
+                return None, None
+
+            token = parts[0].strip('"')
+            server_url = parts[1].strip('"')
+            return token, server_url
+        except Exception:
+            return None, None
+
+    def get_versions(self) -> tuple[str | None, str | None]:
+        """Get owl-os and retina-node versions from Mender provides.
+
+        Returns (owl_os_version, retina_node_version) tuple.
+        On fresh bootstrap, only owl-os version exists. retina-node version
+        appears after the first app OTA update.
+        """
+        try:
+            result = subprocess.run(
+                ["mender-update", "show-provides"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode != 0:
+                return None, None
+
+            owl_os = None
+            retina_node = None
+            for line in result.stdout.splitlines():
+                if line.startswith("rootfs-image.owl-os-pi5.version="):
+                    owl_os = line.split("=", 1)[1]
+                elif line.startswith("rootfs-image.retina-node.version="):
+                    retina_node = line.split("=", 1)[1]
+            return owl_os, retina_node
+        except FileNotFoundError:
+            # mender-update not installed (dev environment)
+            return None, None
+        except Exception:
+            return None, None
+
+    def list_artifacts(self) -> tuple[list[dict], str | None]:
+        """List artifacts for configured release/device type.
+
+        Returns (artifacts, error) tuple. On success, error is None.
+        """
+        token, _ = self.get_jwt()
+        if not token:
+            return [], "Device not authenticated with Mender"
+
+        try:
+            resp = requests.get(
+                f"{self.server_url}/api/devices/v1/deployments/artifacts",
+                params={
+                    "release_name": self.release_name,
+                    "device_type": self.device_type,
+                },
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=30,
+            )
+            if resp.status_code != 200:
+                return [], f"Mender API error: {resp.status_code}"
+            return resp.json(), None
+        except requests.RequestException as e:
+            return [], str(e)
+
+    def get_download_url(self, artifact_id: str) -> tuple[str | None, str | None]:
+        """Get signed download URL for artifact.
+
+        Returns (url, error) tuple. On success, error is None.
+        """
+        token, _ = self.get_jwt()
+        if not token:
+            return None, "Not authenticated"
+
+        try:
+            resp = requests.get(
+                f"{self.server_url}/api/devices/v1/deployments/artifacts/{artifact_id}/download",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=30,
+            )
+            if resp.status_code != 200:
+                return None, f"Failed to get download URL: {resp.status_code}"
+            return resp.json().get("uri"), None
+        except requests.RequestException as e:
+            return None, str(e)
+
+    def install_from_url(self, url: str, timeout: int = 600) -> tuple[bool, str | None]:
+        """Install artifact from URL via mender-update.
+
+        Returns (success, error) tuple. On success, error is None.
+        """
+        try:
+            result = subprocess.run(
+                ["mender-update", "install", url],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            if result.returncode != 0:
+                return False, result.stderr or "Install failed"
+            return True, None
+        except subprocess.TimeoutExpired:
+            return False, "Installation timed out"
+        except Exception as e:
+            return False, str(e)
+
+
+def parse_version(artifact_name: str) -> tuple[int, ...] | None:
+    """Extract semver tuple from 'retina-node-v0.3.2' format.
+
+    Returns version tuple (0, 3, 2) for stable releases.
+    Returns None for RCs, dev, beta, or non-matching names.
+    """
+    match = re.match(r"^retina-node-v(\d+)\.(\d+)\.(\d+)$", artifact_name)
+    if match:
+        return tuple(int(x) for x in match.groups())
+    return None
+
+
+def find_latest_stable(artifacts: list[dict]) -> dict | None:
+    """Find latest stable artifact (excludes RCs, dev, beta).
+
+    Returns the artifact dict with the highest semver version,
+    or None if no stable artifacts found.
+    """
+    stable = []
+    for artifact in artifacts:
+        name = artifact.get("artifact_name", "")
+        version = parse_version(name)
+        if version:
+            stable.append((artifact, version))
+
+    if not stable:
+        return None
+
+    stable.sort(key=lambda x: x[1], reverse=True)
+    return stable[0][0]

--- a/templates/eula.html
+++ b/templates/eula.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>End User License Agreement - Retina Node</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+    <div class="container py-5">
+        <h1>End User License Agreement</h1>
+        <p class="text-muted mb-4">Placeholder - to be replaced with actual terms.</p>
+
+        <p>
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            IMPLIED. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+            OTHER LIABILITY ARISING FROM THE USE OF THE SOFTWARE.
+        </p>
+
+        <a href="/" class="btn btn-outline-secondary mt-3">Back</a>
+    </div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,16 +21,61 @@
 
     <div class="container">
         {% if not retina_node_version %}
-        <div class="alert alert-info mb-4">
+        <div class="alert alert-info mb-4" id="installSection">
             <h5>Welcome to Retina Node</h5>
-            <p>Click below to download and install the radar software.</p>
-            <button type="button" class="btn btn-primary" id="installBtn">
+            <p>To get started, install the Retina passive radar stack.</p>
+            <p id="versionInfo" class="text-muted small">Checking for available software...</p>
+
+            <div class="form-check mb-2">
+                <input type="checkbox" class="form-check-input" id="eulaCheck">
+                <label class="form-check-label" for="eulaCheck">
+                    I accept the <a href="/eula" target="_blank">End User License Agreement</a>
+                </label>
+            </div>
+
+            <div class="form-check mb-3">
+                <input type="checkbox" class="form-check-input" id="regionCheck">
+                <label class="form-check-label" for="regionCheck">
+                    This device will be operated in the United States
+                </label>
+            </div>
+
+            <button type="button" class="btn btn-primary" id="installBtn" disabled>
                 Install Software
             </button>
             <span id="installStatus" class="ms-2"></span>
         </div>
 
         <script>
+        // Check for available version on page load
+        fetch('/mender/check')
+            .then(r => r.json())
+            .then(data => {
+                if (data.installing) {
+                    document.getElementById('versionInfo').textContent =
+                        'Install in progress (' + data.version + ')... Please wait.';
+                    document.getElementById('installBtn').disabled = true;
+                    document.getElementById('installBtn').innerHTML =
+                        '<span class="spinner-border spinner-border-sm"></span> Installing...';
+                } else if (data.error) {
+                    document.getElementById('versionInfo').textContent =
+                        'Unable to check for updates';
+                } else {
+                    document.getElementById('versionInfo').innerHTML =
+                        'Available: <strong>' + data.latest_version + '</strong> (~600MB, takes 5-10 minutes)';
+                }
+            });
+
+        // Enable button only when both checkboxes checked
+        function updateButtonState() {
+            const eula = document.getElementById('eulaCheck').checked;
+            const region = document.getElementById('regionCheck').checked;
+            document.getElementById('installBtn').disabled = !(eula && region);
+        }
+        document.getElementById('eulaCheck').addEventListener('change', updateButtonState);
+        document.getElementById('regionCheck').addEventListener('change', updateButtonState);
+
+        // Install click handler
         document.getElementById('installBtn').addEventListener('click', function() {
             const btn = this;
             const status = document.getElementById('installStatus');
@@ -39,26 +84,22 @@
 
             btn.disabled = true;
             btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Installing...';
-            status.textContent = 'This may take a few minutes';
-            status.className = 'text-muted';
+            status.innerHTML = '<span class="text-warning">This takes 5-10 minutes. Do not close this page.</span>';
 
             fetch('/mender/install', { method: 'POST' })
                 .then(r => r.json())
                 .then(data => {
                     if (data.success) {
-                        status.className = 'text-success';
-                        status.textContent = 'Installed! Reloading...';
-                        setTimeout(() => location.reload(), 2000);
+                        status.innerHTML = '<span class="text-success">Installed! Please reboot the device.</span>';
+                        btn.textContent = 'Installed';
                     } else {
-                        status.className = 'text-danger';
-                        status.textContent = data.error || 'Installation failed';
+                        status.innerHTML = '<span class="text-danger">' + data.error + '</span>';
                         btn.disabled = false;
                         btn.textContent = 'Install Software';
                     }
                 })
                 .catch(e => {
-                    status.className = 'text-danger';
-                    status.textContent = 'Error: ' + e.message;
+                    status.innerHTML = '<span class="text-danger">Error: ' + e.message + '</span>';
                     btn.disabled = false;
                     btn.textContent = 'Install Software';
                 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,23 +20,81 @@
     </nav>
 
     <div class="container">
+        {% if not retina_node_version %}
+        <div class="alert alert-info mb-4">
+            <h5>Welcome to Retina Node</h5>
+            <p>Click below to download and install the radar software.</p>
+            <button type="button" class="btn btn-primary" id="installBtn">
+                Install Software
+            </button>
+            <span id="installStatus" class="ms-2"></span>
+        </div>
+
+        <script>
+        document.getElementById('installBtn').addEventListener('click', function() {
+            const btn = this;
+            const status = document.getElementById('installStatus');
+
+            if (btn.disabled) return;
+
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Installing...';
+            status.textContent = 'This may take a few minutes';
+            status.className = 'text-muted';
+
+            fetch('/mender/install', { method: 'POST' })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) {
+                        status.className = 'text-success';
+                        status.textContent = 'Installed! Reloading...';
+                        setTimeout(() => location.reload(), 2000);
+                    } else {
+                        status.className = 'text-danger';
+                        status.textContent = data.error || 'Installation failed';
+                        btn.disabled = false;
+                        btn.textContent = 'Install Software';
+                    }
+                })
+                .catch(e => {
+                    status.className = 'text-danger';
+                    status.textContent = 'Error: ' + e.message;
+                    btn.disabled = false;
+                    btn.textContent = 'Install Software';
+                });
+        });
+        </script>
+        {% endif %}
+
         <h4>Services</h4>
         <div class="list-group mb-4">
+            {% if retina_node_version %}
             <a href="http://retina.local:49152" target="_blank" class="list-group-item list-group-item-action">
                 blah2 - Passive Radar
             </a>
             <a href="http://retina.local:8078" target="_blank" class="list-group-item list-group-item-action">
                 tar1090 - ADS-B Map
             </a>
+            {% else %}
+            <span class="list-group-item list-group-item-action disabled text-muted">
+                blah2 - Passive Radar
+            </span>
+            <span class="list-group-item list-group-item-action disabled text-muted">
+                tar1090 - ADS-B Map
+            </span>
+            {% endif %}
         </div>
 
+        {% if retina_node_version %}
         <div class="d-flex gap-2 align-items-center mb-4">
             <button type="button" class="btn btn-outline-secondary" id="applyRestartBtn">
                 Restart Services
             </button>
             <span id="applyRestartStatus"></span>
         </div>
+        {% endif %}
 
+        {% if retina_node_version %}
         <script>
         document.getElementById('applyRestartBtn').addEventListener('click', function() {
             const btn = this;
@@ -69,6 +127,7 @@
                 });
         });
         </script>
+        {% endif %}
 
         <h4 class="mt-4">SSH Access</h4>
         <form action="/ssh-keys" method="post" class="mb-3">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -57,55 +57,59 @@ class TestIndexRoute:
 
 
 class TestMenderVersions:
-    """Test get_mender_versions() function."""
+    """Test MenderClient.get_versions() method."""
 
     def test_versions_parsed_correctly(self):
         """Should parse owl-os and retina-node versions from mender output."""
-        from app import get_mender_versions
+        from mender import MenderClient
         mock_output = """rootfs-image.version=v0.5.0
 rootfs-image.owl-os-pi5.version=v0.5.0
 rootfs-image.retina-node.version=v0.3.2
 artifact_name=owl-os-pi5-v0.5.0"""
 
-        with patch('subprocess.run') as mock_run:
+        client = MenderClient()
+        with patch('mender.subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=mock_output)
-            owl_os, retina_node = get_mender_versions()
+            owl_os, retina_node = client.get_versions()
 
         assert owl_os == 'v0.5.0'
         assert retina_node == 'v0.3.2'
 
     def test_retina_node_not_installed(self):
         """Should return None for retina-node if not in mender output."""
-        from app import get_mender_versions
+        from mender import MenderClient
         mock_output = """rootfs-image.version=v0.5.0
 rootfs-image.owl-os-pi5.version=v0.5.0
 artifact_name=owl-os-pi5-v0.5.0"""
 
-        with patch('subprocess.run') as mock_run:
+        client = MenderClient()
+        with patch('mender.subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=mock_output)
-            owl_os, retina_node = get_mender_versions()
+            owl_os, retina_node = client.get_versions()
 
         assert owl_os == 'v0.5.0'
         assert retina_node is None
 
     def test_mender_not_available(self):
         """Should return None, None if mender-update not found."""
-        from app import get_mender_versions
+        from mender import MenderClient
 
-        with patch('subprocess.run') as mock_run:
+        client = MenderClient()
+        with patch('mender.subprocess.run') as mock_run:
             mock_run.side_effect = FileNotFoundError()
-            owl_os, retina_node = get_mender_versions()
+            owl_os, retina_node = client.get_versions()
 
         assert owl_os is None
         assert retina_node is None
 
     def test_mender_command_fails(self):
         """Should return None, None if mender-update returns error."""
-        from app import get_mender_versions
+        from mender import MenderClient
 
-        with patch('subprocess.run') as mock_run:
+        client = MenderClient()
+        with patch('mender.subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='error')
-            owl_os, retina_node = get_mender_versions()
+            owl_os, retina_node = client.get_versions()
 
         assert owl_os is None
         assert retina_node is None

--- a/tests/test_mender.py
+++ b/tests/test_mender.py
@@ -1,0 +1,107 @@
+"""Tests for mender.py - version parsing and artifact selection."""
+import pytest
+from mender import parse_version, find_latest_stable
+
+
+class TestParseVersion:
+    """Version parsing - only stable releases match."""
+
+    def test_stable_version(self):
+        assert parse_version("retina-node-v0.3.5") == (0, 3, 5)
+
+    def test_stable_version_v1(self):
+        assert parse_version("retina-node-v1.0.0") == (1, 0, 0)
+
+    def test_stable_version_large(self):
+        assert parse_version("retina-node-v10.20.30") == (10, 20, 30)
+
+    def test_rc_excluded(self):
+        assert parse_version("retina-node-v0.3.5-rc1") is None
+
+    def test_rc2_excluded(self):
+        assert parse_version("retina-node-v0.3.5-rc2") is None
+
+    def test_dev_excluded(self):
+        assert parse_version("retina-node-v0.3.5-dev") is None
+
+    def test_dev_only_excluded(self):
+        assert parse_version("retina-node-dev") is None
+
+    def test_beta_excluded(self):
+        assert parse_version("retina-node-v0.3.5-beta") is None
+
+    def test_beta1_excluded(self):
+        assert parse_version("retina-node-v0.3.5-beta1") is None
+
+    def test_other_artifact_excluded(self):
+        assert parse_version("other-artifact-v1.0.0") is None
+
+    def test_missing_v_excluded(self):
+        assert parse_version("retina-node-1.0.0") is None
+
+    def test_empty_excluded(self):
+        assert parse_version("") is None
+
+
+class TestFindLatestStable:
+    """Finding latest stable from artifact list."""
+
+    def test_finds_latest(self):
+        artifacts = [
+            {"artifact_name": "retina-node-v0.3.2", "id": "a"},
+            {"artifact_name": "retina-node-v0.3.5", "id": "b"},
+            {"artifact_name": "retina-node-v0.3.3", "id": "c"},
+        ]
+        result = find_latest_stable(artifacts)
+        assert result["id"] == "b"
+        assert result["artifact_name"] == "retina-node-v0.3.5"
+
+    def test_excludes_rc(self):
+        artifacts = [
+            {"artifact_name": "retina-node-v0.3.2", "id": "a"},
+            {"artifact_name": "retina-node-v0.3.6-rc1", "id": "b"},
+        ]
+        result = find_latest_stable(artifacts)
+        assert result["id"] == "a"
+
+    def test_excludes_dev(self):
+        artifacts = [
+            {"artifact_name": "retina-node-v0.3.2", "id": "a"},
+            {"artifact_name": "retina-node-v0.4.0-dev", "id": "b"},
+        ]
+        result = find_latest_stable(artifacts)
+        assert result["id"] == "a"
+
+    def test_empty_list(self):
+        assert find_latest_stable([]) is None
+
+    def test_no_stable(self):
+        artifacts = [
+            {"artifact_name": "retina-node-v0.3.6-rc1", "id": "a"},
+            {"artifact_name": "retina-node-dev", "id": "b"},
+        ]
+        assert find_latest_stable(artifacts) is None
+
+    def test_major_version_wins(self):
+        artifacts = [
+            {"artifact_name": "retina-node-v0.9.9", "id": "a"},
+            {"artifact_name": "retina-node-v1.0.0", "id": "b"},
+        ]
+        result = find_latest_stable(artifacts)
+        assert result["id"] == "b"
+
+    def test_minor_version_wins(self):
+        artifacts = [
+            {"artifact_name": "retina-node-v1.0.9", "id": "a"},
+            {"artifact_name": "retina-node-v1.1.0", "id": "b"},
+        ]
+        result = find_latest_stable(artifacts)
+        assert result["id"] == "b"
+
+    def test_patch_version_wins(self):
+        artifacts = [
+            {"artifact_name": "retina-node-v1.1.0", "id": "a"},
+            {"artifact_name": "retina-node-v1.1.1", "id": "b"},
+        ]
+        result = find_latest_stable(artifacts)
+        assert result["id"] == "b"


### PR DESCRIPTION
## Summary
- Add "Install Software" button for first-boot device-initiated OTA updates
- Use GitHub Releases API to discover latest stable version (filters out rc/dev/beta)
- Query Mender for specific release, download and install via `mender-update`
- Lock file prevents concurrent installs (auto-clears after 30 min)
- EULA + region checkboxes required before install enabled
- Shows available version and install progress on page load

## Changes
- `mender.py` - New MenderClient class with JWT auth, version discovery, artifact install
- `app.py` - `/mender/check` and `/mender/install` endpoints, lock file management
- `templates/index.html` - Install UI with checkboxes, version display, progress states
- `templates/eula.html` - Placeholder EULA page