### PR TITLE
20260605 spectrum wizard fix

### DIFF
--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -153,8 +153,13 @@ def save_config():
 
 @bp.route("/config/apply", methods=["POST"])
 def apply_config():
-    """Run config-merger and restart services."""
+    """Run config-merger and restart services.
+
+    In spectrum mode only config-merger runs — blah2 is intentionally stopped
+    and must not be restarted until the user switches back to radar mode.
+    """
     from app import config_mgr, RETINA_NODE_PATH
+    from routes.mode import get_current_mode
 
     if not config_mgr.is_retina_node_installed():
         return jsonify({"success": False, "error": "retina-node not installed"}), 400
@@ -167,6 +172,9 @@ def apply_config():
         )
         if result.returncode != 0:
             return jsonify({"success": False, "error": f"config-merger failed: {result.stderr or result.stdout}"}), 500
+
+        if get_current_mode() == 'spectrum':
+            return jsonify({"success": True})
 
         result = subprocess.run(
             ["docker", "compose", "-p", "retina-node", "up", "-d", "--force-recreate"],

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -30,90 +30,6 @@ def _write_mode(mode):
         pass  # dev: no /data — in-memory cache is the fallback
 
 
-@bp.route('/api/spectrum/temp-start', methods=['POST'])
-def temp_start_spectrum():
-    """Temporarily start retina-spectrum for the setup wizard RF scan.
-
-    Stops blah2 and starts retina-spectrum so the location step can scan RF
-    signals. Records the pre-wizard mode via the response so the caller can
-    pass it back to temp-restore when done.
-
-    No-op if already in spectrum mode or retina-node is not installed.
-    """
-    from app import RETINA_NODE_PATH, config_mgr
-    if not config_mgr.is_retina_node_installed():
-        return jsonify({'success': True, 'was_mode': 'radar', 'skipped': True})
-
-    if get_current_mode() == 'spectrum':
-        return jsonify({'success': True, 'was_mode': 'spectrum'})
-
-    try:
-        result = subprocess.run(
-            ['docker', 'compose', '-p', 'retina-node', 'stop',
-             'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
-            cwd=RETINA_NODE_PATH, capture_output=True, text=True, timeout=60
-        )
-        if result.returncode != 0:
-            return jsonify({'success': False,
-                            'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
-
-        result = subprocess.run(
-            ['docker', 'compose', '-p', 'retina-node', '--profile', 'spectrum', 'up', '-d'],
-            cwd=RETINA_NODE_PATH, capture_output=True, text=True, timeout=120
-        )
-        if result.returncode != 0:
-            return jsonify({'success': False,
-                            'error': f'Failed to start retina-spectrum: {result.stderr or result.stdout}'}), 500
-
-        return jsonify({'success': True, 'was_mode': 'radar'})
-
-    except subprocess.TimeoutExpired:
-        return jsonify({'success': False, 'error': 'Command timed out'}), 500
-    except Exception as e:
-        return jsonify({'success': False, 'error': str(e)}), 500
-
-
-@bp.route('/api/spectrum/temp-restore', methods=['POST'])
-def temp_restore_spectrum():
-    """Restore the mode that was active before the wizard RF scan.
-
-    Called when the user leaves the location step (Find Towers, Skip, or Back).
-    Passes was_mode from the temp-start response. No-op if was already in
-    spectrum mode or retina-node is not installed.
-    """
-    from app import RETINA_NODE_PATH, config_mgr
-    data = request.get_json(silent=True) or {}
-    was_mode = data.get('was_mode') or 'radar'  # 'or' handles None from JSON null
-
-    if was_mode == 'spectrum' or not config_mgr.is_retina_node_installed():
-        return jsonify({'success': True})
-
-    try:
-        result = subprocess.run(
-            ['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
-            cwd=RETINA_NODE_PATH, capture_output=True, text=True, timeout=60
-        )
-        if result.returncode != 0:
-            return jsonify({'success': False,
-                            'error': f'Failed to stop retina-spectrum: {result.stderr or result.stdout}'}), 500
-
-        result = subprocess.run(
-            ['docker', 'compose', '-p', 'retina-node', 'start',
-             'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
-            cwd=RETINA_NODE_PATH, capture_output=True, text=True, timeout=120
-        )
-        if result.returncode != 0:
-            return jsonify({'success': False,
-                            'error': f'Failed to start blah2: {result.stderr or result.stdout}'}), 500
-
-        return jsonify({'success': True})
-
-    except subprocess.TimeoutExpired:
-        return jsonify({'success': False, 'error': 'Command timed out'}), 500
-    except Exception as e:
-        return jsonify({'success': False, 'error': str(e)}), 500
-
-
 @bp.route('/api/mode', methods=['GET'])
 def get_mode():
     return jsonify({'mode': get_current_mode()})
@@ -148,7 +64,7 @@ def set_mode():
                                 'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
 
             result = subprocess.run(
-                ['docker', 'compose', '-p', 'retina-node', '--profile', 'spectrum', 'up', '-d'],
+                ['docker', 'compose', '-p', 'retina-node', '--profile', 'spectrum', 'up', '-d', 'retina-spectrum'],
                 cwd=RETINA_NODE_PATH,
                 capture_output=True, text=True, timeout=120
             )

--- a/static/setup.js
+++ b/static/setup.js
@@ -178,8 +178,8 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 return ok({ success: true });
             }
             if (path === '/towers/select')               return ok({ success: true, applied: false });
-            if (path === '/api/spectrum/temp-start')   return ok({ success: true, was_mode: 'spectrum' });
-            if (path === '/api/spectrum/temp-restore') return ok({ success: true });
+            if (path === '/api/mode' && (!opts || opts.method !== 'POST')) return ok({ mode: 'spectrum' });
+            if (path === '/api/mode') return ok({ success: true, mode: 'spectrum' });
             if (path === '/set-up/save-step')          return ok({ success: true });
             if (path === '/set-up/complete')           return ok({ success: true });
             return _realFetch(url, opts);
@@ -543,8 +543,8 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     // Step 4: Location input
     leaveHooks.location = function() {
         if (rfSse) { rfSse.close(); rfSse = null; }
-        if (!demoMode) {
-            postJSON('/api/spectrum/temp-restore', { was_mode: wizardWasMode });
+        if (wizardWasMode && wizardWasMode !== 'spectrum') {
+            postJSON('/api/mode', { mode: wizardWasMode });
         }
         wizardWasMode = null;
     };
@@ -554,23 +554,27 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         // spectrum mode or if retina-node is not yet installed).
         var scanBtn = document.getElementById('scanRfBtn');
         var scanStatus = document.getElementById('scanStatus');
-        if (!demoMode) {
-            wizardWasMode = 'radar'; // safe default — overwritten by temp-start response
-            scanBtn.disabled = true;
-            scanBtn.textContent = 'Starting scanner…';
-            scanStatus.textContent = 'Starting spectrum scanner…';
-            scanStatus.style.display = '';
-            postJSON('/api/spectrum/temp-start', {})
-                .then(function(r) { return r.json(); })
-                .then(function(d) {
-                    wizardWasMode = d.was_mode || 'radar';
+        wizardWasMode = 'radar'; // safe default — overwritten by mode fetch
+        scanBtn.disabled = true;
+        scanBtn.textContent = 'Starting analyser…';
+        scanStatus.textContent = 'Starting spectrum analyser…';
+        scanStatus.style.display = '';
+        fetch('/api/mode')
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                wizardWasMode = d.mode || 'radar';
+                if (d.mode === 'spectrum') {
                     if (connectRfSse) connectRfSse();
-                })
-                .catch(function() {
-                    wizardWasMode = 'radar';
-                    scanStatus.textContent = 'Scanner unavailable — RF scan disabled';
-                });
-        }
+                    return;
+                }
+                return postJSON('/api/mode', { mode: 'spectrum' })
+                    .then(function(r) { return r.json(); })
+                    .then(function() { if (connectRfSse) connectRfSse(); });
+            })
+            .catch(function() {
+                wizardWasMode = 'radar';
+                scanStatus.textContent = 'Analyser unavailable — RF scan disabled';
+            });
 
         // Event listeners and inner state set up only once
         if (hookInitialized.location) return;
@@ -669,9 +673,6 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             };
             rfSse.onerror = function() { rfSse.close(); rfSse = null; setTimeout(connectRfSse, 3000); };
         };
-
-        // In demo mode temp-start is skipped, so connect SSE directly
-        if (demoMode) connectRfSse();
 
         scanBtn.addEventListener('click', function() {
             rfMeasurements = [];

--- a/templates/config.html
+++ b/templates/config.html
@@ -377,12 +377,13 @@
 
 {% block scripts %}
 <script>
-// Mode toggle
+// Mode toggle — change is staged; applied when user clicks Apply changes
 (function() {
     var toggle  = document.getElementById('modeToggle');
     var label   = document.getElementById('modeLabel');
     var spinner = document.getElementById('modeSpinner');
     var csrf    = document.querySelector('meta[name="csrf-token"]').content;
+    var loadedMode = 'radar'; // the mode currently active on the device
 
     function setLabel(mode) {
         label.textContent = mode === 'spectrum' ? 'Spectrum' : 'Radar';
@@ -390,36 +391,51 @@
 
     fetch('/api/mode')
         .then(function(r) { return r.json(); })
-        .then(function(d) { toggle.checked = d.mode === 'spectrum'; setLabel(d.mode); })
+        .then(function(d) {
+            loadedMode = d.mode || 'radar';
+            toggle.checked = loadedMode === 'spectrum';
+            setLabel(loadedMode);
+        })
         .catch(function() {});
 
     toggle.addEventListener('change', function() {
-        var newMode = toggle.checked ? 'spectrum' : 'radar';
-        toggle.disabled = true;
-        spinner.style.display = 'inline-block';
-        fetch('/api/mode', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
-            body: JSON.stringify({ mode: newMode })
-        })
-        .then(function(r) { return r.json(); })
-        .then(function(d) {
-            if (d.success) {
-                setLabel(newMode);
-            } else {
-                toggle.checked = !toggle.checked;
-                setLabel(toggle.checked ? 'spectrum' : 'radar');
-            }
-        })
-        .catch(function() {
-            toggle.checked = !toggle.checked;
-            setLabel(toggle.checked ? 'spectrum' : 'radar');
-        })
-        .finally(function() {
-            toggle.disabled = false;
-            spinner.style.display = 'none';
-        });
+        setLabel(toggle.checked ? 'spectrum' : 'radar');
     });
+
+    // Apply mode change as part of the form submit triggered by Apply changes
+    var form = document.getElementById('configForm');
+    if (form) {
+        form.addEventListener('submit', function(e) {
+            var newMode = toggle.checked ? 'spectrum' : 'radar';
+            if (newMode === loadedMode) return; // no mode change — let form submit normally
+            e.preventDefault();
+            toggle.disabled = true;
+            spinner.style.display = 'inline-block';
+            fetch('/api/mode', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+                body: JSON.stringify({ mode: newMode })
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                if (d.success) {
+                    loadedMode = newMode;
+                    form.submit(); // HTMLFormElement.submit() bypasses the submit event
+                } else {
+                    toggle.checked = loadedMode === 'spectrum';
+                    setLabel(loadedMode);
+                }
+            })
+            .catch(function() {
+                toggle.checked = loadedMode === 'spectrum';
+                setLabel(loadedMode);
+            })
+            .finally(function() {
+                toggle.disabled = false;
+                spinner.style.display = 'none';
+            });
+        });
+    }
 })();
 
 // Auto-apply after successful save redirect

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -98,6 +98,7 @@ class TestSetMode:
         assert 'spectrum' in up_args
         assert 'up' in up_args
         assert '-d' in up_args
+        assert 'retina-spectrum' in up_args
 
     @patch('subprocess.run')
     def test_switch_to_radar_calls_correct_docker_commands(self, mock_run, app_client, temp_dir):


### PR DESCRIPTION
## Summary

Three fixes discovered during on-device testing of the spectrum mode and setup
wizard introduced in PR #14.

## Changes

### 1. Simplify wizard RF scan: use mode toggle directly; fix `up -d` scope

**`src/routes/mode.py`**

The dedicated `temp-start` / `temp-restore` endpoints introduced in PR #14 were
redundant — they duplicated the mode toggle logic with an added risk of leaving
mode.txt and container state out of sync if the browser lost connection or the
user navigated away mid-operation.

Removed both endpoints. The wizard now uses `GET /api/mode` to read the current
mode and `POST /api/mode` to switch — the same toggle used in Config → Mode.
mode.txt is always authoritative, so the device state is always recoverable via
the UI toggle even if the wizard is abandoned.

Also fixed a bug in the main mode toggle: `docker compose --profile spectrum up
-d` without a service name starts **all** services in scope, including the
stopped blah2 containers, immediately undoing the stop. Fixed by appending
`retina-spectrum` to target only that service.

**`static/setup.js`**

Wizard location step updated to use `GET /api/mode` + `POST /api/mode` instead
of the removed endpoints. Leave hook simplified accordingly. Button and status
text corrected to "analyser" throughout.

**`tests/test_mode.py`**

Assertion updated to verify `retina-spectrum` is explicitly named in the `up -d`
command.

---

### 2. Config apply: skip blah2 restart in spectrum mode

**`src/routes/config.py`**

`/config/apply` runs `docker compose up -d --force-recreate` to restart
services after a config save. In spectrum mode blah2 is intentionally stopped —
this command was bringing it back up, breaking spectrum mode whenever the user
applied any config change.

Fix: check current mode after config-merger runs. If spectrum, return success
without the `up -d --force-recreate` step. The updated config.yml is still
written for when blah2 is next started.

---

### 3. Stage mode toggle with Apply changes; fix validation display

**`templates/config.html`**

The mode toggle previously applied immediately on click, bypassing the Apply
changes flow. Changed to a staged model: the toggle updates the label and is
counted by the unsaved changes tracker, but the docker switch only happens when
the user clicks Apply. On submit the form intercept calls `/api/mode` first if
the mode changed, then lets the form post normally.

Also fixed a pre-existing bug: validation errors on the location (latitude,
longitude) and tar1090 (port, radius) fields were never shown to the user
because those sections use custom HTML that bypassed the `render_field` macro's
`is-invalid` logic. Added per-field error checks to both sections.