### PR TITLE
20260608 gui spectrum fixes pre customer

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -51,6 +51,12 @@ device_state = DeviceState(
 
 device_state.apply_startup_preferences()
 
+# Always boot into radar mode — delete any persisted spectrum state
+try:
+    os.remove(os.path.join(DATA_DIR, 'mode.txt'))
+except OSError:
+    pass
+
 
 def get_node_id():
     """Get node_id from Mender device identity file."""

--- a/src/mender.py
+++ b/src/mender.py
@@ -202,14 +202,14 @@ def get_retina_node_version_from_docker() -> str | None:
 
 
 def parse_version(artifact_name: str) -> tuple[int, ...] | None:
-    """Extract semver tuple from 'retina-node-v0.3.2' format.
+    """Extract version tuple from 'retina-node-v0.4.0.2' (or 3-part) format.
 
-    Returns version tuple (0, 3, 2) for stable releases.
+    Returns version tuple e.g. (0, 4, 0, 2) for stable releases.
     Returns None for RCs, dev, beta, or non-matching names.
     """
-    match = re.match(r"^retina-node-v(\d+)\.(\d+)\.(\d+)$", artifact_name)
+    match = re.match(r"^retina-node-v(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?$", artifact_name)
     if match:
-        return tuple(int(x) for x in match.groups())
+        return tuple(int(x) for x in match.groups() if x is not None)
     return None
 
 

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -159,31 +159,15 @@ def apply_config():
     and must not be restarted until the user switches back to radar mode.
     """
     from app import config_mgr, RETINA_NODE_PATH
-    from routes.mode import get_current_mode
+    from routes.mode import run_config_merger_and_restart
 
     if not config_mgr.is_retina_node_installed():
         return jsonify({"success": False, "error": "retina-node not installed"}), 400
 
     try:
-        result = subprocess.run(
-            ["docker", "compose", "-p", "retina-node", "run", "--rm", "config-merger"],
-            cwd=RETINA_NODE_PATH,
-            capture_output=True, text=True, timeout=60
-        )
-        if result.returncode != 0:
-            return jsonify({"success": False, "error": f"config-merger failed: {result.stderr or result.stdout}"}), 500
-
-        if get_current_mode() == 'spectrum':
-            return jsonify({"success": True})
-
-        result = subprocess.run(
-            ["docker", "compose", "-p", "retina-node", "up", "-d", "--force-recreate"],
-            cwd=RETINA_NODE_PATH,
-            capture_output=True, text=True, timeout=120
-        )
-        if result.returncode != 0:
-            return jsonify({"success": False, "error": f"restart failed: {result.stderr or result.stdout}"}), 500
-
+        error = run_config_merger_and_restart(RETINA_NODE_PATH)
+        if error:
+            return jsonify({"success": False, "error": error}), 500
         return jsonify({"success": True})
 
     except subprocess.TimeoutExpired:

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify, request
 
 bp = Blueprint('mode', __name__)
 
-_mode_cache = 'radar'  # in-memory fallback when DATA_DIR is not writable (dev)
+_mode_cache = 'radar'  # default mode if file read fails (e.g. dev environment without /data OR on startup before mode is set at least once)
 
 
 def get_current_mode():

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -30,6 +30,34 @@ def _write_mode(mode):
         pass  # dev: no /data — in-memory cache is the fallback
 
 
+def run_config_merger_and_restart(retina_node_path: str) -> str | None:
+    """Run config-merger then, in radar mode, restart services.
+
+    Returns an error string on failure, None on success.
+    Lets TimeoutExpired and FileNotFoundError propagate — callers handle them.
+    """
+    result = subprocess.run(
+        ['docker', 'compose', '-p', 'retina-node', 'run', '--rm', 'config-merger'],
+        cwd=retina_node_path,
+        capture_output=True, text=True, timeout=60
+    )
+    if result.returncode != 0:
+        return f'config-merger failed: {result.stderr or result.stdout}'
+
+    if get_current_mode() == 'spectrum':
+        return None
+
+    result = subprocess.run(
+        ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate'],
+        cwd=retina_node_path,
+        capture_output=True, text=True, timeout=120
+    )
+    if result.returncode != 0:
+        return f'restart failed: {result.stderr or result.stdout}'
+
+    return None
+
+
 @bp.route('/api/mode', methods=['GET'])
 def get_mode():
     return jsonify({'mode': get_current_mode()})

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -64,31 +64,6 @@ def spectrum_events():
     )
 
 
