### PR TITLE
Add Radar/Spectrum mode toggle (Config -> Mode)

### DIFF
--- a/spectrum/docker-compose.yml
+++ b/spectrum/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  retina-spectrum:
+    image: ghcr.io/offworldlabs/retina-spectrum:${SPECTRUM_V:-v0.1.0}
+    restart: unless-stopped
+    network_mode: host
+    pid: "host"
+    privileged: true
+    volumes:
+      - /dev/shm:/dev/shm:rw
+      - /dev/bus/usb:/dev/bus/usb:rw
+    command: bash -c "pkill -9 -f sdrplay_apiService 2>/dev/null || true && sleep 2 && retina-spectrum --web-dir /web"

--- a/src/app.py
+++ b/src/app.py
@@ -19,6 +19,7 @@ DATA_DIR = os.environ.get('DATA_DIR', '/data/retina-gui')
 USER_CONFIG_PATH = os.environ.get('USER_CONFIG_PATH', '/data/retina-node/config/user.yml')
 MERGED_CONFIG_PATH = os.environ.get('MERGED_CONFIG_PATH', '/data/retina-node/config/config.yml')
 RETINA_NODE_PATH = os.environ.get('RETINA_NODE_PATH', '/data/mender-docker-compose/current/manifests')
+RETINA_SPECTRUM_PATH = os.environ.get('RETINA_SPECTRUM_PATH', os.path.join(PROJECT_ROOT, 'spectrum'))
 NODE_ID_FILE = os.environ.get('NODE_ID_FILE', '/data/mender/node_id')
 TOWER_FINDER_URL = os.environ.get('TOWER_FINDER_URL', 'https://api.retina.fm')
 DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
@@ -82,12 +83,14 @@ from routes.config import bp as config_bp
 from routes.mender_routes import bp as mender_bp
 from routes.setup import bp as setup_bp
 from routes.towers import bp as towers_bp
+from routes.mode import bp as mode_bp
 
 app.register_blueprint(home_bp)
 app.register_blueprint(config_bp)
 app.register_blueprint(mender_bp)
 app.register_blueprint(setup_bp)
 app.register_blueprint(towers_bp)
+app.register_blueprint(mode_bp)
 
 
 if __name__ == "__main__":

--- a/src/routes/home.py
+++ b/src/routes/home.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, request
+from routes.mode import get_current_mode
 
 bp = Blueprint('home', __name__)
 
@@ -37,7 +38,8 @@ def index():
                            setup_needed=setup_needed,
                            setup_in_progress=setup_in_progress,
                            tx_name=tx_name,
