### PR TITLE
20260602 setup re run

### DIFF
--- a/src/mender.py
+++ b/src/mender.py
@@ -61,7 +61,11 @@ class MenderClient:
             return None, None
 
     def get_versions(self) -> tuple[str | None, str | None]:
-        """Get owl-os and retina-node versions from Mender provides.
+        """Get owl-os and retina-node versions.
+
+        Checks mender-update show-provides first; falls back to inspecting
+        running Docker containers if mender hasn't committed provides yet
+        (e.g. when install_from_url succeeded but provides lag behind).
 
         Returns (owl_os_version, retina_node_version) tuple.
         On fresh bootstrap, only owl-os version exists. retina-node version
@@ -75,7 +79,7 @@ class MenderClient:
                 timeout=5,
             )
             if result.returncode != 0:
-                return None, None
+                return None, get_retina_node_version_from_docker()
 
             owl_os = None
             retina_node = None
@@ -85,12 +89,16 @@ class MenderClient:
                 elif line.startswith("data-docker.mender-docker-compose.retina-node.version="):
                     raw = line.split("=", 1)[1]
                     retina_node = raw.removeprefix("retina-node-")
+
+            if retina_node is None:
+                retina_node = get_retina_node_version_from_docker()
+
             return owl_os, retina_node
         except FileNotFoundError:
             # mender-update not installed (dev environment)
-            return None, None
+            return None, get_retina_node_version_from_docker()
         except Exception:
-            return None, None
+            return None, get_retina_node_version_from_docker()
 
     def list_artifacts(self, release_name: str | None = None) -> tuple[list[dict], str | None]:
         """List artifacts for a release/device type.
@@ -166,6 +174,30 @@ class MenderClient:
             return False, str(e)
 
 
+def get_retina_node_version_from_docker() -> str | None:
+    """Get retina-node version from running blah2 Docker containers.
+
+    Inspects 'docker ps' output for any offworldlabs/blah2 image and
+    extracts the image tag (e.g. 'v0.3.10').  Used as a fallback when
+    mender-update show-provides has not yet committed the artifact provides.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "--format", "{{.Image}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        for image in result.stdout.splitlines():
+            if "/blah2:" in image:
+                return image.rsplit(":", 1)[-1]
+        return None
+    except Exception:
+        return None
+
+
 def parse_version(artifact_name: str) -> tuple[int, ...] | None:
     """Extract semver tuple from 'retina-node-v0.3.2' format.
 
@@ -176,6 +208,34 @@ def parse_version(artifact_name: str) -> tuple[int, ...] | None:
     if match:
         return tuple(int(x) for x in match.groups())
     return None
+
+
+def get_all_stable_versions_from_github(
+    repo: str = "offworldlabs/retina-node",
+) -> tuple[list[str], str | None]:
+    """Get all stable version tags from GitHub releases, newest first.
+
+    Returns (versions, error) where versions is a list like ["v0.3.5", "v0.3.4"].
+    """
+    try:
+        resp = requests.get(
+            f"https://api.github.com/repos/{repo}/releases",
+            headers={"Accept": "application/vnd.github+json"},
+            timeout=30,
+        )
+        if resp.status_code != 200:
+            return [], f"GitHub API error: {resp.status_code}"
+
+        stable = []
+        for release in resp.json():
+            tag = release.get("tag_name", "")
+            if parse_version(f"retina-node-{tag}"):
+                stable.append(tag)
+
+        stable.sort(key=lambda t: parse_version(f"retina-node-{t}"), reverse=True)
+        return stable, None
+    except requests.RequestException as e:
+        return [], str(e)
 
 
 def get_latest_stable_from_github(

--- a/src/mender.py
+++ b/src/mender.py
@@ -177,9 +177,12 @@ class MenderClient:
 def get_retina_node_version_from_docker() -> str | None:
     """Get retina-node version from running blah2 Docker containers.
 
-    Inspects 'docker ps' output for any offworldlabs/blah2 image and
-    extracts the image tag (e.g. 'v0.3.10').  Used as a fallback when
-    mender-update show-provides has not yet committed the artifact provides.
+    Inspects 'docker ps' output for any offworldlabs/blah2 image and extracts
+    the image tag. Used as a fallback when mender-update show-provides has not
+    yet committed the artifact provides.
+
+    Returns the image tag string (e.g. 'v0.3.10'), or None if no blah2
+    containers are running or docker is unavailable.
     """
     try:
         result = subprocess.run(
@@ -215,7 +218,10 @@ def get_all_stable_versions_from_github(
 ) -> tuple[list[str], str | None]:
     """Get all stable version tags from GitHub releases, newest first.
 
