### PR TITLE
20260609 container handeling fix

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_wtf.csrf import CSRFProtect
 import os
+import subprocess
 
 from config_manager import ConfigManager
 from device_state import DeviceState
@@ -56,6 +57,17 @@ try:
     os.remove(os.path.join(DATA_DIR, 'mode.txt'))
 except OSError:
     pass
+
+# Enforce radar at the Docker level: stop and remove retina-spectrum if it is running.
+# retina-spectrum is only allowed while the wizard location step or config toggle is active.
+if config_mgr.is_retina_node_installed():
+    try:
+        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                       cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
+        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                       cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
+    except Exception:
+        pass
 
 
 def get_node_id():

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -11,6 +11,14 @@ from form_utils import schema_to_form_fields
 bp = Blueprint('config', __name__)
 
 
+@bp.before_request
+def _check_wizard_not_active():
+    """Block config access while the setup wizard is in progress."""
+    from app import device_state
+    if device_state.is_setup_wizard_in_progress():
+        return redirect('/set-up')
+
+
 @bp.route("/config")
 def config_page():
     """Configuration page with all settings."""

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -47,6 +47,16 @@ def run_config_merger_and_restart(retina_node_path: str) -> str | None:
     if get_current_mode() == 'spectrum':
         return None
 
+    # Defensive: ensure retina-spectrum is stopped before bringing the radar stack up.
+    # Non-fatal — retina-spectrum may already be stopped.
+    try:
+        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                       cwd=retina_node_path, capture_output=True, timeout=60)
+        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                       cwd=retina_node_path, capture_output=True, timeout=30)
+    except Exception:
+        pass
+
     result = subprocess.run(
         ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate'],
         cwd=retina_node_path,
@@ -110,6 +120,14 @@ def set_mode():
                 return jsonify({'success': False,
                                 'error': f'Failed to stop retina-spectrum: {result.stderr or result.stdout}'}), 500
 
+            # Remove the stopped container so it cannot be auto-restarted and
+            # so the SDR device is cleanly released before blah2 starts.
+            subprocess.run(
+                ['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                cwd=RETINA_NODE_PATH,
+                capture_output=True, text=True, timeout=30
+            )
+
             result = subprocess.run(
                 ['docker', 'compose', '-p', 'retina-node', 'start',
                  'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
@@ -127,3 +145,44 @@ def set_mode():
         return jsonify({'success': False, 'error': 'Command timed out'}), 500
     except Exception as e:
         return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@bp.route('/api/spectrum/ready', methods=['GET'])
+def spectrum_ready():
+    """Probe retina-spectrum to see if it is serving yet.
+
+    Returns {ready: true} as soon as the container responds on its port,
+    regardless of HTTP status code.
+    """
+    from app import RETINA_SPECTRUM_URL
+    import urllib.request
+    import urllib.error
+    try:
+        urllib.request.urlopen(RETINA_SPECTRUM_URL, timeout=2)
+        return jsonify({'ready': True})
+    except urllib.error.HTTPError:
+        return jsonify({'ready': True})  # server responded — it's up
+    except Exception:
+        return jsonify({'ready': False})
+
+
+@bp.route('/api/mode/release-spectrum', methods=['POST'])
+def release_spectrum():
+    """Stop retina-spectrum and revert to radar mode.
+
+    Called via navigator.sendBeacon when the user navigates away from the
+    wizard location step mid-flow. Returns 204 — callers do not inspect the
+    response body.
+    """
+    from app import RETINA_NODE_PATH, config_mgr
+    if not config_mgr.is_retina_node_installed():
+        return '', 204
+    try:
+        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                       cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
+        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                       cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
+        _write_mode('radar')
+    except Exception:
+        pass
+    return '', 204

--- a/static/setup.js
+++ b/static/setup.js
@@ -75,52 +75,51 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     }
 
     function showStep(index) {
-        // Call leave hook for the step we're navigating away from
         var leaveFn = leaveHooks[steps[currentIndex].name];
-        if (leaveFn) leaveFn();
+        var leavePromise = Promise.resolve(leaveFn ? leaveFn() : null);
 
-        // Clear any active polling timer when leaving a step
-        if (pollTimer) {
-            clearInterval(pollTimer);
-            pollTimer = null;
+        // Disable navigation while an async leave hook (e.g. mode revert) completes.
+        var navBtns = document.querySelectorAll('.step-foot-btns button, #wizBackBtn');
+        navBtns.forEach(function(b) { b.disabled = true; });
+
+        function doTransition() {
+            navBtns.forEach(function(b) { b.disabled = false; });
+
+            if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+
+            var card = document.querySelector('.setup-card');
+            var towersIndex = -1;
+            for (var i = 0; i < steps.length; i++) {
+                if (steps[i].name === 'towers') { towersIndex = i; break; }
+            }
+            card.classList.toggle('wide', index === towersIndex);
+
+            steps.forEach(function(s, i) {
+                s.el.style.display = (i === index) ? '' : 'none';
+            });
+            currentIndex = index;
+            updateProgress(index);
+
+            var backBtn = document.getElementById('wizBackBtn');
+            if (backBtn) {
+                backBtn.style.display = '';
+                backBtn.textContent = (index === 0) ? 'Exit' : '← Back';
+            }
+
+            document.querySelectorAll('.step-foot-btns').forEach(function(el) {
+                el.style.display = 'none';
+            });
+            var activeBtns = document.getElementById('stepBtns-' + steps[index].name);
+            if (activeBtns) activeBtns.style.display = '';
+
+            postJSON('/set-up/save-step', { step: steps[index].name });
+
+            var enterFn = enterHooks[steps[index].name];
+            if (enterFn) enterFn();
         }
 
-        var card = document.querySelector('.setup-card');
-        // Wide card only for towers step
-        var towersIndex = -1;
-        for (var i = 0; i < steps.length; i++) {
-            if (steps[i].name === 'towers') { towersIndex = i; break; }
-        }
-        if (index === towersIndex) {
-            card.classList.add('wide');
-        } else {
-            card.classList.remove('wide');
-        }
-
-        steps.forEach(function(s, i) {
-            s.el.style.display = (i === index) ? '' : 'none';
-        });
-        currentIndex = index;
-        updateProgress(index);
-
-        // Back/Exit button — always visible; label changes based on step
-        var backBtn = document.getElementById('wizBackBtn');
-        if (backBtn) {
-            backBtn.style.display = '';
-            backBtn.textContent = (index === 0) ? 'Exit' : '← Back';
-        }
-
-        // Switch active footer button group
-        document.querySelectorAll('.step-foot-btns').forEach(function(el) {
-            el.style.display = 'none';
-        });
-        var activeBtns = document.getElementById('stepBtns-' + steps[index].name);
-        if (activeBtns) activeBtns.style.display = '';
-
-        postJSON('/set-up/save-step', {step: steps[index].name});
-
-        var enterFn = enterHooks[steps[index].name];
-        if (enterFn) enterFn();
+        // Always transition regardless of leave hook success or failure.
+        leavePromise.then(doTransition, doTransition);
     }
 
     function advance() {
@@ -199,6 +198,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     var wizardWasMode = null;
     var connectRfSse = null; // defined inside enterHooks.location on first entry
     var locationActive = false; // guards against dangling fetch resolving after leave
+    var unloadHandler = null; // beforeunload safety net — registered on location enter, cleared on leave
 
     // Step 1: Agreements
     enterHooks.agreements = function() {
@@ -577,10 +577,17 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         locationActive = false;
         clearTimeout(rfSseReconnectTimer); rfSseReconnectTimer = null;
         if (rfSse) { rfSse.close(); rfSse = null; }
-        if (wizardWasMode && wizardWasMode !== 'spectrum') {
-            postJSON('/api/mode', { mode: wizardWasMode });
-        }
+        if (unloadHandler) { window.removeEventListener('beforeunload', unloadHandler); unloadHandler = null; }
+        var targetMode = wizardWasMode || 'radar';
         wizardWasMode = null;
+        if (targetMode === 'spectrum') return; // already in spectrum — nothing to revert
+        var scanStatus = document.getElementById('scanStatus');
+        if (scanStatus) { scanStatus.textContent = 'Reverting to radar mode…'; scanStatus.style.display = ''; }
+        return postJSON('/api/mode', { mode: targetMode })
+            .then(
+                function() { if (scanStatus) scanStatus.style.display = 'none'; },
+                function() { if (scanStatus) scanStatus.style.display = 'none'; }
+            );
     };
 
     enterHooks.location = function() {
@@ -598,18 +605,25 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             .then(function(d) {
                 if (!locationActive) return;
                 wizardWasMode = d.mode || 'radar';
-                if (d.mode === 'spectrum') {
-                    if (connectRfSse) connectRfSse();
-                    return;
-                }
-                return postJSON('/api/mode', { mode: 'spectrum' })
-                    .then(function(r) { return r.json(); })
-                    .then(function() { if (connectRfSse) connectRfSse(); });
+                return postJSON('/api/mode', { mode: 'spectrum' });
+            })
+            .then(function() {
+                if (locationActive && connectRfSse) connectRfSse();
             })
             .catch(function() {
                 if (!locationActive) return;
                 scanStatus.textContent = 'Analyser unavailable — RF scan disabled';
             });
+
+        // Register beforeunload safety net: if the user navigates away mid-step,
+        // stop retina-spectrum via beacon so the SDR is released.
+        if (unloadHandler) window.removeEventListener('beforeunload', unloadHandler);
+        unloadHandler = function() {
+            var fd = new FormData();
+            fd.append('csrf_token', csrfToken);
+            if (navigator.sendBeacon) navigator.sendBeacon('/api/mode/release-spectrum', fd);
+        };
+        window.addEventListener('beforeunload', unloadHandler);
 
         // Event listeners and inner state set up only once
         if (hookInitialized.location) return;

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,7 +56,8 @@
     <section class="spectrum-section">
         <div class="section-head"><h2>Spectrum</h2></div>
         <div class="spectrum-frame-wrap">
-            <iframe id="spectrumFrame" class="spectrum-frame" src="" frameborder="0"></iframe>
+            <div id="spectrumLoading" style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:var(--ink-3);font-size:14px;">Starting spectrum analyser…</div>
+            <iframe id="spectrumFrame" class="spectrum-frame" src="" frameborder="0" style="display:none"></iframe>
         </div>
     </section>
     {% else %}
@@ -138,7 +139,40 @@
 {% block scripts %}
 {% if mode == 'spectrum' %}
 <script>
-document.getElementById('spectrumFrame').src = 'http://' + window.location.hostname + ':3020';
+(function() {
+    var frame   = document.getElementById('spectrumFrame');
+    var loading = document.getElementById('spectrumLoading');
+    var host    = 'http://' + window.location.hostname + ':3020';
+    var maxAttempts = 30; // 30 × 2 s = 60 s before giving up
+    var attempt = 0;
+
+    function showFrame() {
+        frame.src = host;
+        frame.style.display = '';
+        if (loading) loading.style.display = 'none';
+    }
+
+    function poll() {
+        fetch('/api/spectrum/ready')
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                if (d.ready) {
+                    showFrame();
+                } else if (attempt < maxAttempts) {
+                    attempt++;
+                    setTimeout(poll, 2000);
+                } else {
+                    showFrame(); // timed out — show iframe so user sees the error
+                }
+            })
+            .catch(function() {
+                if (attempt < maxAttempts) { attempt++; setTimeout(poll, 2000); }
+                else { showFrame(); }
+            });
+    }
+
+    poll();
+})();
 </script>
 {% endif %}
 {% if retina_node_version %}


### PR DESCRIPTION
## Summary
- **SDR exclusivity enforcement**: `retina-spectrum` and `blah2` share the same SDR hardware and
  cannot run simultaneously. Multiple code paths could leave both running at once — most critically
  a Flask restart while in spectrum mode, and a wizard re-install that left blah2 running with a
  stale `mode.txt`. This PR closes all identified gaps
- **Wizard location step safety**: the mode revert when leaving the location step was fire-and-forget;
  navigation now waits for it to complete. The enter hook unconditionally POSTs spectrum mode on every
  entry so container state is always correct regardless of `mode.txt`. A `beforeunload` beacon stops
  retina-spectrum if the user navigates away mid-step
- **Spectrum iframe reliability**: the home page previously set the iframe `src` once on load — if
  retina-spectrum wasn't ready at that instant the iframe showed a browser error and never retried.
  It now polls `/api/spectrum/ready` and loads the iframe only once the container is confirmed serving
- **Config lockout**: all config routes redirect to `/set-up` while the wizard is in progress