### PR TITLE
20260623 - Added description to "Bandwidth Number" config option.

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -14,6 +14,7 @@ Layered Config System:
 import os
 import yaml
 from copy import deepcopy
+from typing import Literal
 from pydantic import BaseModel, Field, VERSION
 
 # Detect Pydantic version for Field() syntax
@@ -122,7 +123,11 @@ class CaptureFormConfig(BaseModel):
     device_lnaState: int = Field(ge=1, le=9, title="LNA State", description="1=max gain, 9=min gain")
     device_dabNotch: bool = Field(title="DAB Notch Filter")
     device_rfNotch: bool = Field(title="RF Notch Filter")
-    device_bandwidthNumber: int = Field(title="Bandwidth Number")
+    device_bandwidthNumber: Literal[0, 5, 50, 100] = Field(
+        title="Bandwidth Number",
+        description="AGC loop bandwidth (Hz). 0 disables AGC — gain is fixed by Gain Reduction/LNA State. "
+                     "5/50/100 enable AGC: lower is slower and more stable, higher reacts faster but chases noise more."
+    )
 
 
 # ============================================================================

--- a/src/form_utils.py
+++ b/src/form_utils.py
@@ -3,7 +3,7 @@ Utilities for converting Pydantic schemas to form field dicts for Jinja renderin
 
 Compatible with both Pydantic v1 (Debian Bookworm apt) and v2.
 """
-from typing import get_origin, get_args, Union
+from typing import get_origin, get_args, Union, Literal
 
 # Detect Pydantic version
 try:
@@ -52,20 +52,32 @@ def get_field_readonly(field_info):
     return False
 
 
-def get_field_input_type(field_info):
-    """Map Pydantic field type to HTML input type."""
-    annotation = get_field_type(field_info)
-
-    # Handle Optional[X] by extracting X
+def _unwrap_optional(annotation):
+    """Strip Optional[X] down to X."""
     origin = get_origin(annotation)
     if origin is Union:
         args = get_args(annotation)
-        # Filter out NoneType
         non_none = [a for a in args if a is not type(None)]
         if non_none:
-            annotation = non_none[0]
+            return non_none[0]
+    return annotation
 
-    if annotation == bool:
+
+def get_field_options(field_info):
+    """Get the allowed choices for a Literal[...] field, or None."""
+    annotation = _unwrap_optional(get_field_type(field_info))
+    if get_origin(annotation) is Literal:
+        return list(get_args(annotation))
+    return None
+
+
+def get_field_input_type(field_info):
+    """Map Pydantic field type to HTML input type."""
+    annotation = _unwrap_optional(get_field_type(field_info))
+
+    if get_origin(annotation) is Literal:
+        return "select"
+    elif annotation == bool:
         return "checkbox"
     elif annotation in (int, float):
         return "number"
@@ -97,13 +109,7 @@ def get_field_constraints(field_info):
             constraints['max'] = fi.le
 
     # Add step for float fields
-    annotation = get_field_type(field_info)
-    origin = get_origin(annotation)
-    if origin is Union:
-        args = get_args(annotation)
-        non_none = [a for a in args if a is not type(None)]
-        if non_none:
-            annotation = non_none[0]
+    annotation = _unwrap_optional(get_field_type(field_info))
     if annotation == float:
         constraints['step'] = 'any'  # Allow any decimal
 
@@ -139,15 +145,7 @@ def schema_to_form_fields(model_class, values: dict):
     """
     fields = []
     for name, field_info in get_model_fields(model_class).items():
-        annotation = get_field_type(field_info)
-
-        # Handle Optional[X]
-        origin = get_origin(annotation)
-        if origin is Union:
-            args = get_args(annotation)
-            non_none = [a for a in args if a is not type(None)]
-            if non_none:
-                annotation = non_none[0]
+        annotation = _unwrap_optional(get_field_type(field_info))
 
         # Check if this is a nested Pydantic model
         if is_nested_model(annotation):
