### PR TITLE
20260609 - Flesh out DEV_MODE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__/
 tests/__pycache__/
 .venv/
+
+# Dev mode local data
+src/dev_data/

--- a/src/app.py
+++ b/src/app.py
@@ -14,15 +14,23 @@ app = Flask(__name__,
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', os.urandom(32).hex())
 csrf = CSRFProtect(app)
 
-# Configurable paths - override via environment for local dev
-DATA_DIR = os.environ.get('DATA_DIR', '/data/retina-gui')
-USER_CONFIG_PATH = os.environ.get('USER_CONFIG_PATH', '/data/retina-node/config/user.yml')
-MERGED_CONFIG_PATH = os.environ.get('MERGED_CONFIG_PATH', '/data/retina-node/config/config.yml')
+DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
+
+# Configurable paths - override via environment for local dev.
+# In dev mode, default to a writable local directory instead of the on-device paths.
+DATA_DIR = os.environ.get('DATA_DIR',
+    os.path.join(PROJECT_ROOT, 'dev_data') if DEV_MODE else '/data/retina-gui'
+)
+USER_CONFIG_PATH = os.environ.get('USER_CONFIG_PATH',
+    os.path.join(PROJECT_ROOT, 'dev_data', 'user.yml') if DEV_MODE else '/data/retina-node/config/user.yml'
+)
+MERGED_CONFIG_PATH = os.environ.get('MERGED_CONFIG_PATH',
+    os.path.join(PROJECT_ROOT, 'dev_data', 'config.yml') if DEV_MODE else '/data/retina-node/config/config.yml'
+)
 RETINA_NODE_PATH = os.environ.get('RETINA_NODE_PATH', '/data/mender-docker-compose/current/manifests')
 RETINA_SPECTRUM_URL = os.environ.get('RETINA_SPECTRUM_URL', 'http://localhost:3020')
 NODE_ID_FILE = os.environ.get('NODE_ID_FILE', '/data/mender/node_id')
 TOWER_FINDER_URL = os.environ.get('TOWER_FINDER_URL', 'https://api.retina.fm')
-DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
 
 # Shared services
 ssh_keys = SSHKeyManager(os.path.join(DATA_DIR, "authorized_keys"))
@@ -37,6 +45,8 @@ mender = MenderClient(
     server_url=os.environ.get('MENDER_SERVER_URL', 'https://hosted.mender.io'),
     release_name=os.environ.get('MENDER_RELEASE_NAME', 'retina-node'),
     device_type=os.environ.get('MENDER_DEVICE_TYPE', 'pi5-v3-arm64'),
+    dev_mode=DEV_MODE,
+    dev_data_dir=DATA_DIR,
 )
 
 MENDER_SERVICES = ["mender-authd", "mender-updated", "mender-connect"]
@@ -47,15 +57,17 @@ device_state = DeviceState(
     mender_conf_path="/data/mender/mender.conf",
     mender_conf_backup_dir="/data/mender-cloud-disabled",
     mender_conf_backup_path="/data/mender-cloud-disabled/mender.conf",
+    dev_mode=DEV_MODE,
 )
 
-device_state.apply_startup_preferences()
+if not DEV_MODE:
+    device_state.apply_startup_preferences()
 
-# Always boot into radar mode — delete any persisted spectrum state
-try:
-    os.remove(os.path.join(DATA_DIR, 'mode.txt'))
-except OSError:
-    pass
+    # Always boot into radar mode — delete any persisted spectrum state
+    try:
+        os.remove(os.path.join(DATA_DIR, 'mode.txt'))
+    except OSError:
+        pass
 
 
 def get_node_id():

--- a/src/device_state.py
+++ b/src/device_state.py
@@ -36,7 +36,7 @@ class DeviceState:
     """
 
     def __init__(self, data_dir, mender_services, mender_conf_path,
-                 mender_conf_backup_dir, mender_conf_backup_path):
+                 mender_conf_backup_dir, mender_conf_backup_path, dev_mode=False):
         self.data_dir = data_dir
         self.install_lock_file = os.path.join(data_dir, "install.lock")
         self.cloud_disabled_flag = os.path.join(data_dir, "cloud-services-disabled")
@@ -46,6 +46,7 @@ class DeviceState:
         self.mender_conf_backup_dir = mender_conf_backup_dir
         self.mender_conf_backup_path = mender_conf_backup_path
         self.setup_wizard_file = os.path.join(data_dir, "setup-wizard.json")
+        self.dev_mode = dev_mode
 
     # ── State Queries ──────────────────────────────────────────
 
@@ -121,6 +122,14 @@ class DeviceState:
 
     def get_cloud_services_status(self) -> dict:
         """Full status for GET /mender/cloud-services."""
+        if self.dev_mode:
+            return {
+                "enabled": self.is_cloud_services_enabled(),
+                "services": {s: True for s in self.mender_services},
+                "update_in_progress": False,
+                "update_reason": None,
+            }
+
         service_status = {}
         for service in self.mender_services:
             try:
@@ -184,6 +193,15 @@ class DeviceState:
         if not allowed:
             return False, reason
 
+        if self.dev_mode:
+            os.makedirs(self.data_dir, exist_ok=True)
+            if enabled:
+                if os.path.exists(self.cloud_disabled_flag):
+                    os.remove(self.cloud_disabled_flag)
+            else:
+                open(self.cloud_disabled_flag, 'w').close()
+            return True, None
+
         try:
             if enabled:
                 if os.path.exists(self.cloud_disabled_flag):
@@ -228,6 +246,9 @@ class DeviceState:
         Ensures the setting persists across OTA updates.
         If OTA regenerates mender.conf, we stop services and re-backup.
         """
+        if self.dev_mode:
+            return
+
         if not os.path.exists(self.cloud_disabled_flag):
             return  # Enabled - nothing to enforce
 
@@ -322,6 +343,9 @@ class DeviceState:
         Takes get_jwt_fn callable to avoid circular dependency with MenderClient.
         Returns (success, error).
         """
+        if self.dev_mode:
+            return True, None
+
         if not os.path.exists(self.cloud_disabled_flag):
             token, _ = get_jwt_fn()
             if token:

--- a/src/mender.py
+++ b/src/mender.py
@@ -1,8 +1,17 @@
 """Mender client for device-initiated OTA updates."""
+import os
 import re
 import subprocess
 
 import requests
+
+
+# Fake version history used by all dev-mode routes — newest first.
+# Set DEV_NODE_VERSION env var to control the simulated installed version:
+#   DEV_NODE_VERSION=v1.0.0  (default) → re-run with v1.1.0 and v1.0.5 available
+#   DEV_NODE_VERSION=v1.1.0            → re-run, up to date (no updates)
+#   DEV_NODE_VERSION=                  → fresh install (no package installed)
+DEV_VERSIONS = ['v1.1.0', 'v1.0.5', 'v1.0.0', 'v0.9.5', 'v0.9.0']
 
 
 class MenderClient:
@@ -17,10 +26,14 @@ class MenderClient:
         server_url: str = "https://hosted.mender.io",
         release_name: str = "retina-node",
         device_type: str = "pi5-v3-arm64",
+        dev_mode: bool = False,
+        dev_data_dir: str | None = None,
     ):
         self.server_url = server_url
         self.release_name = release_name
         self.device_type = device_type
+        self.dev_mode = dev_mode
+        self.dev_data_dir = dev_data_dir
 
     def get_jwt(self) -> tuple[str, str] | tuple[None, None]:
         """Get device JWT via D-Bus from mender-auth.
@@ -60,6 +73,23 @@ class MenderClient:
         except Exception:
             return None, None
 
+    def dev_get_node_version(self) -> str | None:
+        """Read the simulated installed retina-node version from dev_data."""
+        if self.dev_data_dir:
+            path = os.path.join(self.dev_data_dir, 'dev_node_version.txt')
+            if os.path.exists(path):
+                v = open(path).read().strip()
+                return v or None
+        v = os.environ.get('DEV_NODE_VERSION', 'v1.0.0')
+        return v or None
+
+    def dev_set_node_version(self, version: str):
+        """Write the simulated installed retina-node version to dev_data."""
+        if self.dev_data_dir:
+            os.makedirs(self.dev_data_dir, exist_ok=True)
+            with open(os.path.join(self.dev_data_dir, 'dev_node_version.txt'), 'w') as f:
+                f.write(version)
+
     def get_versions(self) -> tuple[str | None, str | None]:
         """Get owl-os and retina-node versions.
 
@@ -71,6 +101,9 @@ class MenderClient:
         On fresh bootstrap, only owl-os version exists. retina-node version
         appears after the first app OTA update.
         """
+        if self.dev_mode:
+            return ('2.4.1-dev', self.dev_get_node_version())
+
         try:
             result = subprocess.run(
                 ["mender-update", "show-provides"],

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -14,10 +14,10 @@ bp = Blueprint('config', __name__)
 @bp.route("/config")
 def config_page():
     """Configuration page with all settings."""
-    from app import config_mgr, ssh_keys
+    from app import config_mgr, ssh_keys, DEV_MODE
 
     config = config_mgr.load_merged_config()
-    retina_installed = config_mgr.is_retina_node_installed()
+    retina_installed = config_mgr.is_retina_node_installed() or DEV_MODE or request.args.get('demo') == '1'
 
     capture_flat = config_mgr.flatten_capture_for_form(config.get('capture', {}))
     capture_fields = schema_to_form_fields(CaptureFormConfig, capture_flat)
@@ -96,9 +96,9 @@ def save_config():
             all_errors.update(ConfigManager.format_validation_errors(e, 'tar1090'))
 
     if all_errors:
-        from app import ssh_keys
+        from app import ssh_keys, DEV_MODE
         return render_template("config.html",
-                               retina_installed=config_mgr.is_retina_node_installed(),
+                               retina_installed=config_mgr.is_retina_node_installed() or DEV_MODE or request.args.get('demo') == '1',
                                capture_fields=schema_to_form_fields(CaptureFormConfig, capture_flat),
                                location_fields=schema_to_form_fields(LocationFormConfig, location_flat),
                                truth_fields=schema_to_form_fields(AdsbTruthConfig, truth_data),
@@ -158,8 +158,11 @@ def apply_config():
     In spectrum mode only config-merger runs — blah2 is intentionally stopped
     and must not be restarted until the user switches back to radar mode.
     """
-    from app import config_mgr, RETINA_NODE_PATH
+    from app import config_mgr, RETINA_NODE_PATH, DEV_MODE
     from routes.mode import run_config_merger_and_restart
+
+    if DEV_MODE:
+        return jsonify({"success": True})
 
     if not config_mgr.is_retina_node_installed():
         return jsonify({"success": False, "error": "retina-node not installed"}), 400

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -8,8 +8,32 @@ bp = Blueprint('mender', __name__, url_prefix='/mender')
 @bp.route("/check")
 def check():
     """Check for available retina-node updates and install status."""
-    from app import mender, device_state
-    from mender import get_all_stable_versions_from_github, parse_version
+    from app import mender, device_state, DEV_MODE
+    from mender import get_all_stable_versions_from_github, parse_version, DEV_VERSIONS
+
+    if DEV_MODE:
+        in_progress, reason = device_state.is_any_update_in_progress()
+        if in_progress:
+            locked, lock_info = device_state.is_install_locked()
+            return jsonify({
+                "installing": True,
+                "stage": "pulling",
+                "version": lock_info["version"] if lock_info else "retina-node",
+                "reason": reason,
+            })
+        current = mender.dev_get_node_version()
+        if current and current in DEV_VERSIONS:
+            available_updates = DEV_VERSIONS[:DEV_VERSIONS.index(current)]
+        elif current:
+            available_updates = []
+        else:
+            available_updates = list(DEV_VERSIONS)
+        return jsonify({
+            "installing": False,
+            "latest_version": DEV_VERSIONS[0],
+            "current_version": current,
+            "available_updates": available_updates,
+        })
 
     _, current = mender.get_versions()
 
@@ -56,11 +80,29 @@ def install():
     Accepts an optional 'version' in the JSON body (e.g. {"version": "v0.3.11"}).
     Defaults to the latest stable release if omitted.
     """
-    from app import mender, device_state, app
-    from mender import get_latest_stable_from_github
+    from app import mender, device_state, app, DEV_MODE
+    from mender import get_latest_stable_from_github, DEV_VERSIONS
+    import time
 
     body = request.get_json() or {}
     requested_version = body.get("version")
+
+    if DEV_MODE:
+        version_tag = requested_version or DEV_VERSIONS[0]
+        can_install, reason = device_state.can_start_install()
+        if not can_install:
+            return jsonify({"success": False, "error": reason}), 409
+        release_name = f"retina-node-{version_tag}"
+        if not device_state.acquire_install_lock(release_name):
+            return jsonify({"success": False, "error": "Install already in progress"}), 409
+
+        def _dev_install():
+            time.sleep(8)
+            mender.dev_set_node_version(version_tag)
+            device_state.release_install_lock()
+
+        threading.Thread(target=_dev_install, daemon=True).start()
+        return jsonify({"success": True, "version": release_name})
 
     success, error = device_state.ensure_cloud_services_enabled(mender.get_jwt)
     if not success:
@@ -144,8 +186,15 @@ def cloud_services_toggle():
 @bp.route("/check-os")
 def check_os():
     """Check for owl-os updates and install status."""
-    from app import mender, device_state
+    from app import mender, device_state, DEV_MODE
     from mender import get_latest_owl_os_from_github, parse_os_version
+
+    if DEV_MODE:
+        return jsonify({
+            "installing": False,
+            "current_version": "2.4.1-dev",
+            "update_available": False,
+        })
 
     owl_os_current, _ = mender.get_versions()
 
@@ -184,8 +233,24 @@ def check_os():
 @bp.route("/install-os", methods=["POST"])
 def install_os():
     """Trigger managed OS update via Mender daemon."""
-    from app import mender, device_state
+    from app import mender, device_state, DEV_MODE
     from mender import get_latest_owl_os_from_github
+    import time
+
+    if DEV_MODE:
+        can_install, reason = device_state.can_start_install()
+        if not can_install:
+            return jsonify({"success": False, "error": reason}), 409
+        if not device_state.acquire_install_lock("owl-os-dev"):
+            return jsonify({"success": False, "error": "Install already in progress"}), 409
+
+        def _dev_os_install():
+            time.sleep(6)
+            device_state.release_install_lock()
+
+        threading.Thread(target=_dev_os_install, daemon=True).start()
+        device_state.save_setup_wizard_step("system")
+        return jsonify({"success": True, "version": "owl-os-dev", "state": "waiting"})
 
     can_install, reason = device_state.can_start_install()
     if not can_install:


### PR DESCRIPTION
## Summary

- `app.py`: `DATA_DIR`, `USER_CONFIG_PATH`, and `MERGED_CONFIG_PATH` now default to `dev_data/` in dev mode instead of hard-coded `/data/` paths; startup side-effects (`apply_startup_preferences`, `mode.txt` deletion) are skipped
- `device_state.py`: cloud service calls stub out `systemctl`; `ensure_cloud_services_enabled` returns immediately instead of blocking for up to 60 seconds
- `mender.py`: `get_versions()` returns a dev stub; `dev_get/set_node_version()` reads and writes `dev_data/dev_node_version.txt` to persist simulated installed version state across requests
- `mender_routes.py`: `/check` and `/install` use canned `DEV_VERSIONS` with a simulated 8-second install; `/check-os` and `/install-os` are fully stubbed
- `config.py`: Apply Changes button visible in dev and demo mode; `/config/apply` short-circuits instead of running `config-merger`
- `.gitignore`: `dev_data/` excluded

Set `DEV_NODE_VERSION=v1.0.0` (default) for a re-run with updates available, `v1.1.0` for up-to-date, or empty for a fresh install. The installed version persists in `dev_data/dev_node_version.txt` after a simulated install and can be deleted to reset.

## Note on longevity

This is an intentionally temporary solution to unblock local GUI development before product launch. Branching on `DEV_MODE` throughout production files and is not intended to be permanent. Once post-launch stabilisation tasks are complete, this will be replaced by a proper dev workflow, most likely a fully simulated node environment, which will allow the production code paths to remain clean. I am simply creating this PR so that the simulated enviroment where I test chnages quickly is reflected on the remote.