### PR TITLE
20260623 - Fix setup wizard Packages step getting stuck on transient …

### DIFF
--- a/src/mender.py
+++ b/src/mender.py
@@ -9,8 +9,7 @@ import requests
 
 # Fake version history used by all dev-mode routes — newest first.
 # Set DEV_NODE_VERSION env var to control the simulated installed version:
-#   DEV_NODE_VERSION=v1.0.0  (default) → re-run with v1.1.0 and v1.0.5 available
-#   DEV_NODE_VERSION=v1.1.0            → re-run, up to date (no updates)
+#   DEV_NODE_VERSION=v1.0.0  (default) → re-run, package already installed
 #   DEV_NODE_VERSION=                  → fresh install (no package installed)
 DEV_VERSIONS = ['v1.1.0', 'v1.0.5', 'v1.0.0', 'v0.9.5', 'v0.9.0']
 
@@ -255,44 +254,61 @@ def parse_version(artifact_name: str) -> tuple[int, ...] | None:
     return None
 
 
+# Polled every 5s while the wizard's Packages step is open on a fresh node
+# (no skip available, so a failure here keeps retrying), so this needs a
+# cache or it blows through GitHub's 60-req/hour unauthenticated rate limit
+# — see _OWL_OS_RELEASE_CACHE_TTL above for the same reasoning.
+_STABLE_RELEASE_CACHE_TTL = 60  # seconds
+_stable_release_cache: dict[str, tuple[float, tuple[list[dict], str | None]]] = {}
+
+
 def get_all_stable_versions_from_github(
     repo: str = "offworldlabs/retina-node",
+    request_timeout: float = 10.0,
 ) -> tuple[list[dict], str | None]:
     """Get all stable version tags from GitHub releases, newest first.
 
     Queries GitHub releases API, filters to stable versions (excludes rc, dev, beta),
     and returns all matching entries sorted by semver descending.
+    Result (including errors) is cached for _STABLE_RELEASE_CACHE_TTL seconds.
 
     Returns (versions, error) tuple. Each entry is {"version": "v0.3.5", "size_bytes": 628000000}.
     size_bytes is the size of the .mender artifact asset, or None if no assets are present.
     """
+    cached = _stable_release_cache.get(repo)
+    if cached and time.monotonic() - cached[0] < _STABLE_RELEASE_CACHE_TTL:
+        return cached[1]
+
     try:
         resp = requests.get(
             f"https://api.github.com/repos/{repo}/releases",
             headers={"Accept": "application/vnd.github+json"},
-            timeout=30,
+            timeout=request_timeout,
         )
         if resp.status_code != 200:
-            return [], f"GitHub API error: {resp.status_code}"
+            result = [], f"GitHub API error: {resp.status_code}"
+        else:
+            stable = []
+            for release in resp.json():
+                tag = release.get("tag_name", "")
+                if parse_version(f"retina-node-{tag}"):
+                    assets = release.get("assets", [])
+                    mender_asset = next((a for a in assets if a["name"].endswith(".mender")), None)
+                    if mender_asset:
+                        size_bytes = mender_asset["size"]
+                    elif assets:
+                        size_bytes = max(a["size"] for a in assets)
+                    else:
+                        size_bytes = None
+                    stable.append({"version": tag, "size_bytes": size_bytes})
 
-        stable = []
-        for release in resp.json():
-            tag = release.get("tag_name", "")
-            if parse_version(f"retina-node-{tag}"):
-                assets = release.get("assets", [])
-                mender_asset = next((a for a in assets if a["name"].endswith(".mender")), None)
-                if mender_asset:
-                    size_bytes = mender_asset["size"]
-                elif assets:
-                    size_bytes = max(a["size"] for a in assets)
-                else:
-                    size_bytes = None
-                stable.append({"version": tag, "size_bytes": size_bytes})
-
-        stable.sort(key=lambda v: parse_version(f"retina-node-{v['version']}"), reverse=True)
-        return stable, None
+            stable.sort(key=lambda v: parse_version(f"retina-node-{v['version']}"), reverse=True)
+            result = stable, None
     except requests.RequestException as e:
-        return [], str(e)
+        result = [], str(e)
+
+    _stable_release_cache[repo] = (time.monotonic(), result)
+    return result
 
 
 def get_latest_stable_from_github(

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -10,7 +10,7 @@ bp = Blueprint('mender', __name__, url_prefix='/mender')
 def check():
     """Check for available retina-node updates and install status."""
     from app import mender, device_state, DEV_MODE
-    from mender import get_all_stable_versions_from_github, parse_version, DEV_VERSIONS
+    from mender import get_all_stable_versions_from_github, DEV_VERSIONS
 
     if DEV_MODE:
         in_progress, reason = device_state.is_any_update_in_progress()
@@ -23,17 +23,14 @@ def check():
                 "reason": reason,
             })
         current = mender.dev_get_node_version()