@@ -161,6 +159,7 @@ def schema_to_form_fields(model_class, values: dict):
         else:
             constraints = get_field_constraints(field_info)
             readonly = get_field_readonly(field_info)
+            options = get_field_options(field_info)
             fields.append({
                 'name': name,
                 'title': get_field_title(field_info, name),
@@ -168,6 +167,7 @@ def schema_to_form_fields(model_class, values: dict):
                 'type': get_field_input_type(field_info),
                 'value': values.get(name),  # From user.yml, NOT schema default
                 'readonly': readonly,
+                'options': options,
                 **constraints,
             })
     return fields

--- a/templates/config.html
+++ b/templates/config.html
@@ -18,6 +18,23 @@
         {% for subfield in field.fields %}
             {{ render_field(subfield, section, prefix ~ field.name ~ '.') }}
         {% endfor %}
+    {% elif field.type == 'select' %}
+        <div class="cfg-row">
+            <div class="label-col">
+                <label for="{{ field_id }}">{{ field.title }}</label>
+                {% if field.description %}<span class="help">{{ field.description }}</span>{% endif %}
+            </div>
+            <div>
+                <select name="{{ field_name }}" id="{{ field_id }}"
+                        class="ds-input{% if field_err %} is-invalid{% endif %}"
+                        {% if field.readonly %}disabled{% endif %}>
+                    {% for opt in field.options %}
+                        <option value="{{ opt }}" {% if field.value == opt %}selected{% endif %}>{{ opt }}</option>
+                    {% endfor %}
+                </select>
+                {% if field_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ field_err }}</div>{% endif %}
+            </div>
+        </div>
     {% elif field.type == 'checkbox' %}
         <div class="toggle-row">
             <label class="ds-switch">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -196,7 +196,7 @@ class TestConfigSaveRoute:
             'capture.device_lnaState': '5',
             'capture.device_dabNotch': 'on',
             'capture.device_rfNotch': 'on',
-            'capture.device_bandwidthNumber': '1'
+            'capture.device_bandwidthNumber': '5'
         }, follow_redirects=False)
 
         # Should redirect on success


### PR DESCRIPTION
## Summary

`device_bandwidthNumber` (AGC loop bandwidth, Hz) was a free-form integer with no
explanation of what it controlled. Users could enter any value, including ones the
RSPduo capture firmware silently ignores (it only accepts 0/5/50/100). This PR turns
the field into a constrained dropdown with inline guidance, and rejects invalid
values server-side.

## Changes

- **`src/config_schema.py`** — `CaptureFormConfig.device_bandwidthNumber` changed
  from `int` to `Literal[0, 5, 50, 100]`, with a description explaining what each
  value does:
  - `0` disables AGC (gain fixed by Gain Reduction / LNA State)
  - `5` / `50` / `100` enable AGC at that loop bandwidth — lower is slower/more
    stable, higher reacts faster but tracks noise more
- **`src/form_utils.py`** — generalized form-field generation to support
  `Literal[...]` annotations:
  - `get_field_options()` extracts the allowed choices from a `Literal` type
  - `get_field_input_type()` now maps `Literal` fields to a new `"select"` input
    type
  - de-duplicated the repeated `Optional[X]`-unwrapping logic into a single
    `_unwrap_optional()` helper
- **`templates/config.html`** — added a `select` branch to the `render_field`
  macro, rendering a `<select>` populated from `field.options`, with the
  description shown underneath (consistent with other fields)
- **`tests/test_app.py`** — `test_save_valid_config` posted `bandwidthNumber: '1'`,
  which is no longer a valid choice; updated to `'5'`

## Why

The SDRplay API (and `blah2-arm`'s `RspDuo.cpp`) only recognizes 0, 5, 50, or 100 Hz
as AGC bandwidth values — anything else is either rejected or silently has no
effect. The GUI previously let users submit arbitrary integers with no indication
of what the field even did. Constraining the input and explaining the AGC behavior
prevents users from submitting values that look plausible but do nothing.