-    Returns (versions, error) where versions is a list like ["v0.3.5", "v0.3.4"].
+    Queries GitHub releases API, filters to stable versions (excludes rc, dev, beta),
+    and returns all matching tags sorted by semver descending.
+
+    Returns (versions, error) tuple. versions is a list like ["v0.3.5", "v0.3.4"].
     """
     try:
         resp = requests.get(

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request
+import subprocess
 import threading
 
 bp = Blueprint('mender', __name__, url_prefix='/mender')
@@ -8,7 +9,7 @@ bp = Blueprint('mender', __name__, url_prefix='/mender')
 def check():
     """Check for available retina-node updates and install status."""
     from app import mender, device_state
-    from mender import get_latest_stable_from_github
+    from mender import get_all_stable_versions_from_github, parse_version
 
     _, current = mender.get_versions()
 
@@ -25,39 +26,60 @@ def check():
             "reason": reason,
         })
 
-    latest, error = get_latest_stable_from_github()
+    all_versions, error = get_all_stable_versions_from_github()
     if error:
         return jsonify({"error": error})
+
+    latest = all_versions[0] if all_versions else None
+
+    if current:
+        current_tuple = parse_version(f"retina-node-{current}")
+        available_updates = [
+            v for v in all_versions
+            if (vt := parse_version(f"retina-node-{v}")) and current_tuple and vt > current_tuple
+        ]
+    else:
+        available_updates = list(all_versions)
 
     return jsonify({
         "installing": False,
         "latest_version": latest,
         "current_version": current,
-        "update_available": current is None or latest != current,
+        "update_available": bool(available_updates),
+        "available_updates": available_updates,
     })
 
 
 @bp.route("/install", methods=["POST"])
 def install():
-    """Install latest stable retina-node artifact from Mender."""
+    """Install a retina-node artifact from Mender.
+
+    Accepts an optional 'version' in the JSON body (e.g. {"version": "v0.3.11"}).
+    Defaults to the latest stable release if omitted.
+    """
     from app import mender, device_state, app
     from mender import get_latest_stable_from_github
+
+    body = request.get_json() or {}
+    requested_version = body.get("version")
 
     success, error = device_state.ensure_cloud_services_enabled(mender.get_jwt)
     if not success:
         return jsonify({"success": False, "error": error})
 
     _, retina_node_version = mender.get_versions()
-    if retina_node_version:
-        return jsonify({"success": False, "error": "Already installed"})
+    is_reinstall = retina_node_version is not None
 
     can_install, reason = device_state.can_start_install()
     if not can_install:
         return jsonify({"success": False, "error": reason}), 409
 
-    version_tag, error = get_latest_stable_from_github()
-    if error:
-        return jsonify({"success": False, "error": f"Failed to get version: {error}"})
+    if requested_version:
+        version_tag = requested_version
+    else:
+        version_tag, error = get_latest_stable_from_github()
+        if error:
+            return jsonify({"success": False, "error": f"Failed to get version: {error}"})
 
     release_name = f"retina-node-{version_tag}"
     if not device_state.acquire_install_lock(release_name):
@@ -80,6 +102,11 @@ def install():
 
     def _run_install(download_url):
         try:
+            if is_reinstall:
+                subprocess.run(
+                    ["docker", "compose", "-p", "retina-node", "down"],
+                    capture_output=True, timeout=60
+                )
             success, error = mender.install_from_url(download_url)
             if not success:
                 app.logger.error(f"Background install failed: {error}")

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -45,7 +45,6 @@ def check():
         "installing": False,
         "latest_version": latest,
         "current_version": current,
-        "update_available": bool(available_updates),
         "available_updates": available_updates,
     })
 
@@ -68,7 +67,7 @@ def install():
         return jsonify({"success": False, "error": error})
 
     _, retina_node_version = mender.get_versions()
-    is_reinstall = retina_node_version is not None
+    already_installed = retina_node_version is not None
 
     can_install, reason = device_state.can_start_install()
     if not can_install:
@@ -102,7 +101,7 @@ def install():
 
     def _run_install(download_url):
         try:
-            if is_reinstall:
+            if already_installed:
                 subprocess.run(
                     ["docker", "compose", "-p", "retina-node", "down"],
                     capture_output=True, timeout=60

--- a/src/routes/setup.py
+++ b/src/routes/setup.py
@@ -15,6 +15,8 @@ def wizard():
     is_rerun = retina_node_version is not None
 
     demo_mode = request.args.get('demo') == '1'
+    if demo_mode:
+        is_rerun = True
 
     return render_template("setup.html",
                            resume_step=resume_step,

--- a/static/setup.js
+++ b/static/setup.js
@@ -148,6 +148,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
     // ── Demo mode: mock all API calls ────────────────────
     if (demoMode) {
+        var _demoNodeInstalling = false;
         var _realFetch = window.fetch;
         window.fetch = function(url, opts) {
             var path = url.split('?')[0];
@@ -157,8 +158,22 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             if (path === '/mender/cloud-services')  return ok({ success: true, enabled: true });
             if (path === '/mender/check-os')         return ok({ current_version: '2.4.1-demo', update_available: false });
             if (path === '/mender/install-os')       return ok({ success: true });
-            if (path === '/mender/check')            return ok({ current_version: '0.9.0-demo' });
-            if (path === '/mender/install')          return ok({ success: true });
+            if (path === '/mender/check') {
+                if (_demoNodeInstalling) {
+                    return ok({ installing: true, stage: 'pulling', reason: 'Installing retina-node-v1.0.0-demo' });
+                }
+                return ok({
+                    current_version: 'v0.9.0-demo',
+                    latest_version: 'v1.0.0-demo',
+                    update_available: true,
+                    available_updates: ['v1.0.0-demo', 'v0.9.5-demo'],
+                });
+            }
+            if (path === '/mender/install') {
+                _demoNodeInstalling = true;
+                setTimeout(function() { _demoNodeInstalling = false; }, 8000);
+                return ok({ success: true });
+            }
             if (path === '/towers/select')           return ok({ success: true, applied: false });
             if (path === '/set-up/save-step')        return ok({ success: true });
             if (path === '/set-up/complete')         return ok({ success: true });
@@ -342,19 +357,86 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         var regionCheck = document.getElementById('regionCheck');
         var packageStatus = document.getElementById('radarPackageStatus');
 
-        // On re-run, skip updates — package updates are managed remotely after onboarding
+        // On re-run, package is already installed \u2014 show available updates as cards, don't require action
         if (isRerun) {
+            function rerunUpdateGate() {
+                if (installBtn.style.display !== 'none') {
+                    installBtn.disabled = !regionCheck.checked;
+                }
+            }
+            regionCheck.addEventListener('change', rerunUpdateGate);
+
             fetch('/mender/check')
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
-                    if (data.current_version) {
-                        document.getElementById('radarLatestVersion').textContent = data.current_version;
+                    var updates = data.available_updates || [];
+                    var packageList = document.getElementById('radarPackageList');
+
+                    if (updates.length > 0) {
+                        var cards = updates.map(function(v, i) {
+                            var safeId = 'pkg-' + v.replace(/[^a-z0-9]/gi, '-');
+                            return '<div class="step-card">' +
+                                '<div><input type="radio" name="packageSelect" id="' + safeId + '" value="' + v + '"' +
+                                (i === 0 ? ' checked' : '') +
+                                ' style="accent-color:var(--ink);margin-right:12px;"></div>' +
+                                '<label class="step-card-body" for="' + safeId + '" style="cursor:pointer;">' +
+                                '<div class="step-card-title">Retina Passive Radar <span style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;">' + v + '</span></div>' +
+                                '<div class="step-card-sub">~600 MB \u00b7 5\u201310 minutes</div>' +
+                                '</label></div>';
+                        });
+                        if (data.current_version) {
+                            var cur = data.current_version;
+                            var safeId = 'pkg-' + cur.replace(/[^a-z0-9]/gi, '-');
+                            cards.push(
+                                '<div class="step-card">' +
+                                '<div><input type="radio" name="packageSelect" id="' + safeId + '" value="' + cur + '"' +
+                                ' style="accent-color:var(--ink);margin-right:12px;"></div>' +
+                                '<label class="step-card-body" for="' + safeId + '" style="cursor:pointer;">' +
+                                '<div class="step-card-title">Retina Passive Radar <span style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;">' + cur + '</span>' +
+                                '<span style="font-size:11px;color:var(--ink-3);margin-left:6px;">(installed)</span></div>' +
+                                '<div class="step-card-sub">Reinstall \u00b7 ~600 MB \u00b7 5\u201310 minutes</div>' +
+                                '</label></div>'
+                            );
+                        }
+                        packageList.innerHTML = cards.join('');
+                        installBtn.textContent = 'Install selected';
+                        installBtn.style.display = '';
+                        rerunUpdateGate();
+                        nextBtn.textContent = 'Skip \u2192';
+                    } else {
+                        if (data.current_version) {
+                            document.getElementById('radarLatestVersion').textContent = data.current_version;
+                        }
+                        packageStatus.innerHTML = '<span class="text-success">&#10003;</span>';
+                        status.innerHTML = 'Packages are up to date &#10003;';
+                        nextBtn.textContent = 'Continue \u2192';
                     }
-                    status.innerHTML = 'Package updates are managed remotely &#10003;';
-                    packageStatus.innerHTML = '<span class="text-success">&#10003;</span>';
+
                     nextBtn.style.display = '';
-                    nextBtn.textContent = 'Continue \u2192';
                 });
+
+            installBtn.addEventListener('click', function() {
+                var selected = document.querySelector('input[name="packageSelect"]:checked');
+                installBtn.style.display = 'none';
+                nextBtn.style.display = 'none';
+                status.textContent = 'Installing...';
+                installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
+
+                postJSON('/mender/install', selected ? {version: selected.value} : undefined)
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) {
+                        if (data.success) {
+                            startRadarPoll();
+                        } else {
+                            installStatus.innerHTML = '<span class="text-danger">' + data.error + '</span>';
+                            status.textContent = '';
+                            installBtn.style.display = '';
+                            nextBtn.style.display = '';
+                            rerunUpdateGate();
+                        }
+                    });
+            });
+
             nextBtn.addEventListener('click', advance);
             return;
         }

--- a/static/setup.js
+++ b/static/setup.js
@@ -472,6 +472,8 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     document.getElementById('radarLatestVersion').textContent = data.latest_version;
                     installBtn.style.display = '';
                     updateInstallGate();
+                    nextBtn.style.display = '';
+                    nextBtn.textContent = 'Skip →';
                 }
             });
 

--- a/static/setup.js
+++ b/static/setup.js
@@ -165,7 +165,6 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 return ok({
                     current_version: 'v0.9.0-demo',
                     latest_version: 'v1.0.0-demo',
-                    update_available: true,
                     available_updates: ['v1.0.0-demo', 'v0.9.5-demo'],
                 });
             }

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -74,8 +74,8 @@
             {# Packages #}
             <div id="stepBtns-radar" class="step-foot-btns" style="display:none;">
                 <span id="radarInstallStatus" style="font-size:13px;color:var(--ink-3);"></span>
-                <button type="button" class="ds-btn primary" id="radarInstallBtn" style="display:none;">Install selected</button>
-                <button type="button" class="ds-btn ghost"   id="radarNextBtn"   style="display:none;">Next →</button>
+                <button type="button" class="ds-btn ghost" id="radarInstallBtn" style="display:none;">Install selected</button>
+                <button type="button" class="ds-btn ghost" id="radarNextBtn"   style="display:none;">Next →</button>
             </div>
 
             {# Location #}


### PR DESCRIPTION
## Improve setup wizard package detection and re-run experience

The radar/packages step previously had no fallback if `mender-update show-provides`
didn't reflect a completed install — the wizard could get stuck showing "Install may
have failed" even with blah2 containers running. This PR fixes detection, improves
the re-run UX, and makes the install step skippable.

### Detection

- Add docker-based fallback in `mender.get_versions()`: if mender provides don't list
  a retina-node version, inspect running container images for any `offworldlabs/blah2`
  tag and use that as the installed version
- `is_rerun` (and thus the wizard re-run path) is now correctly set when packages are
  installed via either source

### Re-run UX

- Available updates are now shown as individual selectable version cards (one per
  GitHub release newer than installed), rather than a single "Update to vX.X.X" button
- "Currently installed: vX.X.X" shown below the cards so users know their current version
- If already on the latest, shows "Packages are up to date ✓" with no cards

### Install behaviour

- `/mender/install` now accepts an optional `version` body field to install a specific
  release; defaults to latest if omitted
- When reinstalling over an existing stack, `docker compose -p retina-node down` runs
  first for a clean teardown before `mender-update install`

### First-time install

- "Skip →" button added alongside "Install selected" so users can proceed without installing
- Both buttons are `ds-btn ghost` (equal visual weight — neither is presented as the
  obvious choice)

### Demo mode

- `is_rerun` forced to `true` in demo so the re-run path is always exercised
- `/mender/check` mock returns two update version cards and simulates an 8-second
  install polling cycle