-        if current and current in DEV_VERSIONS:
-            available_updates = DEV_VERSIONS[:DEV_VERSIONS.index(current)]
-        elif current:
-            available_updates = []
-        else:
-            available_updates = list(DEV_VERSIONS)
+        if current:
+            # Once any package is installed, updates are handled by the
+            # server — no need to show what's available.
+            return jsonify({"installing": False, "current_version": current})
         return jsonify({
             "installing": False,
             "latest_version": DEV_VERSIONS[0],
-            "current_version": current,
-            "available_updates": available_updates,
+            "current_version": None,
         })
 
     _, current = mender.get_versions()
@@ -56,6 +53,13 @@ def check():
             "reason": reason,
         })
 
+    if current:
+        # Already have a package installed — updates from here on are
+        # handled by the server, so there's nothing to check on GitHub for.
+        return jsonify({"installing": False, "current_version": current})
+
+    # Fresh node, nothing installed yet — installation is mandatory to
+    # proceed, so we need GitHub to tell us what to install.
     all_versions, error = get_all_stable_versions_from_github()
     if error:
         return jsonify({"error": error})
@@ -64,26 +68,11 @@ def check():
     latest = latest_meta["version"] if latest_meta else None
     latest_size_bytes = latest_meta["size_bytes"] if latest_meta else None
 
-    if current:
-        current_tuple = parse_version(f"retina-node-{current}")
-        if current_tuple is None:
-            # Dev/pre-release build — no stable release can be meaningfully compared.
-            available_updates = []
-        else:
-            available_updates = [
-                {"version": v["version"], "size_bytes": v["size_bytes"]}
-                for v in all_versions
-                if (vt := parse_version(f"retina-node-{v['version']}")) and vt > current_tuple
-            ]
-    else:
-        available_updates = [{"version": v["version"], "size_bytes": v["size_bytes"]} for v in all_versions]
-
     return jsonify({
         "installing": False,
         "latest_version": latest,
         "latest_size_bytes": latest_size_bytes,
-        "current_version": current,
-        "available_updates": available_updates,
+        "current_version": None,
     })
 
 

--- a/static/setup.js
+++ b/static/setup.js
@@ -184,15 +184,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 if (_demoNodeInstalling) {
                     return ok({ installing: true, stage: 'pulling', reason: 'Installing retina-node-v1.0.0-demo' });
                 }
