### PR TITLE
20260608 - Redesign setup wizard packages step for clarity. 

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -532,6 +532,14 @@ h1, h2, h3, h4, h5, h6 {
 .step-check-text { font-size: 14px; }
 .step-check-help { font-size: 12.5px; color: var(--ink-3); margin-top: 2px; }
 
+.wiz-section-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--ink-3);
+}
+
 /* Step card (packages etc.) */
 .step-card {
     display: flex;

--- a/static/setup.js
+++ b/static/setup.js
@@ -370,7 +370,8 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         var regionCheck = document.getElementById('regionCheck');
         var packageStatus = document.getElementById('radarPackageStatus');
 
-        // On re-run, package is already installed \u2014 show available updates as cards, don't require action
+        // Re-run: RETINA is already installed — show current version in its own section,
+        // and any available updates in a separate section below.
         if (isRerun) {
             function rerunUpdateGate() {
                 if (installBtn.style.display !== 'none') {
@@ -384,47 +385,54 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 .then(function(data) {
                     var updates = data.available_updates || [];
                     var packageList = document.getElementById('radarPackageList');
+                    var currentSection = document.getElementById('radarCurrentSection');
+                    var currentList = document.getElementById('radarCurrentList');
+                    var availableSection = document.getElementById('radarAvailableSection');
+                    var availableHeading = document.getElementById('radarAvailableHeading');
+                    var description = document.getElementById('radarDescription');
+
+                    // Always render the installed version in its own section
+                    if (data.current_version) {
+                        var cur = data.current_version;
+                        var curId = 'pkg-' + cur.replace(/[^a-z0-9]/gi, '-');
+                        currentList.innerHTML =
+                            '<div class="step-card">' +
+                            '<div><input type="radio" name="packageSelect" id="' + curId + '" value="' + esc(cur) + '"' +
+                            (updates.length === 0 ? ' checked' : '') +
+                            ' style="accent-color:var(--ink);margin-right:12px;"></div>' +
+                            '<label class="step-card-body" for="' + curId + '" style="cursor:pointer;">' +
+                            '<div class="step-card-title">Retina Passive Radar <span style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;">' + esc(cur) + '</span></div>' +
+                            '<div class="step-card-sub">Reinstall \u00b7 ~600 MB \u00b7 5\u201310 minutes</div>' +
+                            '</label></div>';
+                        currentSection.style.display = '';
+                    }
 
                     if (updates.length > 0) {
+                        description.textContent = 'RETINA is installed. You can upgrade to a newer version, or reinstall your current one.';
                         var cards = updates.map(function(v, i) {
                             var safeId = 'pkg-' + v.replace(/[^a-z0-9]/gi, '-');
                             return '<div class="step-card">' +
-                                '<div><input type="radio" name="packageSelect" id="' + safeId + '" value="' + v + '"' +
+                                '<div><input type="radio" name="packageSelect" id="' + safeId + '" value="' + esc(v) + '"' +
                                 (i === 0 ? ' checked' : '') +
                                 ' style="accent-color:var(--ink);margin-right:12px;"></div>' +
                                 '<label class="step-card-body" for="' + safeId + '" style="cursor:pointer;">' +
-                                '<div class="step-card-title">Retina Passive Radar <span style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;">' + v + '</span></div>' +
+                                '<div class="step-card-title">Retina Passive Radar <span style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;">' + esc(v) + '</span></div>' +
                                 '<div class="step-card-sub">~600 MB \u00b7 5\u201310 minutes</div>' +
                                 '</label></div>';
                         });
-                        if (data.current_version) {
-                            var cur = data.current_version;
-                            var safeId = 'pkg-' + cur.replace(/[^a-z0-9]/gi, '-');
-                            cards.push(
-                                '<div class="step-card">' +
-                                '<div><input type="radio" name="packageSelect" id="' + safeId + '" value="' + cur + '"' +
-                                ' style="accent-color:var(--ink);margin-right:12px;"></div>' +
-                                '<label class="step-card-body" for="' + safeId + '" style="cursor:pointer;">' +
-                                '<div class="step-card-title">Retina Passive Radar <span style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;">' + cur + '</span>' +
-                                '<span style="font-size:11px;color:var(--ink-3);margin-left:6px;">(installed)</span></div>' +
-                                '<div class="step-card-sub">Reinstall \u00b7 ~600 MB \u00b7 5\u201310 minutes</div>' +
-                                '</label></div>'
-                            );
-                        }
                         packageList.innerHTML = cards.join('');
+                        availableHeading.textContent = 'Available updates';
+                        availableHeading.style.display = '';
                         installBtn.textContent = 'Install selected';
-                        installBtn.style.display = '';
-                        rerunUpdateGate();
-                        nextBtn.textContent = 'Skip \u2192';
                     } else {
-                        if (data.current_version) {
-                            document.getElementById('radarLatestVersion').textContent = data.current_version;
-                        }
-                        packageStatus.innerHTML = '<span class="text-success">&#10003;</span>';
-                        status.innerHTML = 'Packages are up to date &#10003;';
-                        nextBtn.textContent = 'Continue \u2192';
+                        description.textContent = 'RETINA is up to date. You can reinstall your current version if needed.';
+                        availableSection.style.display = 'none';
+                        installBtn.textContent = 'Reinstall';
                     }
 
+                    installBtn.style.display = '';
+                    rerunUpdateGate();
+                    nextBtn.textContent = 'Skip \u2192';
                     nextBtn.style.display = '';
                 });
 
@@ -454,6 +462,11 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             return;
         }
 
+        // Fresh install — RETINA is not yet on this node, installation is required.
+        document.getElementById('radarDescription').textContent = 'RETINA is not yet installed on this node. Select a version below to continue.';
+        installBtn.classList.remove('ghost');
+        installBtn.classList.add('primary');
+
         function updateInstallGate() {
             if (installBtn.style.display !== 'none') {
                 installBtn.disabled = !regionCheck.checked;
@@ -481,12 +494,10 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     document.getElementById('radarLatestVersion').textContent = data.current_version;
                     nextBtn.style.display = '';
                 } else {
-                    status.textContent = '';
                     document.getElementById('radarLatestVersion').textContent = data.latest_version;
                     installBtn.style.display = '';
                     updateInstallGate();
-                    nextBtn.style.display = '';
-                    nextBtn.textContent = 'Skip →';
+                    // No skip — installation is required on a fresh node
                 }
             });
 

--- a/templates/setup/_packages.html
+++ b/templates/setup/_packages.html
@@ -1,8 +1,8 @@
 <!-- Step 3: Packages -->
 <div data-step="radar" class="step-panel" style="display:none;">
     <div class="wiz-title-row">
-        <h1>Install radar packages</h1>
-        <p>Select the software packages you would like to deploy to this node.</p>
+        <h1>RETINA packages</h1>
+        <p id="radarDescription"></p>
     </div>
     <div class="step-stack">
         <label class="step-check">
@@ -13,20 +13,30 @@
             </div>
         </label>
 
-        <div id="radarPackageList">
-            <div class="step-card" id="radarPackageCard">
-                <div>
-                    <input type="radio" name="packageSelect" id="packageRetina" value="retina-node" checked
-                           style="accent-color:var(--ink);margin-right:12px;">
+        <!-- Currently installed (shown in re-run mode only) -->
+        <div id="radarCurrentSection" style="display:none;">
+            <div class="wiz-section-label">Currently installed</div>
+            <div id="radarCurrentList" style="display:flex;flex-direction:column;gap:8px;margin-top:8px;"></div>
+        </div>
+
+        <!-- Available packages / updates -->
+        <div id="radarAvailableSection" style="display:flex;flex-direction:column;gap:8px;">
+            <div id="radarAvailableHeading" class="wiz-section-label" style="display:none;"></div>
+            <div id="radarPackageList" style="display:flex;flex-direction:column;gap:8px;">
+                <div class="step-card" id="radarPackageCard">
+                    <div>
+                        <input type="radio" name="packageSelect" id="packageRetina" value="retina-node" checked
+                               style="accent-color:var(--ink);margin-right:12px;">
+                    </div>
+                    <label class="step-card-body" for="packageRetina" style="cursor:pointer;">
+                        <div class="step-card-title">Retina Passive Radar <span id="radarLatestVersion" style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;"></span></div>
+                        <div class="step-card-sub">~600 MB · 5–10 minutes</div>
+                    </label>
+                    <span id="radarPackageStatus"></span>
                 </div>
-                <label class="step-card-body" for="packageRetina" style="cursor:pointer;">
-                    <div class="step-card-title">Retina Passive Radar <span id="radarLatestVersion" style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;"></span></div>
-                    <div class="step-card-sub">~600 MB · 5–10 minutes</div>
-                </label>
-                <span id="radarPackageStatus"></span>
             </div>
         </div>
     </div>
 
-    <p id="radarStatus" style="color:var(--ink-3);font-size:13.5px;margin:16px 0 0;">Checking for software…</p>
+    <p id="radarStatus" style="color:var(--ink-3);font-size:13.5px;margin:16px 0 0;"></p>
 </div>


### PR DESCRIPTION
## Summary

- **Fresh install**: Adds a description telling the user RETINA is not yet installed, promotes the install button to primary style (required action), and removes the skip option so installation is enforced
- **Re-run with updates**: Splits the page into two labelled sections — "Currently installed" shows the active version card, "Available updates" lists newer versions below it — so the user always knows their current state before choosing what to install
- **Re-run up to date**: Shows only the "Currently installed" section with a "Reinstall" action; hides the updates section entirely

Also adds a `.wiz-section-label` CSS class for the section headings, and fixes a latent XSS issue by passing all version strings through `esc()` before injecting them into innerHTML.

## For Example

<img width="591" height="754" alt="image" src="https://github.com/user-attachments/assets/c7508d02-2f25-4200-b2a5-c805c1aaf7f5" />
