### PR TITLE
20260614 wizard owl os install

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -52,6 +52,16 @@ device_state = DeviceState(
 
 device_state.apply_startup_preferences()
 
+# After an OWL-OS rootfs update the device reboots into the new partition
+# with Mender in "awaiting commit" state. Commit here to make it permanent,
+# then clear the install lock that was intentionally left by install_os.
+# This is idempotent — mender-update commit is a no-op when nothing is pending.
+try:
+    subprocess.run(["mender-update", "commit"], capture_output=True, timeout=30)
+except Exception:
+    pass
+device_state.release_install_lock()
+
 # Always boot into radar mode — delete any persisted spectrum state
 try:
     os.remove(os.path.join(DATA_DIR, 'mode.txt'))

--- a/src/mender.py
+++ b/src/mender.py
@@ -150,11 +150,19 @@ class MenderClient:
         except requests.RequestException as e:
             return None, str(e)
 
-    def install_from_url(self, url: str, timeout: int = 600) -> tuple[bool, str | None]:
+    def install_from_url(
+        self, url: str, timeout: int = 600, commit: bool = True
+    ) -> tuple[bool, str | None]:
         """Install artifact from URL via mender-update (standalone).
 
-        Used for app updates only (no reboot needed). OS updates use managed
-        mode via the mender-updated daemon — see /mender/install-os.
+        Args:
+            url:     Signed artifact download URL.
+            timeout: Download+install timeout in seconds. OS images need much
+                     longer than the default — pass 1800 for a ~600 MB rootfs.
+            commit:  Whether to commit immediately after install. True for
+                     app artifacts (no reboot needed). False for OS rootfs
+                     artifacts, where the device must reboot into the new
+                     partition first; commit is then called at next startup.
 
         Returns (success, error) tuple.
         """
@@ -167,14 +175,15 @@ class MenderClient:
             )
             if result.returncode != 0:
                 return False, result.stderr or "Install failed"
-            try:
-                subprocess.run(
-                    ["mender-update", "commit"],
-                    capture_output=True,
-                    timeout=30,
-                )
-            except Exception:
-                pass
+            if commit:
+                try:
+                    subprocess.run(
+                        ["mender-update", "commit"],
+                        capture_output=True,
+                        timeout=30,
+                    )
+                except Exception:
+                    pass
             return True, None
         except subprocess.TimeoutExpired:
             return False, "Installation timed out"