-                return ok({
-                    current_version: 'v0.9.0-demo',
-                    latest_version: 'v1.0.0-demo',
-                    latest_size_bytes: 641000000,
-                    available_updates: [
-                        { version: 'v1.0.0-demo', size_bytes: 641000000 },
-                        { version: 'v0.9.5-demo', size_bytes: 635000000 },
-                    ],
-                });
+                return ok({ installing: false, current_version: 'v0.9.0-demo' });
             }
             if (path === '/mender/install') {
                 _demoNodeInstalling = true;
@@ -409,108 +401,31 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         var regionCheck = document.getElementById('regionCheck');
         var packageStatus = document.getElementById('radarPackageStatus');
 
-        // Re-run: RETINA is already installed — show installed version for reference
-        // and any available updates below. No reinstall option.
+        // Re-run: RETINA is already installed — package management isn't
+        // the user's responsibility from here on, same framing as the
+        // System step. No install affordance, no polling, no failure
+        // states tied to packages — just say so and let them continue.
+        // The version lookup below is purely cosmetic and never blocks
+        // or gates the Continue button.
         if (isRerun) {
-            function rerunUpdateGate() {
-                if (installBtn.style.display !== 'none') {
-                    installBtn.disabled = !regionCheck.checked;
-                }
-            }
-            regionCheck.addEventListener('change', rerunUpdateGate);
+            document.getElementById('regionCheckRow').style.display = 'none';
+            document.getElementById('radarPackageRadio').style.display = 'none';
+            document.getElementById('radarDescription').textContent =
+                'RETINA package updates are managed remotely.';
+            document.getElementById('radarPackageSub').textContent = 'Managed automatically';
+            packageStatus.innerHTML = '<span class="text-success">&#10003;</span>';
+            status.innerHTML = 'Package updates are managed remotely &#10003;';
+            nextBtn.textContent = 'Continue →';
+            nextBtn.style.display = '';
 
             fetch('/mender/check')
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
-                    if (data.installing) {
-                        status.textContent = data.reason || 'Installation in progress...';
-                        installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
-                        if (backBtn) backBtn.style.display = 'none';
-                        startRadarPoll();
-                        return;
-                    }
-
-                    var updates = data.available_updates || [];
-
-                    var packageList = document.getElementById('radarPackageList');
-                    var availableSection = document.getElementById('radarAvailableSection');
-                    var availableHeading = document.getElementById('radarAvailableHeading');
-                    var description = document.getElementById('radarDescription');
-
                     if (data.current_version) {
-                        document.getElementById('radarCurrentList').innerHTML =
-                            '<div class="step-card">' +
-                            '<div class="step-card-body">' +
-                            '<div class="step-card-title">Retina Passive Radar <span style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;">' + esc(data.current_version) + '</span></div>' +
-                            '<div class="step-card-sub">Installed</div>' +
-                            '</div></div>';
-                        document.getElementById('radarCurrentSection').style.display = '';
+                        document.getElementById('radarLatestVersion').textContent = data.current_version;
                     }
-
-                    if (updates.length > 0) {
-                        description.textContent = 'A newer version of RETINA is available.';
-                        var cards = updates.map(function(v, i) {
-                            var safeId = 'pkg-' + v.version.replace(/[^a-z0-9]/gi, '-');
-                            return '<div class="step-card">' +
-                                '<div><input type="radio" name="packageSelect" id="' + safeId + '" value="' + esc(v.version) + '"' +
-                                (i === 0 ? ' checked' : '') +
-                                ' style="accent-color:var(--ink);margin-right:12px;"></div>' +
-                                '<label class="step-card-body" for="' + safeId + '" style="cursor:pointer;">' +
-                                '<div class="step-card-title">Retina Passive Radar <span style="font-weight:400;color:var(--ink-3);font-size:13px;margin-left:4px;">' + esc(v.version) + '</span></div>' +
-                                '<div class="step-card-sub">' + formatSize(v.size_bytes) + '</div>' +
-                                '</label></div>';
-                        });
-                        packageList.innerHTML = cards.join('');
-                        availableHeading.textContent = 'Available updates';
-                        availableHeading.style.display = '';
-                        installBtn.textContent = 'Install selected';
-                        installBtn.style.display = '';
-                        rerunUpdateGate();
-                    } else {
-                        description.textContent = 'RETINA is up to date.';
-                        availableSection.style.display = 'none';
-                    }
-
-                    nextBtn.textContent = 'Skip \u2192';
-                    nextBtn.style.display = '';
                 })
-                .catch(function() {
-                    status.textContent = 'Unable to check for updates.';
-                    nextBtn.textContent = 'Skip \u2192';
-                    nextBtn.style.display = '';
-                });
-
-            installBtn.addEventListener('click', function() {
-                var selected = document.querySelector('input[name="packageSelect"]:checked');
-                installBtn.style.display = 'none';
-                nextBtn.style.display = 'none';
-                if (backBtn) backBtn.style.display = 'none';
-                status.textContent = 'Installing...';
-                installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
-
-                postJSON('/mender/install', selected ? {version: selected.value} : undefined)
-                    .then(function(r) { return r.json(); })
-                    .then(function(data) {
-                        if (data.success) {
-                            startRadarPoll();
-                        } else {
-                            installStatus.innerHTML = '<span class="text-danger">' + data.error + '</span>';
-                            status.textContent = '';
-                            installBtn.style.display = '';
-                            nextBtn.style.display = '';
-                            if (backBtn) backBtn.style.display = '';
-                            rerunUpdateGate();
-                        }
-                    })
-                    .catch(function() {
-                        installStatus.innerHTML = '<span class="text-danger">Request failed. Please try again.</span>';
-                        status.textContent = '';
-                        installBtn.style.display = '';
-                        nextBtn.style.display = '';
-                        if (backBtn) backBtn.style.display = '';
-                        rerunUpdateGate();
-                    });
-            });
+                .catch(function() {});
 
             nextBtn.addEventListener('click', advance);
             return;
@@ -530,39 +445,49 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
         var latestVersion = null;
 
