### PR TITLE
20260609 - Fix setup wizard install and reinstall flow 

### DIFF
--- a/src/device_state.py
+++ b/src/device_state.py
@@ -175,6 +175,19 @@ class DeviceState:
         if os.path.exists(self.install_lock_file):
             os.remove(self.install_lock_file)
 
+    def update_install_stage(self, stage: str):
+        """Update the stage field in the install lock for UI progress reporting."""
+        if not os.path.exists(self.install_lock_file):
+            return
+        try:
+            with open(self.install_lock_file) as f:
+                lock = json.load(f)
+            lock["stage"] = stage
+            with open(self.install_lock_file, "w") as f:
+                json.dump(lock, f)
+        except Exception:
+            pass
+
     def set_cloud_services(self, enabled: bool) -> tuple[bool, str | None]:
         """Enable/disable cloud services. Respects guards.
 

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify, request
 import subprocess
 import threading
+import time
 
 bp = Blueprint('mender', __name__, url_prefix='/mender')
 
@@ -17,7 +18,12 @@ def check():
     if in_progress:
         locked, lock_info = device_state.is_install_locked()
         mender_status = device_state._get_mender_update_status()
-        stage = mender_status.get("state") if mender_status else "downloading"
+        if mender_status:
+            stage = mender_status.get("state")
+        elif lock_info:
+            stage = lock_info.get("stage", "downloading")
+        else:
+            stage = "downloading"
         return jsonify({
             "installing": True,
             "stage": stage,
@@ -100,15 +106,28 @@ def install():
         return jsonify({"success": False, "error": error})
 
     def _run_install(download_url):
+        from mender import get_retina_node_version_from_docker
         try:
             if already_installed:
-                subprocess.run(
-                    ["docker", "compose", "-p", "retina-node", "down"],
-                    capture_output=True, timeout=60
-                )
+                try:
+                    subprocess.run(
+                        ["docker", "compose", "-p", "retina-node", "down"],
+                        capture_output=True, timeout=60
+                    )
+                except Exception as e:
+                    app.logger.warning(f"Pre-install docker down failed (continuing): {e}")
             success, error = mender.install_from_url(download_url)
             if not success:
                 app.logger.error(f"Background install failed: {error}")
+            else:
+                device_state.update_install_stage("starting")
+                deadline = time.time() + 120
+                while time.time() < deadline:
+                    if get_retina_node_version_from_docker():
+                        break
+                    time.sleep(3)
+                else:
+                    app.logger.warning("Containers did not come up within 2 minutes after install")
         except Exception as e:
             app.logger.error(f"Background install crashed: {e}")
         finally:

--- a/static/setup.js
+++ b/static/setup.js
@@ -383,6 +383,14 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             fetch('/mender/check')
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
+                    if (data.installing) {
+                        status.textContent = data.reason || 'Installation in progress...';
+                        installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
+                        if (backBtn) backBtn.style.display = 'none';
+                        startRadarPoll();
+                        return;
+                    }
+
                     var updates = data.available_updates || [];
                     var packageList = document.getElementById('radarPackageList');
                     var currentSection = document.getElementById('radarCurrentSection');
@@ -440,6 +448,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 var selected = document.querySelector('input[name="packageSelect"]:checked');
                 installBtn.style.display = 'none';
                 nextBtn.style.display = 'none';
+                if (backBtn) backBtn.style.display = 'none';
                 status.textContent = 'Installing...';
                 installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
 
@@ -453,6 +462,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                             status.textContent = '';
                             installBtn.style.display = '';
                             nextBtn.style.display = '';
+                            if (backBtn) backBtn.style.display = '';
                             rerunUpdateGate();
                         }
                     });
@@ -481,6 +491,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     status.textContent = data.reason || 'Installation in progress...';
                     installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
                     packageStatus.innerHTML = '<span class="spinner-border spinner-border-sm text-primary"></span>';
+                    if (backBtn) backBtn.style.display = 'none';
                     startRadarPoll();
                     return;
                 }
@@ -503,6 +514,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
         installBtn.addEventListener('click', function() {
             installBtn.style.display = 'none';
+            if (backBtn) backBtn.style.display = 'none';
             packageStatus.innerHTML = '<span class="spinner-border spinner-border-sm text-primary"></span>';
             status.textContent = 'Installing...';
             installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
@@ -517,6 +529,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                         packageStatus.innerHTML = '';
                         status.textContent = '';
                         installBtn.style.display = '';
+                        if (backBtn) backBtn.style.display = '';
                         updateInstallGate();
                     }
                 });
@@ -543,10 +556,16 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                                 packageStatus.innerHTML = '';
                                 status.textContent = '';
                                 installBtn.style.display = '';
+                                if (isRerun) nextBtn.style.display = '';
+                                if (backBtn) backBtn.style.display = '';
                                 updateInstallGate();
                             }
                         } else {
-                            status.textContent = (data.stage || 'Installing') + '...';
+                            var stageText = {
+                                downloading: 'Downloading...',
+                                starting: 'Starting retina-node...'
+                            };
+                            status.textContent = stageText[data.stage] || 'Installing...';
                         }
                     });
             }, 5000);


### PR DESCRIPTION
## Summary

- Fixed the wizard auto-advancing to the location step before retina-node containers were running after install, causing the location step to switch to spectrum mode and destroy the freshly deployed containers
- Wrapped the pre-install `docker compose down` in its own try/except so a timeout no longer silently aborts the mender install
- After a successful mender install, the backend now holds the install lock until `docker ps` confirms retina-node containers are running (2 min deadline) — the wizard can only advance once this is confirmed
- Added `update_install_stage()` to `DeviceState` so the lock file carries a stage field, enabling the frontend to show Downloading vs Starting retina-node progress
- Fixed `/mender/check` stage resolution to read from the lock file for GUI-initiated installs rather than always falling back to the mender-update status file
- Added `data.installing` check on packages step entry for both fresh install and re-run paths — if the page is refreshed mid-install, polling resumes correctly
- Hidden the Back button for the duration of any install to prevent the user navigating away and leaving the wizard in an unrecoverable state
- Restored the Skip button after a failed re-run install (was missing from the poll error path)