--- a/src/mender.py
+++ b/src/mender.py
@@ -304,11 +304,12 @@ def get_latest_stable_from_github(
 def parse_os_version(tag: str) -> tuple[int, ...] | None:
     """Extract semver tuple from owl-os version strings.
 
-    Handles formats: 'os-v0.1.0', 'v0.1.0', '0.1.0'.
-    Returns version tuple (0, 1, 0) for stable releases.
-    Returns None for RCs, dev, or non-matching strings.
+    Handles formats: 'os-v0.1.0', 'v0.1.0', '0.1.0',
+    and pre-release variants like 'os-v0.1.0-dev', 'v0.1.0-rc1'.
+    Returns the numeric version tuple (0, 1, 0) — suffix is ignored for comparison.
+    Returns None for non-matching strings.
     """
-    match = re.match(r"^(?:os-)?v?(\d+)\.(\d+)\.(\d+)$", tag)
+    match = re.match(r"^(?:os-)?v?(\d+)\.(\d+)\.(\d+)(?:[-.].+)?$", tag)
     if match:
         return tuple(int(x) for x in match.groups())
     return None
@@ -317,12 +318,13 @@ def parse_os_version(tag: str) -> tuple[int, ...] | None:
 def get_latest_owl_os_from_github(
     repo: str = "offworldlabs/owl-os",
 ) -> tuple[str | None, str | None]:
-    """Get latest stable owl-os version tag from GitHub releases.
+    """Get latest owl-os version tag from GitHub releases.
 
-    Queries GitHub releases API, filters to stable versions
-    (tags matching os-v*.*.*), and returns the highest semver version.
+    Queries GitHub releases API, includes both stable and pre-release builds
+    (tags matching os-v*.*.*[-suffix]), and returns the highest semver version.
 
-    Returns (version_tag, error) tuple. version_tag is like 'os-v0.2.0'.
+    Returns (version_tag, error) tuple. version_tag is like 'os-v0.2.0' or
+    'os-v0.2.1-dev'.
     """
     try:
         resp = requests.get(
@@ -333,20 +335,19 @@ def get_latest_owl_os_from_github(
         if resp.status_code != 200:
             return None, f"GitHub API error: {resp.status_code}"
 
-        releases = resp.json()
-        stable = []
-        for release in releases:
+        found = []
+        for release in resp.json():
             tag = release.get("tag_name", "")
             if not tag.startswith("os-v"):
                 continue
             version = parse_os_version(tag)
             if version:
-                stable.append((tag, version))
+                found.append((tag, version))
 
-        if not stable:
-            return None, "No stable owl-os releases found"
+        if not found:
+            return None, "No owl-os releases found"
 
-        stable.sort(key=lambda x: x[1], reverse=True)
-        return stable[0][0], None
+        found.sort(key=lambda x: x[1], reverse=True)
+        return found[0][0], None
     except requests.RequestException as e:
         return None, str(e)

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -275,9 +275,7 @@ def install_os():
         return jsonify({"success": False, "error": error})
 
     def _run_os_install(download_url):
-        from routes.mode import _write_mode
         try:
-            _write_mode('spectrum')
             try:
                 subprocess.run(
                     ["mender-update", "rollback"],
@@ -296,7 +294,6 @@ def install_os():
             if not success:
                 app.logger.error(f"OS install failed: {error}")
                 device_state.release_install_lock()
-                _write_mode('radar')
                 return
 
             # Save wizard step so the wizard resumes at "system" post-reboot
@@ -311,12 +308,10 @@ def install_os():
             except Exception as e:
                 app.logger.error(f"Reboot failed: {e}")
                 device_state.release_install_lock()
-                _write_mode('radar')
 
         except Exception as e:
             app.logger.error(f"OS install thread crashed: {e}")
             device_state.release_install_lock()
-            _write_mode('radar')
 
     threading.Thread(target=_run_os_install, args=(url,), daemon=True).start()
     return jsonify({"success": True, "version": release_name})

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -190,7 +190,12 @@ def check_os():
     if in_progress:
         locked, lock_info = device_state.is_install_locked()
         mender_status = device_state._get_mender_update_status()
-        stage = mender_status.get("state") if mender_status else "waiting"
+        if mender_status:
+            stage = mender_status.get("state")
+        elif lock_info:
+            stage = lock_info.get("stage", "downloading")
+        else:
+            stage = "downloading"
         return jsonify({
             "installing": True,
             "stage": stage,
@@ -269,10 +274,18 @@ def install_os():
         return jsonify({"success": False, "error": f"No artifact found for {release_name}"})
 
     artifact = artifacts[0]
-    url, error = mender.get_download_url(artifact["id"])
+    artifact_id = artifact.get("id")
+    if not artifact_id:
+        device_state.release_install_lock()
+        return jsonify({"success": False, "error": "Artifact missing ID field"})
+
+    url, error = mender.get_download_url(artifact_id)
     if error:
         device_state.release_install_lock()
         return jsonify({"success": False, "error": error})
+    if not url:
+        device_state.release_install_lock()
+        return jsonify({"success": False, "error": "Mender returned no download URL"})
 
     def _run_os_install(download_url):
         try:

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -220,9 +220,30 @@ def check_os():
 
 @bp.route("/install-os", methods=["POST"])
 def install_os():
-    """Trigger managed OS update via Mender daemon."""
-    from app import mender, device_state
+    """Install an OWL-OS update using the same direct-download paradigm as retina-node.
+
+    Flow mirrors /mender/install exactly:
+      1. Ensure mender-authd is running so we can obtain a device JWT.
+      2. Look up the latest OWL-OS release on GitHub to determine the artifact name.
+      3. Fetch the artifact metadata from the Mender server using the JWT.
+      4. Get a short-lived signed download URL for the artifact.
+      5. Spawn a background thread that runs mender-update install <url>.
+         Unlike retina-node, we do NOT commit immediately — the rootfs update
+         requires a reboot into the new partition first. commit=False leaves
+         Mender in the "awaiting commit" state; the app startup code commits
+         on the next boot (see app.py apply_startup_preferences).
+      6. On success the thread saves the wizard step and calls systemctl reboot.
+         The install lock is intentionally left in place through the reboot and
+         cleared by startup code, ensuring check-os stays in "installing" state
+         until the device comes back up.
+      7. On failure the thread releases the lock and restores radar mode.
+    """
+    from app import mender, device_state, app
     from mender import get_latest_owl_os_from_github
+
+    success, error = device_state.ensure_cloud_services_enabled(mender.get_jwt)
+    if not success:
+        return jsonify({"success": False, "error": error})
 
     can_install, reason = device_state.can_start_install()
     if not can_install:
@@ -238,11 +259,64 @@ def install_os():
     if not device_state.acquire_install_lock(release_name):
         return jsonify({"success": False, "error": "Install already in progress"}), 409
 
-    success, error = device_state.ensure_cloud_services_enabled(mender.get_jwt)
-    if not success:
+    artifacts, error = mender.list_artifacts(release_name=release_name)
+    if error:
         device_state.release_install_lock()
         return jsonify({"success": False, "error": error})
 
-    device_state.save_setup_wizard_step("system")
+    if not artifacts:
+        device_state.release_install_lock()
+        return jsonify({"success": False, "error": f"No artifact found for {release_name}"})
 
-    return jsonify({"success": True, "version": release_name, "state": "waiting"})
+    artifact = artifacts[0]
+    url, error = mender.get_download_url(artifact["id"])
+    if error:
+        device_state.release_install_lock()
+        return jsonify({"success": False, "error": error})
+
+    def _run_os_install(download_url):
+        from routes.mode import _write_mode
+        try:
+            _write_mode('spectrum')
+            try:
+                subprocess.run(
+                    ["mender-update", "rollback"],
+                    capture_output=True, timeout=30,
+                )
+            except Exception:
+                pass
+
+            # OS image is ~600 MB — use a 30-minute timeout.
+            # commit=False: the new rootfs is written to the inactive A/B
+            # partition but NOT committed yet. Commit happens at next startup
+            # after the reboot confirms the new OS boots successfully.
+            success, error = mender.install_from_url(
+                download_url, timeout=1800, commit=False
+            )
+            if not success:
+                app.logger.error(f"OS install failed: {error}")
+                device_state.release_install_lock()
+                _write_mode('radar')
+                return
+
+            # Save wizard step so the wizard resumes at "system" post-reboot
+            # and can confirm the update completed.
+            device_state.save_setup_wizard_step("system")
+            device_state.update_install_stage("rebooting")
+
+            # Reboot into the new partition. The install lock survives the
+            # reboot on disk; startup code clears it after committing.
+            try:
+                subprocess.run(["systemctl", "reboot"], capture_output=True, timeout=10)
+            except Exception as e:
+                app.logger.error(f"Reboot failed: {e}")
+                device_state.release_install_lock()
+                _write_mode('radar')
+
+        except Exception as e:
+            app.logger.error(f"OS install thread crashed: {e}")
+            device_state.release_install_lock()
+            _write_mode('radar')
+
+    threading.Thread(target=_run_os_install, args=(url,), daemon=True).start()
+    return jsonify({"success": True, "version": release_name})

--- a/static/setup.js
+++ b/static/setup.js
@@ -314,7 +314,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     status.innerHTML = 'System is up to date &#10003;';
                     cardStatus.innerHTML = '<span class="text-success">&#10003;</span>';
                     nextBtn.style.display = '';
-                    nextBtn.textContent = 'Skip \u2192';
+                    nextBtn.textContent = 'Continue \u2192';
                 }
             })
             .catch(function() {
@@ -355,6 +355,8 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 status.textContent = 'Downloading OS update...';
             } else if (stage === 'installing') {
                 status.textContent = 'Installing OS update...';
+            } else if (stage === 'rebooting') {
+                status.textContent = 'Rebooting device...';
             } else {
                 status.textContent = 'Updating...';
             }
@@ -363,6 +365,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
         function startSystemPoll() {
             showStage('waiting');
+            if (backBtn) backBtn.style.display = 'none';
             if (pollTimer) clearInterval(pollTimer);
             pollTimer = setInterval(function() {
                 fetch('/mender/check-os')
@@ -371,6 +374,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                         if (!data.installing) {
                             clearInterval(pollTimer);
                             pollTimer = null;
+                            if (backBtn) backBtn.style.display = '';
                             if (!data.update_available) {
                                 status.innerHTML = 'Update complete &#10003;';
                                 installStatus.innerHTML = '<span class="text-success">Complete!</span>';

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -774,6 +774,42 @@ class TestMenderCheckOs:
         data = json.loads(response.data)
         assert 'error' in data
 
+    @patch('app.device_state')
+    @patch('app.mender')
+    def test_check_os_installing_stage_from_lock(self, mock_mender, mock_ds, app_client):
+        """Stage should be read from the install lock when no mender-update status exists."""
+        mock_mender.get_versions.return_value = ('v0.1.0', None)
+        mock_ds.is_any_update_in_progress.return_value = (True, 'Installing owl-os-pi5-v0.2.0')
+        mock_ds.is_install_locked.return_value = (True, {
+            'version': 'owl-os-pi5-v0.2.0',
+            'started_at': '2026-01-01T00:00:00',
+            'stage': 'rebooting',
+        })
+        mock_ds._get_mender_update_status.return_value = None
+
+        response = app_client.get('/mender/check-os')
+        data = json.loads(response.data)
+        assert data['installing'] is True
+        assert data['stage'] == 'rebooting'
+        assert data['version'] == 'owl-os-pi5-v0.2.0'
+
+    @patch('app.device_state')
+    @patch('app.mender')
+    def test_check_os_installing_stage_defaults_to_downloading(self, mock_mender, mock_ds, app_client):
+        """Stage should default to 'downloading' when lock has no stage field yet."""
+        mock_mender.get_versions.return_value = ('v0.1.0', None)
+        mock_ds.is_any_update_in_progress.return_value = (True, 'Installing owl-os-pi5-v0.2.0')
+        mock_ds.is_install_locked.return_value = (True, {
+            'version': 'owl-os-pi5-v0.2.0',
+            'started_at': '2026-01-01T00:00:00',
+        })
+        mock_ds._get_mender_update_status.return_value = None
+
+        response = app_client.get('/mender/check-os')
+        data = json.loads(response.data)
+        assert data['installing'] is True
+        assert data['stage'] == 'downloading'
+
 
 class TestMenderInstallOs:
     """Test the /mender/install-os endpoint."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -778,45 +778,98 @@ class TestMenderCheckOs:
 class TestMenderInstallOs:
     """Test the /mender/install-os endpoint."""
 
+    @patch('routes.mender_routes.threading.Thread')
+    @patch('app.mender')
     @patch('app.device_state')
     @patch('mender.get_latest_owl_os_from_github')
-    def test_install_os_success(self, mock_github, mock_ds, app_client):
-        """Should enable cloud services, acquire lock, and return waiting state."""
+    def test_install_os_success(self, mock_github, mock_ds, mock_mender, mock_thread, app_client):
+        """Should return success immediately and spawn a background install thread."""
+        mock_ds.ensure_cloud_services_enabled.return_value = (True, None)
         mock_ds.can_start_install.return_value = (True, None)
         mock_ds.acquire_install_lock.return_value = True
-        mock_ds.ensure_cloud_services_enabled.return_value = (True, None)
         mock_github.return_value = ('os-v0.2.0', None)
+        mock_mender.list_artifacts.return_value = ([{"id": "abc123"}], None)
+        mock_mender.get_download_url.return_value = ("https://example.com/artifact.mender", None)
 
         response = app_client.post('/mender/install-os')
         data = json.loads(response.data)
         assert data['success'] is True
         assert data['version'] == 'owl-os-pi5-v0.2.0'
-        assert data['state'] == 'waiting'
+        assert 'state' not in data
         mock_ds.acquire_install_lock.assert_called_once_with('owl-os-pi5-v0.2.0')
-        mock_ds.save_setup_wizard_step.assert_called_once_with('system')
+        mock_thread.assert_called_once()
 
     @patch('app.device_state')
     @patch('mender.get_latest_owl_os_from_github')
     def test_install_os_not_authenticated(self, mock_github, mock_ds, app_client):
-        """Should fail and release lock when cloud services can't be enabled."""
-        mock_ds.can_start_install.return_value = (True, None)
-        mock_ds.acquire_install_lock.return_value = True
-        mock_github.return_value = ('os-v0.2.0', None)
+        """Should fail before acquiring lock when cloud services can't be enabled."""
         mock_ds.ensure_cloud_services_enabled.return_value = (False, 'Timed out')
 
         response = app_client.post('/mender/install-os')
         data = json.loads(response.data)
         assert data['success'] is False
         assert 'Timed out' in data['error']
-        mock_ds.release_install_lock.assert_called_once()
+        mock_ds.acquire_install_lock.assert_not_called()
+        mock_ds.release_install_lock.assert_not_called()
 
     @patch('app.device_state')
     def test_install_os_already_updating(self, mock_ds, app_client):
         """Should fail when update already in progress."""
+        mock_ds.ensure_cloud_services_enabled.return_value = (True, None)
         mock_ds.can_start_install.return_value = (False, 'Installing v0.3.5')
 
         response = app_client.post('/mender/install-os')
         assert response.status_code == 409
+
+    @patch('app.mender')
+    @patch('app.device_state')
+    @patch('mender.get_latest_owl_os_from_github')
+    def test_install_os_github_error(self, mock_github, mock_ds, mock_mender, app_client):
+        """Should fail and not acquire lock when GitHub version lookup fails."""
+        mock_ds.ensure_cloud_services_enabled.return_value = (True, None)
+        mock_ds.can_start_install.return_value = (True, None)
+        mock_github.return_value = (None, 'GitHub API error: 503')
+
+        response = app_client.post('/mender/install-os')
+        data = json.loads(response.data)
+        assert data['success'] is False
+        assert 'GitHub API error' in data['error']
+        mock_ds.acquire_install_lock.assert_not_called()
+
+    @patch('app.mender')
+    @patch('app.device_state')
+    @patch('mender.get_latest_owl_os_from_github')
+    def test_install_os_no_artifact(self, mock_github, mock_ds, mock_mender, app_client):
+        """Should fail and release lock when no artifact is found in Mender."""
+        mock_ds.ensure_cloud_services_enabled.return_value = (True, None)
+        mock_ds.can_start_install.return_value = (True, None)
+        mock_ds.acquire_install_lock.return_value = True
+        mock_github.return_value = ('os-v0.2.0', None)
+        mock_mender.list_artifacts.return_value = ([], None)
+
+        response = app_client.post('/mender/install-os')
+        data = json.loads(response.data)
+        assert data['success'] is False
+        assert 'No artifact found' in data['error']
+        mock_ds.release_install_lock.assert_called_once()
+
+    @patch('app.mender')
+    @patch('app.device_state')
+    @patch('mender.get_latest_owl_os_from_github')
+    def test_install_os_download_url_error(self, mock_github, mock_ds, mock_mender, app_client):
+        """Should fail and release lock when download URL fetch fails."""
+        mock_ds.ensure_cloud_services_enabled.return_value = (True, None)
+        mock_ds.can_start_install.return_value = (True, None)
+        mock_ds.acquire_install_lock.return_value = True
+        mock_github.return_value = ('os-v0.2.0', None)
+        mock_mender.list_artifacts.return_value = ([{"id": "abc123"}], None)
+        mock_mender.get_download_url.return_value = (None, 'Failed to get download URL: 403')
+
+        response = app_client.post('/mender/install-os')
+        data = json.loads(response.data)
+        assert data['success'] is False
+        assert '403' in data['error']
+        mock_ds.release_install_lock.assert_called_once()
 
 
 class TestSetupWizardStepRoutes:


### PR DESCRIPTION
# OWL-OS install: direct-download paradigm (mirrors retina-node)

## Background

The "Update OWL-OS" button in the setup wizard was non-functional. The previous implementation attempted to use the Mender managed-update daemon (`mender-updated`) to trigger an update, but this approach was architecturally flawed — managed deployments are fleet-initiated and install automatically when the daemon runs, so they cannot be gated on user consent from the device side.

## What changed

The OWL-OS install process has been redesigned to use the same standalone download-URL paradigm that the retina-node install uses and that is known to work reliably.

### Core flow (`POST /mender/install-os`)

1. Ensure `mender-authd` is running and obtain a device JWT (up to 60s)
2. Query GitHub Releases for the latest `os-v*.*.*` tag
3. Derive the Mender artifact name: `os-v0.8.20` → `owl-os-pi5-v0.8.20`
4. Fetch the artifact list and a signed download URL from the Mender Device API using the device JWT — no management credentials required
5. Spawn a background thread that runs `mender-update install <url>` with a 30-minute timeout and `commit=False`
6. Return `{"success": true}` immediately; the frontend polls `/mender/check-os` every 5 seconds

The critical difference from the retina-node install is `commit=False`. A rootfs update writes to the inactive A/B partition and requires a reboot before committing. On the next startup, `app.py` calls `mender-update commit` unconditionally (it is a no-op when nothing is pending) and clears the install lock. If the new OS fails to boot, Mender's built-in A/B rollback restores the previous partition automatically.

### Files changed

**`src/mender.py`**
- `install_from_url` gains a `commit: bool = True` parameter. Passing `commit=False` skips the immediate commit, leaving Mender in "awaiting commit" state for post-reboot finalisation.
- `parse_os_version` regex broadened to accept pre-release suffixes (`-dev`, `-rc1` etc.) for testing without a stable release. **Must be reverted before shipping a stable release.**
- `get_latest_owl_os_from_github` updated to include pre-release builds accordingly.

**`src/routes/mender_routes.py`**
- `install_os` fully rewritten to mirror the `install` (retina-node) route exactly: auth → concurrency guard → GitHub version lookup → lock → artifact fetch → download URL → background thread → reboot.
- `check_os` stage reporting fixed: previously always returned `"waiting"` during a GUI-initiated install. Now falls back to the install lock's `stage` field (`"downloading"` → `"rebooting"`), matching the behaviour of the retina-node `check` route.
- All error paths release the install lock before returning. No lock leaks.

**`src/app.py`**
- Added post-reboot commit and lock-clear immediately after `apply_startup_preferences()`:
  ```python
  subprocess.run(["mender-update", "commit"], ...)  # idempotent
  device_state.release_install_lock()
  ```

**`static/setup.js`**
- `showStage` handles `"rebooting"` stage explicitly.
- `startSystemPoll` hides the back button during the poll (mirrors radar step behaviour) — previously the back button was active during a 30-minute download, and clicking it would stop the poll with no way to restart it short of a page refresh.
- "Skip →" changed to "Continue →" when no update is available, so the label is not misleading after a successful post-reboot resume.

**`tests/test_app.py`**
- `TestMenderInstallOs` fully rewritten to reflect the new route (6 tests covering: success, auth failure, concurrency, GitHub error, no artifact, download URL error).
- Two new `TestMenderCheckOs` tests verify stage is read from the install lock (`"rebooting"`) and defaults to `"downloading"` when no stage field is present.

### Error handling summary

| Failure | Behaviour |
|---------|-----------|
| Mender auth timeout | Returns error; no lock acquired |
| Another install in progress | Returns 409; no lock acquired |
| GitHub unreachable | Returns error; no lock acquired |
| Artifact not in Mender | Releases lock; returns "No artifact found" |
| Mender API error | Releases lock; returns error |
| Download URL missing | Releases lock; returns error |
| `mender-update install` fails | Releases lock; logs error |
| Install timeout (30 min) | Releases lock; returns timeout error |
| `systemctl reboot` fails | Releases lock; logs error |
| Thread crash | Outer `except` releases lock |
| New OS fails to boot (A/B rollback) | Startup commit is no-op; lock cleared; old version remains; update available again |

## Testing notes

Pre-release (`-dev`) tags are currently included in the version check to allow testing without a stable GitHub release. A dev build at a **higher semver** than the currently installed version (e.g. `os-v0.8.21-dev` when device is on `v0.8.20`) will trigger the update button. The `-dev` suffix is stripped for version comparison only.

**This must be reverted in `src/mender.py` before merging to main for a stable release.**