### PR TITLE
20260624 - Fix setup wizard treating pre-installed retina-node as a w…

### DIFF
--- a/src/device_state.py
+++ b/src/device_state.py
@@ -46,6 +46,7 @@ class DeviceState:
         self.mender_conf_backup_dir = mender_conf_backup_dir
         self.mender_conf_backup_path = mender_conf_backup_path
         self.setup_wizard_file = os.path.join(data_dir, "setup-wizard.json")
+        self.setup_wizard_completed_flag = os.path.join(data_dir, "setup-wizard-completed")
         self.dev_mode = dev_mode
 
     # ── State Queries ──────────────────────────────────────────
@@ -344,6 +345,21 @@ class DeviceState:
         """Clear wizard state (called on completion)."""
         if os.path.exists(self.setup_wizard_file):
             os.remove(self.setup_wizard_file)
+
+    def has_completed_setup_wizard(self) -> bool:
+        """Whether the wizard has ever been completed on this device.
+
+        Distinct from retina-node being installed: a node can ship with
+        retina-node pre-installed but never have had the wizard run on it,
+        in which case it's still a first run.
+        """
+        return os.path.exists(self.setup_wizard_completed_flag)
+
+    def mark_setup_wizard_completed(self):
+        """Record that the wizard has been completed at least once."""
+        os.makedirs(os.path.dirname(self.setup_wizard_completed_flag), exist_ok=True)
+        with open(self.setup_wizard_completed_flag, "w") as f:
+            f.write(datetime.now().isoformat())
 
     def is_setup_wizard_in_progress(self) -> bool:
         """Check if setup wizard is active (not completed)."""

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -23,14 +23,15 @@ def check():
                 "reason": reason,
             })
         current = mender.dev_get_node_version()
-        if current:
-            # Once any package is installed, updates are handled by the
-            # server — no need to show what's available.
+        if current and device_state.has_completed_setup_wizard():
+            # Once any package is installed and the wizard has completed at
+            # least once, updates are handled by the server — no need to
+            # show what's available.
             return jsonify({"installing": False, "current_version": current})
         return jsonify({
             "installing": False,
             "latest_version": DEV_VERSIONS[0],
-            "current_version": None,
+            "current_version": current,
         })
 
     _, current = mender.get_versions()
@@ -53,13 +54,15 @@ def check():
             "reason": reason,
         })
 
-    if current:
-        # Already have a package installed — updates from here on are
-        # handled by the server, so there's nothing to check on GitHub for.
+    if current and device_state.has_completed_setup_wizard():
+        # Already have a package installed and the wizard has completed at
+        # least once — updates from here on are handled by the server, so
+        # there's nothing to check on GitHub for.
         return jsonify({"installing": False, "current_version": current})
 
-    # Fresh node, nothing installed yet — installation is mandatory to
-    # proceed, so we need GitHub to tell us what to install.
+    # Either nothing is installed yet, or this is the first time the wizard
+    # is running on a node that shipped with retina-node pre-installed — in
+    # both cases the user should be able to see/install the latest version.
     all_versions, error = get_all_stable_versions_from_github()
     if error:
         return jsonify({"error": error})
@@ -72,7 +75,7 @@ def check():
         "installing": False,
         "latest_version": latest,
         "latest_size_bytes": latest_size_bytes,
-        "current_version": None,
+        "current_version": current,
     })
 
 
@@ -146,7 +149,23 @@ def install():
 
     def _run_install(download_url):
         from mender import get_retina_node_version_from_docker
-        from routes.mode import _write_mode
+        from routes.mode import _write_mode, enforce_radar_mode
+        from app import RETINA_NODE_PATH
+
+        def _recover():
+            # The new artifact failed to apply. If something was already
+            # running, bring the previous (still-on-disk) compose stack back
+            # up rather than leaving the device with no radar containers at
+            # all — the failed install never committed, so RETINA_NODE_PATH
+            # still points at the old manifests.
+            #
+            # Mode stays 'spectrum' (watchdog silenced) until the containers
+            # are actually back up — flipping to 'radar' first would let the
+            # cron watchdog's own docker compose calls race these ones.
+            if already_installed:
+                enforce_radar_mode(RETINA_NODE_PATH)
+            _write_mode('radar')
+
         try:
             # Silence the watchdog before touching containers so it cannot see
             # blah2 go down and trigger a spurious radar stack restart mid-install.
@@ -169,7 +188,7 @@ def install():
             success, error = mender.install_from_url(download_url)
             if not success:
                 app.logger.error(f"Background install failed: {error}")
-                _write_mode('radar')
+                _recover()
             else:
                 device_state.update_install_stage("starting")
                 deadline = time.time() + 120
@@ -179,10 +198,10 @@ def install():
                     time.sleep(3)
                 else:
                     app.logger.warning("Containers did not come up within 2 minutes after install")
-                    _write_mode('radar')
+                    _recover()
         except Exception as e:
             app.logger.error(f"Background install crashed: {e}")
-            _write_mode('radar')
+            _recover()
         finally:
             device_state.release_install_lock()
 