-                           rx_name=rx_name)
+                           rx_name=rx_name,
+                           mode=get_current_mode())
 
 
 @bp.route("/eula")

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -1,0 +1,101 @@
+import os
+import subprocess
+from flask import Blueprint, jsonify, request
+
+bp = Blueprint('mode', __name__)
+
+_mode_cache = 'radar'  # in-memory fallback when DATA_DIR is not writable (dev)
+
+
+def get_current_mode():
+    """Read persisted mode. Returns 'radar' or 'spectrum'."""
+    from app import DATA_DIR
+    try:
+        with open(os.path.join(DATA_DIR, 'mode.txt')) as f:
+            mode = f.read().strip()
+            return mode if mode in ('radar', 'spectrum') else 'radar'
+    except (FileNotFoundError, OSError):
+        return _mode_cache
+
+
+def _write_mode(mode):
+    global _mode_cache
+    _mode_cache = mode
+    from app import DATA_DIR
+    try:
+        os.makedirs(DATA_DIR, exist_ok=True)
+        with open(os.path.join(DATA_DIR, 'mode.txt'), 'w') as f:
+            f.write(mode)
+    except OSError:
+        pass  # dev: no /data — in-memory cache is the fallback
+
+
+@bp.route('/api/mode', methods=['GET'])
+def get_mode():
+    return jsonify({'mode': get_current_mode()})
+
+
+@bp.route('/api/mode', methods=['POST'])
+def set_mode():
+    from app import RETINA_NODE_PATH, RETINA_SPECTRUM_PATH, config_mgr
+
+    data = request.get_json(silent=True) or {}
+    mode = data.get('mode')
+    if mode not in ('radar', 'spectrum'):
+        return jsonify({'success': False, 'error': 'Invalid mode'}), 400
+
+    node_installed = config_mgr.is_retina_node_installed()
+
+    try:
+        if not node_installed:
+            # Dev / pre-deployment: persist mode but skip docker commands
+            _write_mode(mode)
+            return jsonify({'success': True, 'mode': mode})
+
+        if mode == 'spectrum':
+            result = subprocess.run(
+                ['docker', 'compose', '-p', 'retina-node', 'stop',
+                 'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
+                cwd=RETINA_NODE_PATH,
+                capture_output=True, text=True, timeout=60
+            )
+            if result.returncode != 0:
+                return jsonify({'success': False,
+                                'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
+
+            result = subprocess.run(
+                ['docker', 'compose', '-p', 'retina-spectrum', 'up', '-d'],
+                cwd=RETINA_SPECTRUM_PATH,
+                capture_output=True, text=True, timeout=120
+            )
+            if result.returncode != 0:
+                return jsonify({'success': False,
+                                'error': f'Failed to start retina-spectrum: {result.stderr or result.stdout}'}), 500
+
+        else:  # radar
+            result = subprocess.run(
+                ['docker', 'compose', '-p', 'retina-spectrum', 'down'],
+                cwd=RETINA_SPECTRUM_PATH,
+                capture_output=True, text=True, timeout=60
+            )
+            if result.returncode != 0:
+                return jsonify({'success': False,
+                                'error': f'Failed to stop retina-spectrum: {result.stderr or result.stdout}'}), 500
+
+            result = subprocess.run(
+                ['docker', 'compose', '-p', 'retina-node', 'start',
+                 'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
+                cwd=RETINA_NODE_PATH,
+                capture_output=True, text=True, timeout=120
+            )
+            if result.returncode != 0:
+                return jsonify({'success': False,
+                                'error': f'Failed to start blah2: {result.stderr or result.stdout}'}), 500
+
+        _write_mode(mode)
+        return jsonify({'success': True, 'mode': mode})
+
+    except subprocess.TimeoutExpired:
+        return jsonify({'success': False, 'error': 'Command timed out'}), 500
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500

--- a/static/common.css
+++ b/static/common.css
@@ -145,34 +145,6 @@ h1, h2, h3, h4, h5, h6 {
 .nav-tab:hover  { color: var(--ink); background: var(--surface-2); }
 .nav-tab.active { color: var(--ink); background: var(--surface-2); }
 .nav-spacer { flex: 1; }
-.nav-divider { width: 1px; height: 18px; background: var(--line); flex-shrink: 0; }
-.nav-mode-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    flex-shrink: 0;
-}
-.nav-mode-label {
-    font-size: 13px;
-    font-weight: 400;
-    color: var(--ink-3);
-    transition: color .15s, font-weight .15s;
-    user-select: none;
-}
-.nav-mode-label.active {
-    font-weight: 500;
-    color: var(--ink);
-}
-@keyframes nav-spin { to { transform: rotate(360deg); } }
-.nav-mode-spinner {
-    width: 13px; height: 13px;
-    border: 2px solid var(--line);
-    border-top-color: var(--accent);
-    border-radius: 50%;
-    animation: nav-spin .6s linear infinite;
-    flex-shrink: 0;
-}
-
 /* ── Spectrum mode overrides ──────────────────── */
 .main.spectrum-mode { max-width: 1200px; }
 .spectrum-section { display: flex; flex-direction: column; flex: 1; }

--- a/static/common.css
+++ b/static/common.css
@@ -145,6 +145,51 @@ h1, h2, h3, h4, h5, h6 {
 .nav-tab:hover  { color: var(--ink); background: var(--surface-2); }
 .nav-tab.active { color: var(--ink); background: var(--surface-2); }
 .nav-spacer { flex: 1; }
+.nav-divider { width: 1px; height: 18px; background: var(--line); flex-shrink: 0; }
+.nav-mode-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    flex-shrink: 0;
+}
+.nav-mode-label {
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--ink-3);
+    transition: color .15s, font-weight .15s;
+    user-select: none;
+}
+.nav-mode-label.active {
+    font-weight: 500;
+    color: var(--ink);
+}
+@keyframes nav-spin { to { transform: rotate(360deg); } }
+.nav-mode-spinner {
+    width: 13px; height: 13px;
+    border: 2px solid var(--line);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: nav-spin .6s linear infinite;
+    flex-shrink: 0;
+}
+
+/* ── Spectrum mode overrides ──────────────────── */
+.main.spectrum-mode { max-width: 1200px; }
+.spectrum-section { display: flex; flex-direction: column; flex: 1; }
+.spectrum-frame-wrap {
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    overflow: hidden;
+    height: calc(100vh - 160px);
+    min-height: 400px;
+}
+.spectrum-frame {
+    width: 100%;
+    height: 100%;
+    border: none;
+    display: block;
+    background: var(--surface-2);
+}
 /* Nav meta (Config page right side) */
 .nav-meta {
     display: flex; align-items: center; gap: 18px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,73 +33,8 @@
             <a class="nav-tab{% if active_page == 'home' %} active{% endif %}" href="/">Home</a>
             <a class="nav-tab{% if active_page == 'config' %} active{% endif %}" href="/config">Config</a>
         </div>
-        <div class="nav-divider"></div>
-        <div class="nav-mode-toggle">
-            <span class="nav-mode-label" id="navModeRadar">Radar</span>
-            <label class="ds-switch">
-                <input type="checkbox" id="navModeSwitch">
-                <span class="ds-switch-track"></span>
-            </label>
-            <span class="nav-mode-label" id="navModeSpectrum">Spectrum</span>
-            <span class="nav-mode-spinner" id="navModeSpinner" style="display:none;"></span>
-        </div>
         <div class="nav-spacer"></div>
     </nav>
-    <script>
-    (function () {
-        var sw      = document.getElementById('navModeSwitch');
-        var lRadar  = document.getElementById('navModeRadar');
-        var lSpec   = document.getElementById('navModeSpectrum');
-        var spinner = document.getElementById('navModeSpinner');
-        var csrf    = document.querySelector('meta[name="csrf-token"]').content;
-
-        function updateLabels(checked) {
-            lRadar.classList.toggle('active', !checked);
-            lSpec.classList.toggle('active', checked);
-        }
-
-        function setLoading(on) {
-            sw.disabled = on;
-            spinner.style.display = on ? 'inline-block' : 'none';
-        }
-
-        // Sync toggle position from server on every page load
-        fetch('/api/mode')
-            .then(function(r) { return r.json(); })
-            .then(function(d) { sw.checked = d.mode === 'spectrum'; updateLabels(sw.checked); })
-            .catch(function() {
-                var saved = localStorage.getItem('navMode');
-                if (saved === 'spectrum') { sw.checked = true; }
-                updateLabels(sw.checked);
-            });
-
-        sw.addEventListener('change', function () {
-            var newMode = sw.checked ? 'spectrum' : 'radar';
-            setLoading(true);
-            fetch('/api/mode', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
-                body: JSON.stringify({ mode: newMode })
-            })
-            .then(function(r) { return r.json(); })
-            .then(function(d) {
-                if (d.success) {
-                    localStorage.setItem('navMode', newMode);
-                    window.location.reload();
-                } else {
-                    sw.checked = !sw.checked;
-                    updateLabels(sw.checked);
-                    console.error('Mode switch failed:', d.error);
-                }
-            })
-            .catch(function() {
-                sw.checked = !sw.checked;
-                updateLabels(sw.checked);
-            })
-            .finally(function() { setLoading(false); });
-        });
-    })();
-    </script>
     {% endblock %}
 
     {% block content %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,8 +33,73 @@
             <a class="nav-tab{% if active_page == 'home' %} active{% endif %}" href="/">Home</a>
             <a class="nav-tab{% if active_page == 'config' %} active{% endif %}" href="/config">Config</a>
         </div>
+        <div class="nav-divider"></div>
+        <div class="nav-mode-toggle">
+            <span class="nav-mode-label" id="navModeRadar">Radar</span>
+            <label class="ds-switch">
+                <input type="checkbox" id="navModeSwitch">
+                <span class="ds-switch-track"></span>
+            </label>
+            <span class="nav-mode-label" id="navModeSpectrum">Spectrum</span>
+            <span class="nav-mode-spinner" id="navModeSpinner" style="display:none;"></span>
+        </div>
         <div class="nav-spacer"></div>
     </nav>
+    <script>
+    (function () {
+        var sw      = document.getElementById('navModeSwitch');
+        var lRadar  = document.getElementById('navModeRadar');
+        var lSpec   = document.getElementById('navModeSpectrum');
+        var spinner = document.getElementById('navModeSpinner');
+        var csrf    = document.querySelector('meta[name="csrf-token"]').content;
+
+        function updateLabels(checked) {
+            lRadar.classList.toggle('active', !checked);
+            lSpec.classList.toggle('active', checked);
+        }
+
+        function setLoading(on) {
+            sw.disabled = on;
+            spinner.style.display = on ? 'inline-block' : 'none';
+        }
+
+        // Sync toggle position from server on every page load
+        fetch('/api/mode')
+            .then(function(r) { return r.json(); })
+            .then(function(d) { sw.checked = d.mode === 'spectrum'; updateLabels(sw.checked); })
+            .catch(function() {
+                var saved = localStorage.getItem('navMode');
+                if (saved === 'spectrum') { sw.checked = true; }
+                updateLabels(sw.checked);
+            });
+
+        sw.addEventListener('change', function () {
+            var newMode = sw.checked ? 'spectrum' : 'radar';
+            setLoading(true);
+            fetch('/api/mode', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+                body: JSON.stringify({ mode: newMode })
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                if (d.success) {
+                    localStorage.setItem('navMode', newMode);
+                    window.location.reload();
+                } else {
+                    sw.checked = !sw.checked;
+                    updateLabels(sw.checked);
+                    console.error('Mode switch failed:', d.error);
+                }
+            })
+            .catch(function() {
+                sw.checked = !sw.checked;
+                updateLabels(sw.checked);
+            })
+            .finally(function() { setLoading(false); });
+        });
+    })();
+    </script>
     {% endblock %}
 
     {% block content %}{% endblock %}

--- a/templates/config.html
+++ b/templates/config.html
@@ -67,6 +67,8 @@
 
     {# ── Side nav ── #}
     <aside class="side">
+        <h3>Node</h3>
+        <a href="#mode">Mode</a>
         <h3>Radar</h3>
         <a href="#location">Location</a>
         <a href="#capture">Capture</a>
@@ -101,6 +103,27 @@
             Please fix the highlighted fields below.
         </div>
         {% endif %}
+
+        {# ── Mode ── #}
+        <section id="mode" class="cfg-section">
+            <div class="cfg-section-head">
+                <h2>Mode</h2>
+                <span class="desc">Switch the node between passive radar and spectrum analysis.</span>
+            </div>
+            <div class="cfg-body">
+                <div class="toggle-row" style="padding:0;border:0;">
+                    <label class="ds-switch">
+                        <input type="checkbox" id="modeToggle">
+                        <span class="ds-switch-track"></span>
+                    </label>
+                    <div class="body">
+                        <div class="name" id="modeLabel">Radar</div>
+                        <div class="desc">Radar runs the blah2 passive radar pipeline. Spectrum stops blah2 and starts retina-spectrum.</div>
+                    </div>
+                    <span class="spinner-border spinner-border-sm" id="modeSpinner" style="display:none;width:.9em;height:.9em;border-width:1.5px;flex-shrink:0;"></span>
+                </div>
+            </div>
+        </section>
 
         {# ── Location ── #}
         {# Build field lookup for location #}
@@ -354,6 +377,51 @@
 
 {% block scripts %}
 <script>
+// Mode toggle
+(function() {
+    var toggle  = document.getElementById('modeToggle');
+    var label   = document.getElementById('modeLabel');
+    var spinner = document.getElementById('modeSpinner');
+    var csrf    = document.querySelector('meta[name="csrf-token"]').content;
+
+    function setLabel(mode) {
+        label.textContent = mode === 'spectrum' ? 'Spectrum' : 'Radar';
+    }
+
+    fetch('/api/mode')
+        .then(function(r) { return r.json(); })
+        .then(function(d) { toggle.checked = d.mode === 'spectrum'; setLabel(d.mode); })
+        .catch(function() {});
+
+    toggle.addEventListener('change', function() {
+        var newMode = toggle.checked ? 'spectrum' : 'radar';
+        toggle.disabled = true;
+        spinner.style.display = 'inline-block';
+        fetch('/api/mode', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+            body: JSON.stringify({ mode: newMode })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(d) {
+            if (d.success) {
+                setLabel(newMode);
+            } else {
+                toggle.checked = !toggle.checked;
+                setLabel(toggle.checked ? 'spectrum' : 'radar');
+            }
+        })
+        .catch(function() {
+            toggle.checked = !toggle.checked;
+            setLabel(toggle.checked ? 'spectrum' : 'radar');
+        })
+        .finally(function() {
+            toggle.disabled = false;
+            spinner.style.display = 'none';
+        });
+    });
+})();
+
 // Auto-apply after successful save redirect
 if (window.location.search.includes('saved=1')) {
     history.replaceState({}, '', window.location.pathname);
@@ -489,7 +557,7 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
 
 // Side-nav scrollspy
 (function() {
-    var sectionIds = ['location','capture','truth','tar1090','ssh','cloud','wizard'];
+    var sectionIds = ['mode','location','capture','truth','tar1090','ssh','cloud','wizard'];
     var links = {};
     sectionIds.forEach(function(id) {
         var a = document.querySelector('.side a[href="#' + id + '"]');

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 {% set active_page = 'home' %}
 
 {% block content %}
-<main class="main">
+<main class="main{% if mode == 'spectrum' %} spectrum-mode{% endif %}">
 
     <div class="page-head">
         <div>
@@ -52,6 +52,14 @@
     </div>
     {% endif %}
 
+    {% if mode == 'spectrum' %}
+    <section class="spectrum-section">
+        <div class="section-head"><h2>Spectrum</h2></div>
+        <div class="spectrum-frame-wrap">
+            <iframe id="spectrumFrame" class="spectrum-frame" src="" frameborder="0"></iframe>
+        </div>
+    </section>
+    {% else %}
     <section>
         <div class="section-head"><h2>Services</h2></div>
         <div class="svc-grid">
@@ -122,11 +130,17 @@
             {% endif %}
         </div>
     </section>
+    {% endif %}
 
 </main>
 {% endblock %}
 
 {% block scripts %}
+{% if mode == 'spectrum' %}
+<script>
+document.getElementById('spectrumFrame').src = 'http://' + window.location.hostname + ':3020';
+</script>
+{% endif %}
 {% if retina_node_version %}
 <script>
 document.getElementById('applyRestartBtn').addEventListener('click', function() {

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -1,0 +1,217 @@
+"""Tests for the mode (Radar / Spectrum) toggle endpoint and home page rendering."""
+import json
+import os
+import subprocess
+import pytest
+from unittest.mock import patch, MagicMock, call
+
+
+@pytest.fixture(autouse=True)
+def reset_mode_cache():
+    """Reset the in-memory mode cache before every test.
+
+    _mode_cache is a module-level variable in routes.mode that survives
+    importlib.reload(app) because Python's module cache doesn't re-execute
+    already-imported submodules. Without this reset, a test that switches to
+    'spectrum' would pollute the next test's default mode.
+    """
+    import sys
+    if 'routes.mode' in sys.modules:
+        sys.modules['routes.mode']._mode_cache = 'radar'
+    yield
+
+
+class TestGetMode:
+
+    def test_default_mode_is_radar(self, app_client):
+        response = app_client.get('/api/mode')
+        assert response.status_code == 200
+        assert json.loads(response.data) == {'mode': 'radar'}
+
+    def test_returns_persisted_mode(self, app_client, temp_dir):
+        with open(os.path.join(temp_dir, 'mode.txt'), 'w') as f:
+            f.write('spectrum')
+        response = app_client.get('/api/mode')
+        assert json.loads(response.data) == {'mode': 'spectrum'}
+
+    def test_corrupted_mode_file_falls_back_to_radar(self, app_client, temp_dir):
+        with open(os.path.join(temp_dir, 'mode.txt'), 'w') as f:
+            f.write('garbage')
+        response = app_client.get('/api/mode')
+        assert json.loads(response.data) == {'mode': 'radar'}
+
+
+class TestSetMode:
+
+    def test_invalid_mode_returns_400(self, app_client):
+        response = app_client.post('/api/mode',
+                                   data=json.dumps({'mode': 'invalid'}),
+                                   content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.data)['success'] is False
+
+    def test_missing_mode_returns_400(self, app_client):
+        response = app_client.post('/api/mode',
+                                   data=json.dumps({}),
+                                   content_type='application/json')
+        assert response.status_code == 400
+
+    def test_no_retina_node_still_succeeds(self, app_client_no_retina):
+        """Mode switch should succeed (skipping docker) when retina-node is absent."""
+        response = app_client_no_retina.post('/api/mode',
+                                             data=json.dumps({'mode': 'spectrum'}),
+                                             content_type='application/json')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['success'] is True
+        assert data['mode'] == 'spectrum'
+
+    def test_no_retina_node_persists_mode_in_cache(self, app_client_no_retina):
+        """After a no-docker switch the GET endpoint reflects the new mode."""
+        app_client_no_retina.post('/api/mode',
+                                  data=json.dumps({'mode': 'spectrum'}),
+                                  content_type='application/json')
+        response = app_client_no_retina.get('/api/mode')
+        assert json.loads(response.data)['mode'] == 'spectrum'
+
+    @patch('subprocess.run')
+    def test_switch_to_spectrum_calls_correct_docker_commands(self, mock_run, app_client):
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+
+        response = app_client.post('/api/mode',
+                                   data=json.dumps({'mode': 'spectrum'}),
+                                   content_type='application/json')
+
+        assert response.status_code == 200
+        assert json.loads(response.data)['success'] is True
+        assert mock_run.call_count == 2
+
+        stop_args = mock_run.call_args_list[0][0][0]
+        assert stop_args[:4] == ['docker', 'compose', '-p', 'retina-node']
+        assert 'stop' in stop_args
+        for svc in ('blah2', 'blah2_api', 'blah2_web', 'blah2_host'):
+            assert svc in stop_args
+
+        up_args = mock_run.call_args_list[1][0][0]
+        assert up_args[:4] == ['docker', 'compose', '-p', 'retina-spectrum']
+        assert 'up' in up_args
+        assert '-d' in up_args
+
+    @patch('subprocess.run')
+    def test_switch_to_radar_calls_correct_docker_commands(self, mock_run, app_client, temp_dir):
+        # Pre-set mode to spectrum
+        with open(os.path.join(temp_dir, 'mode.txt'), 'w') as f:
+            f.write('spectrum')
+
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+
+        response = app_client.post('/api/mode',
+                                   data=json.dumps({'mode': 'radar'}),
+                                   content_type='application/json')
+
+        assert response.status_code == 200
+        assert json.loads(response.data)['success'] is True
+        assert mock_run.call_count == 2
+
+        down_args = mock_run.call_args_list[0][0][0]
+        assert down_args[:4] == ['docker', 'compose', '-p', 'retina-spectrum']
+        assert 'down' in down_args
+
+        start_args = mock_run.call_args_list[1][0][0]
+        assert start_args[:4] == ['docker', 'compose', '-p', 'retina-node']
+        assert 'start' in start_args
+        for svc in ('blah2', 'blah2_api', 'blah2_web', 'blah2_host'):
+            assert svc in start_args
+
+    @patch('subprocess.run')
+    def test_switch_to_spectrum_writes_mode_file(self, mock_run, app_client, temp_dir):
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+
+        app_client.post('/api/mode',
+                        data=json.dumps({'mode': 'spectrum'}),
+                        content_type='application/json')
+
+        with open(os.path.join(temp_dir, 'mode.txt')) as f:
+            assert f.read().strip() == 'spectrum'
+
+    @patch('subprocess.run')
+    def test_docker_stop_failure_returns_500(self, mock_run, app_client):
+        mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='permission denied')
+
+        response = app_client.post('/api/mode',
+                                   data=json.dumps({'mode': 'spectrum'}),
+                                   content_type='application/json')
+
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert data['success'] is False
+        assert 'blah2' in data['error']
+
+    @patch('subprocess.run')
+    def test_docker_up_failure_returns_500(self, mock_run, app_client):
+        # Stop succeeds, up fails
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout='', stderr=''),
+            MagicMock(returncode=1, stdout='', stderr='image not found'),
+        ]
+
+        response = app_client.post('/api/mode',
+                                   data=json.dumps({'mode': 'spectrum'}),
+                                   content_type='application/json')
+
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert data['success'] is False
+        assert 'retina-spectrum' in data['error']
+
+    @patch('subprocess.run')
+    def test_timeout_returns_500(self, mock_run, app_client):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd='docker', timeout=60)
+
+        response = app_client.post('/api/mode',
+                                   data=json.dumps({'mode': 'spectrum'}),
+                                   content_type='application/json')
+
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert data['success'] is False
+        assert 'timed out' in data['error'].lower()
+
+    @patch('subprocess.run')
+    def test_mode_file_not_written_on_failure(self, mock_run, app_client, temp_dir):
+        """Mode file must not be updated when docker commands fail."""
+        mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='error')
+
+        app_client.post('/api/mode',
+                        data=json.dumps({'mode': 'spectrum'}),
+                        content_type='application/json')
+
+        mode_file = os.path.join(temp_dir, 'mode.txt')
+        assert not os.path.exists(mode_file)
+
+
+class TestHomepageModeRendering:
+
+    def test_radar_mode_shows_services_section(self, app_client):
+        response = app_client.get('/')
+        assert response.status_code == 200
+        assert b'Services' in response.data
+        assert b'spectrumFrame' not in response.data
+
+    @patch('subprocess.run')
+    def test_spectrum_mode_shows_iframe(self, mock_run, app_client, temp_dir):
+        with open(os.path.join(temp_dir, 'mode.txt'), 'w') as f:
+            f.write('spectrum')
+
+        response = app_client.get('/')
+        assert response.status_code == 200
+        assert b'spectrumFrame' in response.data
+        assert b'Services' not in response.data
+
+    def test_spectrum_mode_hides_passive_radar_card(self, app_client, temp_dir):
+        with open(os.path.join(temp_dir, 'mode.txt'), 'w') as f:
+            f.write('spectrum')
+
+        response = app_client.get('/')
+        assert b'Passive Radar' not in response.data
+        assert b'49152' not in response.data

--- a/toggle.md
+++ b/toggle.md
@@ -1,0 +1,46 @@
+# Radar / Spectrum Mode Toggle
+
+A nav-bar toggle allows switching the node between **Radar** mode (blah2 passive radar) and **Spectrum** mode (retina-spectrum SDR visualiser) without manual container management.
+
+---
+
+## What was added
+
+| File | Change |
+|---|---|
+| `spectrum/docker-compose.yml` | Bundled compose file for retina-spectrum, ships with the GUI. References a pre-built image tag via `SPECTRUM_V` env var. |
+| `src/routes/mode.py` | New Flask blueprint. `GET /api/mode` returns current mode. `POST /api/mode` stops/starts the appropriate containers and writes `DATA_DIR/mode.txt`. |
+| `src/app.py` | Added `RETINA_SPECTRUM_PATH` env var (defaults to `<project_root>/spectrum`). Registered the mode blueprint. |
+| `src/routes/home.py` | Reads current mode and passes it to the home template. |
+| `templates/base.html` | Nav toggle syncs from server on page load, POSTs on change with a spinner, reloads page on success. |
+| `templates/index.html` | Radar mode renders the normal service cards. Spectrum mode renders a full-height iframe pointed at port 3020. |
+| `static/common.css` | Spinner animation and spectrum iframe layout styles. |
+| `tests/test_mode.py` | 17 tests covering the API endpoints, docker command sequencing, failure rollback, mode persistence, and home page rendering. |
+
+---
+
+## How it works
+
+**Switching to Spectrum:**
+1. `docker compose -p retina-node stop blah2 blah2_api blah2_web blah2_host` — stops the four SDR-consuming containers. `tar1090` and `adsb2dd` continue running.
+2. `docker compose -p retina-spectrum up -d` — starts retina-spectrum from `RETINA_SPECTRUM_PATH`. The container kills any stale `sdrplay_apiService`, waits 2 seconds, then serves its UI on port 3020.
+3. Mode written to `DATA_DIR/mode.txt`.
+
+**Switching to Radar:**
+1. `docker compose -p retina-spectrum down` — stops retina-spectrum.
+2. `docker compose -p retina-node start blah2 blah2_api blah2_web blah2_host` — restarts the blah2 cluster from existing container state (no config-merger, no `--force-recreate`).
+3. Mode written to `DATA_DIR/mode.txt`.
+
+If either docker command fails the mode file is not updated and the toggle reverts to its previous position.
+
+---
+
+## Deployment prerequisite
+
+`spectrum/docker-compose.yml` references `ghcr.io/offworldlabs/retina-spectrum:${SPECTRUM_V:-v0.1.0}`. Update `SPECTRUM_V` once the image is published to ghcr.io. No changes are required to the retina-node compose stack.
+
+---
+
+## Dev / pre-deployment behaviour
+
+When retina-node is not installed the docker commands are skipped. The toggle still flips and the home page renders the correct content, using an in-memory cache for the mode state.

--- a/toggle.md
+++ b/toggle.md
@@ -1,6 +1,6 @@
 # Radar / Spectrum Mode Toggle
 
-A nav-bar toggle allows switching the node between **Radar** mode (blah2 passive radar) and **Spectrum** mode (retina-spectrum SDR visualiser) without manual container management.
+A toggle in the Config page (under **Node → Mode**) allows switching the node between **Radar** mode (blah2 passive radar) and **Spectrum** mode (retina-spectrum SDR visualiser) without manual container management.
 
 ---
 
@@ -12,9 +12,9 @@ A nav-bar toggle allows switching the node between **Radar** mode (blah2 passive
 | `src/routes/mode.py` | New Flask blueprint. `GET /api/mode` returns current mode. `POST /api/mode` stops/starts the appropriate containers and writes `DATA_DIR/mode.txt`. |
 | `src/app.py` | Added `RETINA_SPECTRUM_PATH` env var (defaults to `<project_root>/spectrum`). Registered the mode blueprint. |
 | `src/routes/home.py` | Reads current mode and passes it to the home template. |
-| `templates/base.html` | Nav toggle syncs from server on page load, POSTs on change with a spinner, reloads page on success. |
+| `templates/config.html` | New **Mode** section with toggle. Syncs from server on page load, POSTs on change with a spinner. |
 | `templates/index.html` | Radar mode renders the normal service cards. Spectrum mode renders a full-height iframe pointed at port 3020. |
-| `static/common.css` | Spinner animation and spectrum iframe layout styles. |
+| `static/common.css` | Spectrum iframe layout styles. |
 | `tests/test_mode.py` | 17 tests covering the API endpoints, docker command sequencing, failure rollback, mode persistence, and home page rendering. |
 
 ---
@@ -35,6 +35,37 @@ If either docker command fails the mode file is not updated and the toggle rever
 
 ---
 
+## Running for review
+
+retina-gui and retina-node are independent — retina-gui is packaged by owl-os and runs as its own systemd service; it is not part of the retina-node compose stack. To test the toggle you need both running.
+
+**1. Start retina-gui**
+
+```bash
+cd retina-gui/src
+pip install -r ../requirements.txt
+python app.py
+```
+
+Visit `http://localhost:5000`. The GUI works without retina-node installed — docker commands are skipped and the toggle still flips using an in-memory cache.
+
+**2. Start retina-node** (for full end-to-end testing)
+
+retina-node ships its own `docker-compose.yml`. Bring it up as the `retina-node` project so the GUI's docker commands target it correctly:
+
+```bash
+cd retina-node
+docker compose -p retina-node up -d
+```
+
+**3. Verify the toggle**
+
+Open Config → Mode. Switching to Spectrum stops the four blah2 containers and starts retina-spectrum; switching back reverses the process. The home page iframe appears at port 3020 when in Spectrum mode.
+
+**Prerequisite:** retina-spectrum must be published to ghcr.io before the `docker compose up` in step 3 can pull the image (see below).
+
+---
+
 ## Deployment prerequisite
 
 `spectrum/docker-compose.yml` references `ghcr.io/offworldlabs/retina-spectrum:${SPECTRUM_V:-v0.1.0}`. Update `SPECTRUM_V` once the image is published to ghcr.io. No changes are required to the retina-node compose stack.
@@ -44,3 +75,9 @@ If either docker command fails the mode file is not updated and the toggle rever
 ## Dev / pre-deployment behaviour
 
 When retina-node is not installed the docker commands are skipped. The toggle still flips and the home page renders the correct content, using an in-memory cache for the mode state.
+
+---
+
+## Validation
+
+The docker command layer was validated end-to-end on a live retina-node stack using a `python:3.12-slim` placeholder container in place of retina-spectrum (the real image targets ARM64 and cannot be built on x86_64). Each subprocess call was executed through Python exactly as `mode.py` issues it, with `cwd` set to the correct project directory. All four commands returned exit code 0, `tar1090` and `adsb2dd` remained untouched throughout, and the full stop → start → stop → restart cycle was confirmed via `docker ps`. The toggle was also validated qualitatively by running the GUI against the live stack and observing the container switching through the browser.


### PR DESCRIPTION
## What I did

Added a Radar / Spectrum mode toggle to the Config page (Config → Mode as a result of our email conversation). Switching to Spectrum stops the four blah2 containers (`blah2`, `blah2_api`, `blah2_web`, `blah2_host`) and starts retina-spectrum via a bundled compose file at `spectrum/docker-compose.yml`. Switching back reverses the process. The home page reflects the active mode — radar shows the normal service cards, spectrum embeds the retina-spectrum UI in a full-height iframe on port 3020.

The chosen approach runs retina-spectrum as a separate compose project (`-p retina-spectrum`) rather than integrating it into the retina-node stack. This keeps it independent of Mender-managed OTA updates and avoids touching the retina-node compose file.

Mode state is persisted to `/data/retina-gui/mode.txt` on the persistent partition, so it survives reboots and A/B OS updates. When retina-node is not installed docker commands are skipped and the toggle still works using an in-memory fallback — the GUI remains fully functional in a dev environment.

17 tests were added covering the API endpoints, docker command sequencing, failure rollback, and mode persistence.

## What I'd do differently with more time

I think I would be containerise retina-gui itself. As I understand it, currently a GUI change requires a full owl-os image release and an A/B rootfs swap via Mender. Running the GUI as a Docker container would decouple its release cycle, letting updates ship as an image pull independently of owl-os. It would also simplify the reviewer and dev setup to a single `docker compose up`. I think this is how you'd like it to work eventually based on your instructions for this task?

## Verification

The core switching logic (docker command sequencing, failure rollback, and mode persistence) cannot be exercised in a standard dev environment because it requires a live retina-node stack and ARM64 hardware for retina-spectrum. The 17 tests in `tests/test_mode.py` exist to mock the subprocess layer and verify that the right docker commands are issued in the right order, that the mode file is not written when a command fails, and that the toggle reverts correctly on error. Without them, the only way to gain confidence in the logic would be manual testing on a real node for every change. They are included because they are the closest thing to a reliable regression check available given the hardware constraints.

## Edge cases noticed but not handled

- **Partial docker failure mid-switch.** If the stop succeeds but the subsequent start fails, the node is left in an inconsistent state with blah2 stopped and retina-spectrum not running. The current implementation does not attempt rollback in this case; the toggle reverts visually but the containers are not restored automatically.
- **Concurrent toggle requests.** The API has no locking. Two rapid requests could interleave docker commands. Acceptable for a single-user device but worth noting.
- **retina-spectrum not yet on ghcr.io.** The compose file references an image that does not yet exist. The toggle will fail at the `docker compose up` step until the image is published.

<img width="1061" height="286" alt="image" src="https://github.com/user-attachments/assets/cf07db8f-7a66-4fd3-8d12-56549fdd14e6" />

<img width="1522" height="833" alt="image" src="https://github.com/user-attachments/assets/556a5039-3484-4a8f-adde-59d459f6a968" />