-@bp.route("/elevation")
-def elevation():
-    """Proxy elevation lookup to Tower-Finder API."""
-    from app import app, TOWER_FINDER_URL
-
-    lat = request.args.get("lat")
-    lon = request.args.get("lon")
-    if not lat or not lon:
-        return jsonify({"error": "lat and lon are required"}), 400
-
-    try:
-        resp = http_requests.get(
-            f"{TOWER_FINDER_URL}/api/elevation",
-            params={"lat": lat, "lon": lon},
-            timeout=15,
-        )
-        resp.raise_for_status()
-        return jsonify(resp.json())
-    except http_requests.RequestException as e:
-        app.logger.warning(f"Elevation lookup failed: {e}")
-        return jsonify({"error": "Elevation lookup failed"}), 502
-    except Exception as e:
-        app.logger.error(f"Elevation lookup unexpected error: {e}")
-        return jsonify({"error": "Elevation lookup failed — check server logs"}), 500
-
 
 @bp.route("/select", methods=["POST"])
 def select():

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -92,8 +92,13 @@ def elevation():
 
 @bp.route("/select", methods=["POST"])
 def select():
-    """Save RX + TX location to user.yml, run config-merger, and restart services."""
+    """Save RX + TX location to user.yml, run config-merger, and restart services.
+
+    In spectrum mode only config-merger runs — blah2 is intentionally stopped
+    and must not be restarted until the user switches back to radar mode.
+    """
     from app import config_mgr, get_node_id, RETINA_NODE_PATH
+    from routes.mode import get_current_mode
 
     data = request.get_json()
     if not data:
@@ -146,6 +151,9 @@ def select():
             if result.returncode != 0:
                 return jsonify({"success": True, "applied": False,
                                 "error": f"config-merger failed: {result.stderr or result.stdout}"})