--- a/src/routes/setup.py
+++ b/src/routes/setup.py
@@ -12,7 +12,10 @@ def wizard():
     owl_os_version, retina_node_version = mender.get_versions()
     node_id = get_node_id()
     highest_step = device_state.get_setup_wizard_highest_step()
-    is_rerun = retina_node_version is not None
+    # A node can ship with retina-node pre-installed but never have had the
+    # wizard run on it — that's still a first run, so re-run status is based
+    # on wizard completion history, not on whether a package is present.
+    is_rerun = device_state.has_completed_setup_wizard()
 
     demo_mode = request.args.get('demo') == '1'
     if demo_mode:
@@ -39,6 +42,7 @@ def save_step():
         return jsonify({"success": False, "error": "Missing 'step' field"}), 400
     if data["step"] == "complete":
         device_state.clear_setup_wizard()
+        device_state.mark_setup_wizard_completed()
     else:
         device_state.save_setup_wizard_step(data["step"])
     return jsonify({"success": True})

--- a/static/setup.js
+++ b/static/setup.js
@@ -455,6 +455,14 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
                     if (data.installing) {
+                        // Resuming into an install already running in the background
+                        // (e.g. after a page reload) — latestVersion was never set by
+                        // this fresh page load, so recover it from the lock's release
+                        // name ("retina-node-vX") to keep the success check below
+                        // accurate instead of comparing against null.
+                        if (!latestVersion && data.version) {
+                            latestVersion = data.version.replace(/^retina-node-/, '');
+                        }
                         status.textContent = data.reason || 'Installation in progress...';
                         installStatus.innerHTML = '<span class="text-warning">Do not power off the device.</span>';
                         packageStatus.innerHTML = '<span class="spinner-border spinner-border-sm text-primary"></span>';
@@ -467,7 +475,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                         setTimeout(checkAvailability, 5000);
                         return;
                     }
-                    if (data.current_version) {
+                    if (data.current_version && data.current_version === data.latest_version) {
                         status.innerHTML = 'Packages are up to date &#10003;';
                         packageStatus.innerHTML = '<span class="text-success">&#10003;</span>';
                         document.getElementById('radarLatestVersion').textContent = data.current_version;
@@ -479,7 +487,14 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                         document.getElementById('radarPackageSub').textContent = formatSize(data.latest_size_bytes);
                         installBtn.style.display = '';
                         updateInstallGate();
-                        // No skip — installation is required on a fresh node
+                        if (data.current_version) {
+                            // Node shipped with retina-node pre-installed, but
+                            // a newer version exists. Installing the latest
+                            // is mandatory on first run regardless — no skip.
+                            document.getElementById('radarDescription').textContent =
+                                'A newer version of RETINA is available (currently ' + data.current_version + '). Select a version below to install it before continuing.';
+                        }
+                        // No skip — installation of the latest version is required on first run
                     }
                 })
                 .catch(function() {
@@ -531,17 +546,31 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                         if (!data.installing) {
                             clearInterval(pollTimer);
                             pollTimer = null;
-                            if (data.current_version) {
+                            if (data.current_version === latestVersion) {
                                 packageStatus.innerHTML = '<span class="text-success">&#10003;</span>';
                                 status.textContent = '';
                                 installStatus.innerHTML = '';
                                 advance();
+                            } else if (data.current_version) {
+                                // Install failed, but the previously working version
+                                // came back up — give the user an explicit way to
+                                // continue rather than getting stuck if updates keep
+                                // failing, instead of silently treating this as success.
+                                installStatus.innerHTML = '<span class="text-danger">Update failed. Your previous version (' +
+                                    data.current_version + ') has been restored and is running.</span>';
+                                packageStatus.innerHTML = '';
+                                status.textContent = '';
+                                installBtn.style.display = '';
+                                installBtn.textContent = 'Try again';
+                                nextBtn.textContent = 'Continue without updating';
+                                nextBtn.style.display = '';
+                                if (backBtn) backBtn.style.display = '';
+                                updateInstallGate();
                             } else {
                                 installStatus.innerHTML = '<span class="text-danger">Install may have failed. Try again.</span>';
                                 packageStatus.innerHTML = '';
                                 status.textContent = '';
                                 installBtn.style.display = '';
-                                if (isRerun) nextBtn.style.display = '';
                                 if (backBtn) backBtn.style.display = '';
                                 updateInstallGate();
                             }


### PR DESCRIPTION
…izard re-run

Re-run detection was based on whether retina-node was already present, which misidentified nodes shipped with retina node pre-installed as having already completed the wizard. They'd skip straight to "managed remotely" on their very first run, with no way to install the latest version — a requirement. Re-run status now comes from a persisted wizard-completion flag instead.

Also makes install failures recoverable: a failed first-run upgrade now restores the previously-working containers via enforce_radar_mode (silencing the watchdog until they're back up to avoid racing its own docker compose calls), and the wizard offers an explicit "Continue without updating" choice when that happens, distinct from a genuine successful update.