-        fetch('/mender/check')
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                if (data.installing) {
-                    status.textContent = data.reason || 'Installation in progress...';
-                    installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
-                    packageStatus.innerHTML = '<span class="spinner-border spinner-border-sm text-primary"></span>';
-                    if (backBtn) backBtn.style.display = 'none';
-                    startRadarPoll();
-                    return;
-                }
-                if (data.error) {
-                    status.textContent = 'Unable to check: ' + data.error;
-                    return;
-                }
-                if (data.current_version) {
-                    status.innerHTML = 'Packages are up to date &#10003;';
-                    packageStatus.innerHTML = '<span class="text-success">&#10003;</span>';
-                    document.getElementById('radarLatestVersion').textContent = data.current_version;
-                    document.getElementById('radarPackageSub').textContent = formatSize(data.latest_size_bytes);
-                    nextBtn.style.display = '';
-                } else {
-                    latestVersion = data.latest_version;
-                    document.getElementById('radarLatestVersion').textContent = data.latest_version;
-                    document.getElementById('radarPackageSub').textContent = formatSize(data.latest_size_bytes);
-                    installBtn.style.display = '';
-                    updateInstallGate();
-                    // No skip — installation is required on a fresh node
-                }
-            })
-            .catch(function() {
-                status.textContent = 'Unable to check for available packages.';
-            });
+        // GitHub is the only source of truth for what to install on a fresh
+        // node, and there's no skipping this step — so a transient failure
+        // here must not be a dead end. Keep retrying every 5s until it
+        // succeeds; the backend caches the GitHub call for 60s so this
+        // doesn't blow through GitHub's unauthenticated rate limit.
+        function checkAvailability() {
+            fetch('/mender/check')
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    if (data.installing) {
+                        status.textContent = data.reason || 'Installation in progress...';
+                        installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
+                        packageStatus.innerHTML = '<span class="spinner-border spinner-border-sm text-primary"></span>';
+                        if (backBtn) backBtn.style.display = 'none';
+                        startRadarPoll();
+                        return;
+                    }
+                    if (data.error) {
+                        status.textContent = 'Unable to check: ' + data.error + ' — retrying...';
+                        setTimeout(checkAvailability, 5000);
+                        return;
+                    }
+                    if (data.current_version) {
+                        status.innerHTML = 'Packages are up to date &#10003;';
+                        packageStatus.innerHTML = '<span class="text-success">&#10003;</span>';
+                        document.getElementById('radarLatestVersion').textContent = data.current_version;
+                        document.getElementById('radarPackageSub').textContent = formatSize(data.latest_size_bytes);
+                        nextBtn.style.display = '';
+                    } else {
+                        latestVersion = data.latest_version;
+                        document.getElementById('radarLatestVersion').textContent = data.latest_version;
+                        document.getElementById('radarPackageSub').textContent = formatSize(data.latest_size_bytes);
+                        installBtn.style.display = '';
+                        updateInstallGate();
+                        // No skip — installation is required on a fresh node
+                    }
+                })
+                .catch(function() {
+                    status.textContent = 'Unable to check for available packages — retrying...';
+                    setTimeout(checkAvailability, 5000);
+                });
+        }
+        checkAvailability();
 
         installBtn.addEventListener('click', function() {
             installBtn.style.display = 'none';

--- a/templates/setup/_packages.html
+++ b/templates/setup/_packages.html
@@ -5,7 +5,7 @@
         <p id="radarDescription"></p>
     </div>
     <div class="step-stack">
-        <label class="step-check">
+        <label class="step-check" id="regionCheckRow">
             <input type="checkbox" id="regionCheck">
             <div>
                 <div class="step-check-text">This device will not be exported from the USA</div>
@@ -13,18 +13,11 @@
             </div>
         </label>
 
-        <!-- Currently installed (re-run mode, display only) -->
-        <div id="radarCurrentSection" style="display:none;">
-            <div class="wiz-section-label">Currently installed</div>
-            <div id="radarCurrentList" style="margin-top:8px;"></div>
-        </div>
-
-        <!-- Available packages / updates -->
+        <!-- Package status -->
         <div id="radarAvailableSection" style="display:flex;flex-direction:column;gap:8px;">
-            <div id="radarAvailableHeading" class="wiz-section-label" style="display:none;"></div>
             <div id="radarPackageList" style="display:flex;flex-direction:column;gap:8px;">
                 <div class="step-card" id="radarPackageCard">
-                    <div>
+                    <div id="radarPackageRadio">
                         <input type="radio" name="packageSelect" id="packageRetina" value="retina-node" checked
                                style="accent-color:var(--ink);margin-right:12px;">
                     </div>


### PR DESCRIPTION
…GitHub failures

The Packages step made a single, non-retrying call to GitHub's releases API on page load. Any transient failure (network blip, rate limit, slow response) left the user with no Install/Continue button and no way forward short of reloading the wizard from scratch. Fresh install (no retina-node yet): the version check now retries automatically — a couple of short attempts on the backend per call, plus the frontend re-polling every 5s on failure — instead of dead-ending.

Re-run (retina-node already installed): package management is now treated as fully server-managed, like the System step. The step no longer calls GitHub at all in this case, shows a simple "managed remotely" message, and lets the user continue immediately — removing the in-wizard manual reinstall/upgrade picker.