+
+            if get_current_mode() == 'spectrum':
+                return jsonify({"success": True, "applied": True})
 
             result = subprocess.run(
                 ["docker", "compose", "-p", "retina-node", "up", "-d", "--force-recreate"],

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -73,7 +73,7 @@ def select():
     and must not be restarted until the user switches back to radar mode.
     """
     from app import config_mgr, get_node_id, RETINA_NODE_PATH
-    from routes.mode import get_current_mode
+    from routes.mode import run_config_merger_and_restart
 
     data = request.get_json()
     if not data:
@@ -118,27 +118,9 @@ def select():
 
     if config_mgr.is_retina_node_installed():
         try:
-            result = subprocess.run(
-                ["docker", "compose", "-p", "retina-node", "run", "--rm", "config-merger"],
-                cwd=RETINA_NODE_PATH,
-                capture_output=True, text=True, timeout=60
-            )
-            if result.returncode != 0:
-                return jsonify({"success": True, "applied": False,
-                                "error": f"config-merger failed: {result.stderr or result.stdout}"})
-
-            if get_current_mode() == 'spectrum':
-                return jsonify({"success": True, "applied": True})
-
-            result = subprocess.run(
-                ["docker", "compose", "-p", "retina-node", "up", "-d", "--force-recreate"],
-                cwd=RETINA_NODE_PATH,
-                capture_output=True, text=True, timeout=120
-            )
-            if result.returncode != 0:
-                return jsonify({"success": True, "applied": False,
-                                "error": f"restart failed: {result.stderr or result.stdout}"})
-
+            error = run_config_merger_and_restart(RETINA_NODE_PATH)
+            if error:
+                return jsonify({"success": True, "applied": False, "error": error})
             return jsonify({"success": True, "applied": True})
 
         except subprocess.TimeoutExpired:

--- a/static/setup.js
+++ b/static/setup.js
@@ -554,7 +554,6 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         // spectrum mode or if retina-node is not yet installed).
         var scanBtn = document.getElementById('scanRfBtn');
         var scanStatus = document.getElementById('scanStatus');
-        wizardWasMode = 'radar'; // safe default — overwritten by mode fetch
         scanBtn.disabled = true;
         scanBtn.textContent = 'Starting analyser…';
         scanStatus.textContent = 'Starting spectrum analyser…';
@@ -572,7 +571,6 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     .then(function() { if (connectRfSse) connectRfSse(); });
             })
             .catch(function() {
-                wizardWasMode = 'radar';
                 scanStatus.textContent = 'Analyser unavailable — RF scan disabled';
             });
 

--- a/static/setup.js
+++ b/static/setup.js
@@ -197,6 +197,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     var rfSse = null;
     var wizardWasMode = null;
     var connectRfSse = null; // defined inside enterHooks.location on first entry
+    var locationActive = false; // guards against dangling fetch resolving after leave
 
     // Step 1: Agreements
     enterHooks.agreements = function() {
@@ -542,6 +543,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
     // Step 4: Location input
     leaveHooks.location = function() {
+        locationActive = false;
         if (rfSse) { rfSse.close(); rfSse = null; }
         if (wizardWasMode && wizardWasMode !== 'spectrum') {
             postJSON('/api/mode', { mode: wizardWasMode });
@@ -552,6 +554,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     enterHooks.location = function() {
         // Start retina-spectrum on every entry (idempotent — no-op if already in
         // spectrum mode or if retina-node is not yet installed).
+        locationActive = true;
         var scanBtn = document.getElementById('scanRfBtn');
         var scanStatus = document.getElementById('scanStatus');
         scanBtn.disabled = true;
@@ -561,6 +564,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         fetch('/api/mode')
             .then(function(r) { return r.json(); })
             .then(function(d) {
+                if (!locationActive) return;
                 wizardWasMode = d.mode || 'radar';
                 if (d.mode === 'spectrum') {
                     if (connectRfSse) connectRfSse();
@@ -571,6 +575,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     .then(function() { if (connectRfSse) connectRfSse(); });
             })
             .catch(function() {
+                if (!locationActive) return;
                 scanStatus.textContent = 'Analyser unavailable — RF scan disabled';
             });
 

--- a/static/setup.js
+++ b/static/setup.js
@@ -195,6 +195,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
     // Shared state for spectrum wizard activation (location step)
     var rfSse = null;
+    var rfSseReconnectTimer = null;
     var wizardWasMode = null;
     var connectRfSse = null; // defined inside enterHooks.location on first entry
     var locationActive = false; // guards against dangling fetch resolving after leave
@@ -544,6 +545,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     // Step 4: Location input
     leaveHooks.location = function() {
         locationActive = false;
+        clearTimeout(rfSseReconnectTimer); rfSseReconnectTimer = null;
         if (rfSse) { rfSse.close(); rfSse = null; }
         if (wizardWasMode && wizardWasMode !== 'spectrum') {
             postJSON('/api/mode', { mode: wizardWasMode });
@@ -673,7 +675,10 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     updateRfUI();
                 }
             };
-            rfSse.onerror = function() { rfSse.close(); rfSse = null; setTimeout(connectRfSse, 3000); };
+            rfSse.onerror = function() {
+                rfSse.close(); rfSse = null;
+                if (locationActive) rfSseReconnectTimer = setTimeout(connectRfSse, 3000);
+            };
         };
 
         scanBtn.addEventListener('click', function() {

--- a/static/setup.js
+++ b/static/setup.js
@@ -594,8 +594,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         var findBtn = document.getElementById('findTowersBtn');
         var geoError = document.getElementById('locationGeoError');
         var skipBtn = document.getElementById('locationSkipBtn');
-        var altManual = false;
-        var elevTimer = null;
+
 
         // RF scan — SSE connected after retina-spectrum starts; button sets 'waiting'
         // phase and the next sweep 'start' event begins accumulation.
@@ -687,29 +686,6 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         rxLat.addEventListener('input', updateFindBtn);
         rxLon.addEventListener('input', updateFindBtn);
 
-        // Auto-lookup elevation (debounced)
-        function lookupElevation() {
-            if (altManual) return;
-            var lat = parseFloat(rxLat.value);
-            var lon = parseFloat(rxLon.value);
-            if (isNaN(lat) || isNaN(lon)) return;
-            fetch('/towers/elevation?lat=' + lat + '&lon=' + lon)
-                .then(function(r) { return r.json(); })
-                .then(function(data) {
-                    if (data.elevation_m != null && !altManual) {
-                        rxAlt.value = Math.round(data.elevation_m);
-                    }
-                })
-                .catch(function() {});
-        }
-        function debouncedElevation() {
-            clearTimeout(elevTimer);
-            elevTimer = setTimeout(lookupElevation, 800);
-        }
-        rxLat.addEventListener('input', debouncedElevation);
-        rxLon.addEventListener('input', debouncedElevation);
-        rxAlt.addEventListener('input', function() { altManual = rxAlt.value !== ''; });
-
         // Use My Location
         useMyLocBtn.addEventListener('click', function() {
             if (!navigator.geolocation) {
@@ -728,10 +704,8 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     rxLon.value = pos.coords.longitude.toFixed(6);
                     if (pos.coords.altitude != null) {
                         rxAlt.value = Math.round(pos.coords.altitude);
-                        altManual = true;
                     }
                     updateFindBtn();
-                    lookupElevation();
                 },
                 function(err) {
                     useMyLocBtn.disabled = false;

--- a/templates/setup/_location.html
+++ b/templates/setup/_location.html
@@ -18,7 +18,7 @@
 
         <div class="ds-field">
             <label class="ds-field-label" for="rxAlt">Altitude (m)</label>
-            <input type="number" class="ds-input mono" id="rxAlt" step="any" min="0" placeholder="Auto-detected from elevation data">
+            <input type="number" class="ds-input mono" id="rxAlt" step="any" min="0" placeholder="Enter altitude manually">
         </div>
 
         <button type="button" class="ds-btn ghost" id="useMyLocationBtn" style="align-self:flex-start;">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,26 +34,24 @@ class TestIndexRoute:
         assert b'href="/config"' in response.data
 
     def test_services_section(self, app_client):
-        """Index should show services links."""
+        """Index should show the Services section heading in radar mode."""
         response = app_client.get('/')
         assert response.status_code == 200
         assert b'Services' in response.data
-        assert b'blah2' in response.data
-        assert b'tar1090' in response.data
 
     def test_ssh_keys_on_config_page(self, app_client):
         """SSH keys should be on config page, not index."""
         response = app_client.get('/config')
         assert response.status_code == 200
-        assert b'SSH Access' in response.data
-        assert b'Add Key' in response.data
+        assert b'SSH access' in response.data
+        assert b'Add key' in response.data
 
     def test_index_shows_version_labels(self, app_client):
         """Index should show owl-os and retina-node version labels."""
         response = app_client.get('/')
         assert response.status_code == 200
-        assert b'owl-os:' in response.data
-        assert b'retina-node:' in response.data
+        assert b'owl-os' in response.data
+        assert b'retina-node' in response.data
 
 
 class TestMenderVersions:
@@ -64,7 +62,7 @@ class TestMenderVersions:
         from mender import MenderClient
         mock_output = """rootfs-image.version=v0.5.0
 rootfs-image.owl-os-pi5.version=v0.5.0
-rootfs-image.retina-node.version=v0.3.2
+data-docker.mender-docker-compose.retina-node.version=retina-node-v0.3.2
 artifact_name=owl-os-pi5-v0.5.0"""
 
         client = MenderClient()
@@ -122,9 +120,9 @@ class TestConfigPageRoute:
         """Config page should load with all sections."""
         response = app_client.get('/config')
         assert response.status_code == 200
-        assert b'Capture Settings' in response.data
-        assert b'Location Settings' in response.data
-        assert b'ADS-B Truth' in response.data
+        assert b'Capture' in response.data
+        assert b'Location' in response.data
+        assert b'ADS-B truth' in response.data
         assert b'tar1090' in response.data
 
     def test_config_shows_capture_values(self, app_client):
@@ -161,18 +159,16 @@ class TestConfigPageRoute:
         """Should show message when retina-node not installed, but cloud services visible."""
         response = app_client_no_retina.get('/config')
         assert response.status_code == 200
-        assert b'Configuration available after retina-node is deployed' in response.data
-        # Should NOT show the Apply button (config form is hidden)
-        assert b'Apply Changes' not in response.data
+        assert b'retina-node is installed' in response.data
         # Cloud Services should still be visible
         assert b'Cloud Services' in response.data
         assert b'cloudServicesToggle' in response.data
 
     def test_config_shows_apply_button(self, app_client):
-        """Config page should have Apply Changes button when retina-node installed."""
+        """Config page should have Apply changes button when retina-node installed."""
         response = app_client.get('/config')
         assert response.status_code == 200
-        assert b'Apply Changes' in response.data
+        assert b'Apply changes' in response.data
 
     def test_cloud_services_toggle_not_hardcoded_checked(self, app_client):
         """Cloud services toggle should not hardcode checked attribute."""
@@ -346,7 +342,7 @@ class TestLocationSave:
         assert saved['location']['rx']['name'] == 'NYC'
 
     def test_save_invalid_latitude(self, app_client):
-        """Invalid latitude should show error."""
+        """Invalid latitude should show error banner."""
         response = app_client.post('/config/save', data={
             'location.rx_latitude': '100',  # Invalid > 90
             'location.rx_longitude': '-74.0',
@@ -358,10 +354,10 @@ class TestLocationSave:
             'location.tx_name': 'Transmitter',
         })
         assert response.status_code == 200
-        assert b'is-invalid' in response.data
+        assert b'Please fix the highlighted fields below' in response.data
 
     def test_save_invalid_longitude(self, app_client):
-        """Invalid longitude should show error."""
+        """Invalid longitude should show error banner."""
         response = app_client.post('/config/save', data={
             'location.rx_latitude': '40.0',
             'location.rx_longitude': '200',  # Invalid > 180
@@ -373,7 +369,7 @@ class TestLocationSave:
             'location.tx_name': 'Transmitter',
         })
         assert response.status_code == 200
-        assert b'is-invalid' in response.data
+        assert b'Please fix the highlighted fields below' in response.data
 
 
 class TestTar1090Save:
@@ -406,7 +402,7 @@ class TestTar1090Save:
         # (only values that differ are saved)
 
     def test_invalid_port(self, app_client):
-        """Port > 65535 should show error."""
+        """Port > 65535 should show error banner."""
         response = app_client.post('/config/save', data={
             'tar1090.adsb_source_host': '10.0.0.1',
             'tar1090.adsb_source_port': '70000',  # Invalid
@@ -415,10 +411,10 @@ class TestTar1090Save:
             'tar1090.adsblol_radius': '50',
         })
         assert response.status_code == 200
-        assert b'is-invalid' in response.data
+        assert b'Please fix the highlighted fields below' in response.data
 
     def test_invalid_radius(self, app_client):
-        """Radius > 500 should show error."""
+        """Radius > 500 should show error banner."""
         response = app_client.post('/config/save', data={
             'tar1090.adsb_source_host': '10.0.0.1',
             'tar1090.adsb_source_port': '30005',
@@ -427,7 +423,7 @@ class TestTar1090Save:
             'tar1090.adsblol_radius': '600',  # Invalid > 500
         })
         assert response.status_code == 200
-        assert b'is-invalid' in response.data
+        assert b'Please fix the highlighted fields below' in response.data
 
 
 class TestTruthSave:

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -44,109 +44,72 @@ SAMPLE_TOWER_RESPONSE = {
 
 
 class TestTowerSearch:
-    """Tests for GET /towers/search proxy route."""
+    """Tests for POST /towers/search proxy route."""
 
-    @patch('routes.towers.http_requests.get')
-    def test_search_returns_towers(self, mock_get, app_client):
+    @patch('routes.towers.http_requests.post')
+    def test_search_returns_towers(self, mock_post, app_client):
         """Proxy returns tower data from Tower-Finder API."""
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = SAMPLE_TOWER_RESPONSE
         mock_resp.raise_for_status.return_value = None
-        mock_get.return_value = mock_resp
+        mock_post.return_value = mock_resp
 
-        resp = app_client.get('/towers/search?lat=-33.8688&lon=151.2093')
+        resp = app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
         assert resp.status_code == 200
         data = json.loads(resp.data)
         assert data['count'] == 1
         assert data['towers'][0]['callsign'] == 'ATN6'
 
-        # Verify we called the Tower-Finder API
-        mock_get.assert_called_once()
-        call_args = mock_get.call_args
-        assert '/api/towers' in call_args[0][0]
+        mock_post.assert_called_once()
+        assert '/api/towers' in mock_post.call_args[0][0]
 
-    def test_search_missing_params(self, app_client):
-        """Returns 400 when lat/lon missing."""
-        resp = app_client.get('/towers/search')
+    def test_search_missing_body(self, app_client):
+        """Returns 400 when request body is missing."""
+        resp = app_client.post('/towers/search', json={})
         assert resp.status_code == 400
-        data = json.loads(resp.data)
-        assert 'error' in data
 
     def test_search_missing_lon(self, app_client):
         """Returns 400 when lon missing."""
-        resp = app_client.get('/towers/search?lat=-33.8688')
+        resp = app_client.post('/towers/search', json={'lat': -33.8688})
         assert resp.status_code == 400
 
-    @patch('routes.towers.http_requests.get')
-    def test_search_timeout(self, mock_get, app_client):
+    @patch('routes.towers.http_requests.post')
+    def test_search_timeout(self, mock_post, app_client):
         """Returns 504 on timeout."""
         import requests
-        mock_get.side_effect = requests.Timeout()
+        mock_post.side_effect = requests.Timeout()
 
-        resp = app_client.get('/towers/search?lat=-33.8688&lon=151.2093')
+        resp = app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
         assert resp.status_code == 504
         data = json.loads(resp.data)
         assert 'timed out' in data['error'].lower()
 
-    @patch('routes.towers.http_requests.get')
-    def test_search_upstream_error(self, mock_get, app_client):
+    @patch('routes.towers.http_requests.post')
+    def test_search_upstream_error(self, mock_post, app_client):
         """Returns 502 when Tower-Finder API is unreachable."""
         import requests
-        mock_get.side_effect = requests.ConnectionError()
+        mock_post.side_effect = requests.ConnectionError()
 
-        resp = app_client.get('/towers/search?lat=-33.8688&lon=151.2093')
+        resp = app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
         assert resp.status_code == 502
 
-    @patch('routes.towers.http_requests.get')
-    def test_search_forwards_params(self, mock_get, app_client):
-        """Forwards all query params to Tower-Finder API."""
+    @patch('routes.towers.http_requests.post')
+    def test_search_forwards_body(self, mock_post, app_client):
+        """Forwards entire JSON body to Tower-Finder API."""
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"towers": [], "count": 0}
         mock_resp.raise_for_status.return_value = None
-        mock_get.return_value = mock_resp
+        mock_post.return_value = mock_resp
 
-        app_client.get('/towers/search?lat=38.9&lon=-77.0&altitude=50&limit=10&source=us&radius_km=100')
+        body = {'lat': 38.9, 'lon': -77.0, 'altitude': 50, 'limit': 10, 'source': 'us', 'radius_km': 100}
+        app_client.post('/towers/search', json=body)
 
-        call_kwargs = mock_get.call_args
-        params = call_kwargs[1]['params']
-        assert params['lat'] == '38.9'
-        assert params['lon'] == '-77.0'
-        assert params['altitude'] == '50'
-        assert params['limit'] == '10'
-        assert params['source'] == 'us'
-        assert params['radius_km'] == '100'
-
-
-class TestTowerElevation:
-    """Tests for GET /towers/elevation proxy route."""
-
-    @patch('routes.towers.http_requests.get')
-    def test_elevation_returns_data(self, mock_get, app_client):
-        """Returns elevation from Tower-Finder API."""
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"elevation_m": 45.2, "latitude": -33.8688, "longitude": 151.2093}
-        mock_resp.raise_for_status.return_value = None
-        mock_get.return_value = mock_resp
-
-        resp = app_client.get('/towers/elevation?lat=-33.8688&lon=151.2093')
-        assert resp.status_code == 200
-        data = json.loads(resp.data)
-        assert data['elevation_m'] == 45.2
-
-    def test_elevation_missing_params(self, app_client):
-        """Returns 400 when lat/lon missing."""
-        resp = app_client.get('/towers/elevation')
-        assert resp.status_code == 400
-
-    @patch('routes.towers.http_requests.get')
-    def test_elevation_upstream_error(self, mock_get, app_client):
-        """Returns 502 when elevation API fails."""
-        import requests
-        mock_get.side_effect = requests.ConnectionError()
-
-        resp = app_client.get('/towers/elevation?lat=-33.8688&lon=151.2093')
-        assert resp.status_code == 502
+        forwarded = mock_post.call_args[1]['json']
+        assert forwarded['lat'] == 38.9
+        assert forwarded['lon'] == -77.0
+        assert forwarded['altitude'] == 50
+        assert forwarded['source'] == 'us'
 
 
 class TestTowerSelect:
@@ -242,8 +205,7 @@ class TestSetupWizardLocationStep:
         resp = app_client.get('/set-up')
         html = resp.data.decode()
         assert 'data-step="location"' in html
-        assert 'data-step="location"' in html
-        assert 'Find Towers' in html
+        assert 'Find towers' in html
 
     def test_setup_page_has_all_steps(self, app_client):
         """Setup wizard has all 6 step panels."""


### PR DESCRIPTION
## Summary

A set of spectrum/radar mode correctness fixes in the setup wizard and supporting backend routes, found during pre-customer review.

**Backend**
- `app.py`: Delete `mode.txt` on every startup so a node previously left in spectrum mode always boots into radar, matching the running container state - https://app.clickup.com/t/90152460893/86ca5b3h6
- `towers.py`: Skip `docker compose up --force-recreate` after tower select when in spectrum mode — was unconditionally restarting blah2 while retina-spectrum held the SDR - https://app.clickup.com/t/90152460893/86ca5b2jp
- `towers.py`: Remove `/towers/elevation` proxy — endpoint was dropped from tower-finder-service - https://app.clickup.com/t/90152460893/86ca52xg3
- `mode.py`: Extract shared `run_config_merger_and_restart()` helper, eliminating duplicated spectrum-mode guard between `config/apply` and `towers/select`
- `mender.py`: Update `parse_version` regex to accept 4-part version strings (`v0.4.0.2`) - https://app.clickup.com/t/90152460893/86ca1yk3k

**Frontend (`setup.js`)**
- `wizardWasMode` now initialised to `null` instead of `'radar'` — prevents a spurious mode restore to radar if the user leaves the location step before the `/api/mode` fetch resolves - https://app.clickup.com/t/90152460893/86ca5b4cx
- `locationActive` flag added — both the `.then` and `.catch` of the enter-hook fetch bail out immediately if the user has already left, closing off a race that could permanently lock the node in spectrum mode
- SSE reconnect timer now stored and cancelled in `leaveHooks.location` — previously `onerror` could schedule a reconnect that fired after leaving the step, leaving a background `EventSource` with no consumer
- Removed debounced elevation auto-lookup (`lookupElevation`, `altManual`) — no longer needed with `/towers/elevation` gone

**Tests**
- Updated `test_app.py` and `test_towers.py` to match current UI strings, Mender key format, and the POST-based tower search API