### PR TITLE
20260528 spectrum in setup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,6 +20,7 @@ USER_CONFIG_PATH = os.environ.get('USER_CONFIG_PATH', '/data/retina-node/config/
 MERGED_CONFIG_PATH = os.environ.get('MERGED_CONFIG_PATH', '/data/retina-node/config/config.yml')
 RETINA_NODE_PATH = os.environ.get('RETINA_NODE_PATH', '/data/mender-docker-compose/current/manifests')
 RETINA_SPECTRUM_PATH = os.environ.get('RETINA_SPECTRUM_PATH', os.path.join(PROJECT_ROOT, 'spectrum'))
+RETINA_SPECTRUM_URL = os.environ.get('RETINA_SPECTRUM_URL', 'http://localhost:3020')
 NODE_ID_FILE = os.environ.get('NODE_ID_FILE', '/data/mender/node_id')
 TOWER_FINDER_URL = os.environ.get('TOWER_FINDER_URL', 'https://api.retina.fm')
 DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, Response, stream_with_context
 import subprocess
 
 import requests as http_requests
@@ -9,43 +9,22 @@ from config_manager import ConfigManager
 bp = Blueprint('towers', __name__, url_prefix='/towers')
 
 
-@bp.route("/search")
+@bp.route("/search", methods=["POST"])
 def search():
-    """Proxy tower search to Tower-Finder API."""
+    """Proxy RF-profile tower search to Tower-Finder API."""
     from app import app, TOWER_FINDER_URL
 
-    lat = request.args.get("lat")
-    lon = request.args.get("lon")
-    if not lat or not lon:
+    body = request.get_json()
+    if not body:
+        return jsonify({"error": "Missing JSON body"}), 400
+
+    if body.get("lat") is None or body.get("lon") is None:
         return jsonify({"error": "lat and lon are required"}), 400
 
     try:
-        lat_f = float(lat)
-        lon_f = float(lon)
-    except (ValueError, TypeError):
-        return jsonify({"error": "lat and lon must be numbers"}), 400
-
-    if not (-90 <= lat_f <= 90) or not (-180 <= lon_f <= 180):
-        return jsonify({"error": "lat must be -90..90 and lon must be -180..180"}), 400
-
-    params = {
-        "lat": lat,
-        "lon": lon,
-        "altitude": request.args.get("altitude", "0"),
-        "limit": request.args.get("limit", "20"),
-        "source": request.args.get("source", "auto"),
-    }
-    radius_km = request.args.get("radius_km")
-    if radius_km:
-        params["radius_km"] = radius_km
-    frequencies = request.args.get("frequencies")
-    if frequencies:
-        params["frequencies"] = frequencies
-
-    try:
-        resp = http_requests.get(
+        resp = http_requests.post(
             f"{TOWER_FINDER_URL}/api/towers",
-            params=params,
+            json=body,
             timeout=90,
         )
         resp.raise_for_status()
@@ -55,6 +34,31 @@ def search():
     except http_requests.RequestException as e:
         app.logger.warning(f"Tower search failed: {e}")
         return jsonify({"error": "Unable to reach tower finder service"}), 502
+
+
+@bp.route("/spectrum/events")
+def spectrum_events():
+    """Proxy SSE stream from retina-spectrum."""
+    from app import RETINA_SPECTRUM_URL
+
+    def generate():
+        try:
+            with http_requests.get(
+                f"{RETINA_SPECTRUM_URL}/api/events",
+                stream=True,
+                timeout=(5, None),
+            ) as r:
+                for chunk in r.iter_content(chunk_size=None):
+                    if chunk:
+                        yield chunk
+        except Exception:
+            yield b'data: {"type":"error"}\n\n'
+
+    return Response(
+        stream_with_context(generate()),
+        content_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @bp.route("/elevation")

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -34,6 +34,9 @@ def search():
     except http_requests.RequestException as e:
         app.logger.warning(f"Tower search failed: {e}")
         return jsonify({"error": "Unable to reach tower finder service"}), 502
+    except Exception as e:
+        app.logger.error(f"Tower search unexpected error: {e}")
+        return jsonify({"error": "Tower search failed — check server logs"}), 500
 
 
 @bp.route("/spectrum/events")
@@ -82,6 +85,9 @@ def elevation():
     except http_requests.RequestException as e:
         app.logger.warning(f"Elevation lookup failed: {e}")
         return jsonify({"error": "Elevation lookup failed"}), 502
+    except Exception as e:
+        app.logger.error(f"Elevation lookup unexpected error: {e}")
+        return jsonify({"error": "Elevation lookup failed — check server logs"}), 500
 
 
 @bp.route("/select", methods=["POST"])

--- a/static/setup.js
+++ b/static/setup.js
@@ -468,30 +468,91 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         var altManual = false;
         var elevTimer = null;
 
-        // Frequency inputs
-        var freqToggle = document.getElementById('freqToggle');
-        var freqSection = document.getElementById('freqSection');
-        var freqInputs = document.getElementById('freqInputs');
-        var addFreqBtn = document.getElementById('addFreqBtn');
-        var freqVisible = false;
+        // RF scan — SSE connected immediately on step entry; button sets 'waiting' phase
+        // and the next sweep 'start' event begins accumulation (mirrors retina-spectrum wizard.html).
+        var scanBtn = document.getElementById('scanRfBtn');
+        var scanStatus = document.getElementById('scanStatus');
+        var scanResult = document.getElementById('scanResult');
+        var rfMeasurements = [];
+        var rfPhase = 'idle'; // idle | waiting | scanning | done
+        var rfSse = null;
+        var rfHwReady = false;
 
-        freqToggle.addEventListener('click', function(e) {
-            e.preventDefault();
-            freqVisible = !freqVisible;
-            freqSection.style.display = freqVisible ? '' : 'none';
-            freqToggle.textContent = freqVisible ? 'Hide Measured Frequencies' : '+ Add Measured Frequencies';
+        function normaliseBand(id) {
+            if (id === 'fm') return 'FM';
+            if (id === 'vhf_hi' || id === 'vhf_lo') return 'VHF';
+            if (id === 'uhf') return 'UHF';
+            return id.toUpperCase();
+        }
+
+        function updateRfUI() {
+            var n = rfMeasurements.length;
+            if (rfPhase === 'idle' || rfPhase === 'waiting') {
+                scanStatus.textContent = rfPhase === 'waiting' ? 'Waiting for sweep to start…' : '';
+                scanStatus.style.display = rfPhase === 'waiting' ? '' : 'none';
+                scanResult.style.display = 'none';
+                scanBtn.disabled = !rfHwReady;
+                scanBtn.textContent = 'Scan RF signals';
+            } else if (rfPhase === 'scanning') {
+                scanStatus.textContent = 'Scanning…' + (n > 0 ? ' — ' + n + ' signal' + (n !== 1 ? 's' : '') + ' found' : '');
+                scanStatus.style.display = '';
+                scanResult.style.display = 'none';
+                scanBtn.disabled = true;
+                scanBtn.textContent = 'Scanning…';
+            } else if (rfPhase === 'done') {
+                scanStatus.style.display = 'none';
+                scanResult.textContent = n + ' signal' + (n !== 1 ? 's' : '') + ' detected';
+                scanResult.style.display = '';
+                scanBtn.disabled = false;
+                scanBtn.textContent = 'Rescan';
+            }
+        }
+
+        function connectRfSse() {
+            if (rfSse) return;
+            rfSse = new EventSource('/towers/spectrum/events');
+            rfSse.onmessage = function(e) {
+                var msg = JSON.parse(e.data);
+                if (msg.type === 'start') {
+                    if (rfPhase !== 'waiting') return;
+                    rfMeasurements = [];
+                    rfPhase = 'scanning';
+                    updateRfUI();
+                } else if (msg.type === 'step') {
+                    if (!rfHwReady) { rfHwReady = true; updateRfUI(); }
+                    if (rfPhase !== 'scanning') return;
+                    if (msg.channels) {
+                        msg.channels.forEach(function(ch) {
+                            if (rfMeasurements.some(function(m) { return m.freq_mhz === ch.fc_mhz; })) return;
+                            var m = { freq_mhz: ch.fc_mhz, band: normaliseBand(ch.band), score: ch.score || 0, snr_db: null, obw_fraction: null, power_db: null };
+                            if (ch.pilot_mhz == null) {
+                                m.snr_db = ch.snr_db != null ? ch.snr_db : null;
+                                m.obw_fraction = ch.obw_fraction != null ? ch.obw_fraction : null;
+                            } else {
+                                var pilot = ch.peaks && ch.peaks.find(function(p) { return p.is_pilot; });
+                                if (pilot) m.power_db = pilot.power_db;
+                            }
+                            rfMeasurements.push(m);
+                        });
+                        updateRfUI();
+                    }
+                } else if (msg.type === 'complete') {
+                    if (rfPhase !== 'scanning') return;
+                    rfPhase = 'done';
+                    updateRfUI();
+                }
+            };
+            rfSse.onerror = function() { rfSse.close(); rfSse = null; setTimeout(connectRfSse, 3000); };
+        }
+
+        scanBtn.disabled = true;
+        scanBtn.addEventListener('click', function() {
+            rfMeasurements = [];
+            rfPhase = 'waiting';
+            updateRfUI();
         });
 
-        addFreqBtn.addEventListener('click', function() {
-            var count = freqInputs.querySelectorAll('input').length;
-            if (count >= 10) return;
-            var div = document.createElement('div');
-            div.className = 'input-group input-group-sm mb-1';
-            div.innerHTML = '<input type="number" class="form-control" step="any" min="0" placeholder="Freq ' + (count + 1) + ' (MHz)">' +
-                '<button type="button" class="btn btn-outline-secondary" title="Remove">&times;</button>';
-            div.querySelector('button').addEventListener('click', function() { div.remove(); });
-            freqInputs.appendChild(div);
-        });
+        connectRfSse();
 
         // Enable Find Towers when lat/lon filled
         function updateFindBtn() {
@@ -565,16 +626,11 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
         // Find Towers → advance to towers step and trigger search
         findBtn.addEventListener('click', function() {
-            var freqs = [];
-            freqInputs.querySelectorAll('input').forEach(function(inp) {
-                var v = parseFloat(inp.value);
-                if (!isNaN(v) && v > 0) freqs.push(v);
-            });
             window._towerSearchParams = {
                 lat: parseFloat(rxLat.value),
                 lon: parseFloat(rxLon.value),
                 alt: parseFloat(rxAlt.value) || 0,
-                frequencies: freqs
+                measurements: rfMeasurements
             };
             advance();
         });
@@ -676,10 +732,11 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         errorEl.style.display = 'none';
         resultsEl.style.display = 'none';
 
-        var url = '/towers/search?lat=' + params.lat + '&lon=' + params.lon + '&altitude=' + params.alt + '&limit=20';
-        if (params.frequencies.length > 0) url += '&frequencies=' + params.frequencies.join(',');
-
-        fetch(url)
+        postJSON('/towers/search', {
+            lat: params.lat,
+            lon: params.lon,
+            measurements: params.measurements || []
+        })
             .then(function(r) { return r.json(); })
             .then(function(data) {
                 loadingEl.style.display = 'none';
@@ -755,6 +812,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     '<span style="color:' + (CLASS_COLORS[t.distance_class] || '#6b7280') +
                     ';font-weight:600;font-size:0.78rem;">' + esc(t.distance_class) + '</span>'
                 );
+                marker.on('click', function() { selectTower(t); });
                 towerMarkers.push({ marker: marker, tower: t });
             });
 
@@ -895,7 +953,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
     if (demoMode) {
         // Demo: start from the top, seed tower search params so towers step works
-        window._towerSearchParams = { lat: 37.7749, lon: -122.4194, alt: 16, frequencies: [] };
+        window._towerSearchParams = { lat: 37.7749, lon: -122.4194, alt: 16, measurements: [] };
         startIndex = 0;
     } else if (devMode) {
         for (var i = 0; i < steps.length; i++) {

--- a/templates/setup/_location.html
+++ b/templates/setup/_location.html
@@ -27,17 +27,13 @@
         </button>
         <p id="locationGeoError" style="display:none;color:var(--danger);font-size:13px;margin:0;"></p>
 
-        <div>
-            <a href="#" style="font-size:13px;color:var(--ink-3);text-decoration:none;" id="freqToggle">+ Add measured frequencies</a>
-            <div id="freqSection" style="display:none;margin-top:12px;">
-                <div class="ds-field">
-                    <label class="ds-field-label">Measured frequencies (MHz)</label>
-                    <div id="freqInputs">
-                        <input type="number" class="ds-input mono" style="margin-bottom:6px;" step="any" min="0" placeholder="Freq 1 (MHz)">
-                    </div>
-                </div>
-                <button type="button" class="ds-btn ghost sm" id="addFreqBtn">+ Add frequency</button>
-            </div>
+        <div class="ds-field">
+            <button type="button" class="ds-btn ghost sm" id="scanRfBtn" style="width:100%;">
+                <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+                Scan RF signals
+            </button>
+            <p id="scanStatus" style="display:none;font-size:13px;color:var(--ink-2);margin:4px 0 0;"></p>
+            <p id="scanResult" style="display:none;font-size:13px;color:var(--ok);margin:4px 0 0;"></p>
         </div>
     </div>
 


### PR DESCRIPTION
- Replaces manual frequency entry in the setup wizard with a live RF scan driven by retina-spectrum SSE events. Scan results (RF measurements) are passed to the tower finder instead of raw frequencies, and the tower search endpoint is changed from GET with query params to POST with a JSON body.
- Tower markers on the setup map are now clickable to select a tower.
- Adds catch-all exception handlers to the /towers/search and /towers/elevation endpoints.