### PR TITLE
20260612 - Fresh install path aligned with re-run path. 

### DIFF
--- a/static/setup.js
+++ b/static/setup.js
@@ -490,6 +490,8 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         }
         regionCheck.addEventListener('change', updateInstallGate);
 
+        var latestVersion = null;
+
         fetch('/mender/check')
             .then(function(r) { return r.json(); })
             .then(function(data) {
@@ -511,6 +513,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     document.getElementById('radarLatestVersion').textContent = data.current_version;
                     nextBtn.style.display = '';
                 } else {
+                    latestVersion = data.latest_version;
                     document.getElementById('radarLatestVersion').textContent = data.latest_version;
                     installBtn.style.display = '';
                     updateInstallGate();
@@ -525,7 +528,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             status.textContent = 'Installing...';
             installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
 
-            postJSON('/mender/install')
+            postJSON('/mender/install', latestVersion ? {version: latestVersion} : undefined)
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
                     if (data.success) {


### PR DESCRIPTION
Before the fresh install path did net pass a tag version for retina-node which would cause a 400 response which the backend could not properly handle. 
The install process on that takes place on a node with an exsisting retina-node package (update path) is verified and passes a version tag.
The fresh install process has been aligned with the update path which only required passing:
data.latest_version is all_versions[0] if all_versions else None
This reflects the versions in github.
This fix will be tested by running a fresh install on a clean node and is linked to https://app.clickup.com/t/90152460893/86ca8aqyg