### PR TITLE
20260626 network config eth

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6,6 +6,7 @@ import subprocess
 from config_manager import ConfigManager
 from device_state import DeviceState
 from mender import MenderClient
+from network_manager import NetworkManager
 from ssh_keys import SSHKeyManager
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -59,6 +60,7 @@ DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
 
 # Shared services
 ssh_keys = SSHKeyManager(os.path.join(DATA_DIR, "authorized_keys"))
+network_mgr = NetworkManager(dev_mode=DEV_MODE)
 
 config_mgr = ConfigManager(
     user_config_path=USER_CONFIG_PATH,
@@ -138,6 +140,7 @@ from routes.mender_routes import bp as mender_bp
 from routes.setup import bp as setup_bp
 from routes.towers import bp as towers_bp
 from routes.mode import bp as mode_bp
+from routes.network import bp as network_bp
 
 app.register_blueprint(home_bp)
 app.register_blueprint(config_bp)
@@ -145,6 +148,7 @@ app.register_blueprint(mender_bp)
 app.register_blueprint(setup_bp)
 app.register_blueprint(towers_bp)
 app.register_blueprint(mode_bp)
+app.register_blueprint(network_bp)
 
 
 if __name__ == "__main__":

--- a/src/network_manager.py
+++ b/src/network_manager.py
@@ -1,0 +1,260 @@
+"""Network status, WiFi scanning, and WiFi connect for retina-gui.
+
+Wraps nmcli (NetworkManager) the same way mender.py wraps the Mender CLI —
+plain subprocess calls, no persisted state beyond what NetworkManager itself
+keeps. Connecting to a new WiFi network never deletes another connection
+profile: nmcli only touches the profile for the SSID being connected to, so
+a previously-saved network stays available for autoconnect if the new one
+fails.
+"""
+
+import ipaddress
+import re
+import subprocess
+import threading
+import time
+
+
+DEV_NETWORKS = [
+    {"ssid": "Dev Office WiFi", "signal": 88, "secured": True},
+    {"ssid": "Dev Guest", "signal": 54, "secured": False},
+    {"ssid": "Neighbor 5G", "signal": 31, "secured": True},
+]
+
+
+def _unescape_terse(value: str) -> str:
+    """Undo nmcli's `-t` escaping of ':' and '\\' within a field."""
+    return re.sub(r'\\(.)', r'\1', value)
+
+
+def _split_terse_line(line: str, n_fields: int) -> list[str]:
+    """Split an nmcli -t line on unescaped colons into exactly n_fields."""
+    parts = re.split(r'(?<!\\):', line)
+    parts = [_unescape_terse(p) for p in parts]
+    # Tolerate trailing fields nmcli sometimes omits (e.g. empty SECURITY).
+    while len(parts) < n_fields:
+        parts.append('')
+    return parts[:n_fields]
+
+
+class NetworkManager:
+    """Reads network status and drives WiFi scan/connect via nmcli."""
+
+    def __init__(self, dev_mode: bool = False):
+        self.dev_mode = dev_mode
+        self._connect_lock = threading.Lock()
+        self._connect_status = {"state": "idle", "ssid": None, "error": None}
+        self._dev_wifi_ssid = None
+
+    # ── Status ─────────────────────────────────────────────────
+
+    def get_network_status(self, client_ip: str | None = None) -> dict:
+        """Ethernet/WiFi connection summary for the Network panel.
+
+        `client_ip` is the requesting browser's address (Flask's
+        request.remote_addr) — used to warn the user when their own
+        session is riding over the WiFi network they're about to
+        reconfigure, since that connection won't survive the switch.
+        """
+        if self.dev_mode:
+            return {
+                "ethernet_connected": False,
+                "wifi_connected": self._dev_wifi_ssid is not None,
+                "wifi_ssid": self._dev_wifi_ssid,
+                "client_on_wifi": False,
+            }
+
+        ethernet_connected = False
+        wifi_connected = False
+        try:
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "TYPE,STATE", "device", "status"],
+                capture_output=True, text=True, timeout=5,
+            )
+            for line in result.stdout.strip().splitlines():
+                dev_type, state = _split_terse_line(line, 2)
+                if dev_type == "ethernet" and state == "connected":
+                    ethernet_connected = True
+                if dev_type == "wifi" and state == "connected":
+                    wifi_connected = True
+        except Exception:
+            pass
+
+        wifi_ssid = None
+        if wifi_connected:
+            try:
+                result = subprocess.run(
+                    ["nmcli", "-t", "-f", "ACTIVE,SSID", "device", "wifi"],
+                    capture_output=True, text=True, timeout=5,
+                )
+                for line in result.stdout.strip().splitlines():
+                    active, ssid = _split_terse_line(line, 2)
+                    if active == "yes" and ssid:
+                        wifi_ssid = ssid
+                        break
+            except Exception:
+                pass
+
+        return {
+            "ethernet_connected": ethernet_connected,
+            "wifi_connected": wifi_connected,
+            "wifi_ssid": wifi_ssid,
+            "client_on_wifi": wifi_connected and self._is_client_on_wifi_subnet(client_ip),
+        }
+
+    def _get_wifi_device(self) -> str | None:
+        try:
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "DEVICE,TYPE", "device", "status"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except Exception:
+            return None
+        for line in result.stdout.strip().splitlines():
+            device, dev_type = _split_terse_line(line, 2)
+            if dev_type == "wifi":
+                return device
+        return None
+
+    def _is_client_on_wifi_subnet(self, client_ip: str | None) -> bool:
+        """Best-effort check: does client_ip fall within the WiFi device's subnet?
+
+        A heuristic, not a guarantee — but good enough to warn a user before
+        they reconfigure the WiFi network their own browser session is
+        likely using.
+        """
+        if not client_ip:
+            return False
+        try:
+            client = ipaddress.ip_address(client_ip)
+        except ValueError:
+            return False
+
+        device = self._get_wifi_device()
+        if not device:
+            return False
+
+        try:
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "IP4.ADDRESS", "device", "show", device],
+                capture_output=True, text=True, timeout=5,
+            )
+        except Exception:
+            return False
+
+        for cidr in re.findall(r'\d{1,3}(?:\.\d{1,3}){3}/\d{1,2}', result.stdout):
+            try:
+                if client in ipaddress.ip_interface(cidr).network:
+                    return True
+            except ValueError:
+                continue
+        return False
+
+    # ── Scan ───────────────────────────────────────────────────
+
+    def scan_wifi(self) -> list[dict]:
+        """Nearby WiFi networks, de-duped by SSID (strongest signal kept)."""
+        if self.dev_mode:
+            return list(DEV_NETWORKS)
+
+        try:
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "SSID,SIGNAL,SECURITY", "device", "wifi",
+                 "list", "--rescan", "yes"],
+                capture_output=True, text=True, timeout=15,
+            )
+        except Exception:
+            return []
+
+        best_by_ssid: dict[str, dict] = {}
+        for line in result.stdout.strip().splitlines():
+            ssid, signal_raw, security = _split_terse_line(line, 3)
+            if not ssid:
+                continue  # hidden network — use manual entry instead
+            try:
+                signal = int(signal_raw)
+            except ValueError:
+                signal = 0
+            secured = bool(security)
+            existing = best_by_ssid.get(ssid)
+            if existing is None or signal > existing["signal"]:
+                best_by_ssid[ssid] = {"ssid": ssid, "signal": signal, "secured": secured}
+
+        return sorted(best_by_ssid.values(), key=lambda n: n["signal"], reverse=True)
+
+    # ── Connect ────────────────────────────────────────────────
+
+    def connect_wifi(self, ssid: str, password: str | None = None, hidden: bool = False):
+        """Start a background WiFi connect attempt. Returns immediately."""
+        with self._connect_lock:
+            self._connect_status = {"state": "connecting", "ssid": ssid, "error": None}
+
+        if self.dev_mode:
+            threading.Thread(target=self._dev_connect, args=(ssid,), daemon=True).start()
+            return
+
+        threading.Thread(
+            target=self._run_connect, args=(ssid, password, hidden), daemon=True
+        ).start()
+
+    def get_connect_status(self) -> dict:
+        with self._connect_lock:
+            return dict(self._connect_status)
+
+    def _dev_connect(self, ssid: str):
+        time.sleep(2)
+        with self._connect_lock:
+            self._dev_wifi_ssid = ssid
+            self._connect_status = {"state": "connected", "ssid": ssid, "error": None}
+
+    def _run_connect(self, ssid: str, password: str | None, hidden: bool):
+        cmd = ["nmcli", "device", "wifi", "connect", ssid]
+        if password:
+            cmd += ["password", password]
+        if hidden:
+            cmd += ["hidden", "yes"]
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=45)
+        except subprocess.TimeoutExpired:
+            with self._connect_lock:
+                self._connect_status = {"state": "failed", "ssid": ssid, "error": "Connection attempt timed out"}
+            return
+        except Exception as e:
+            with self._connect_lock:
+                self._connect_status = {"state": "failed", "ssid": ssid, "error": str(e)}
+            return
+
+        if result.returncode != 0:
+            with self._connect_lock:
+                self._connect_status = {
+                    "state": "failed", "ssid": ssid,
+                    "error": (result.stderr or result.stdout or "nmcli connect failed").strip(),
+                }
+            return
+
+        # Don't trust the exit code alone — verify the connection is actually
+        # active before telling the UI it's safe to take the old network down.
+        if self._is_ssid_active(ssid):
+            with self._connect_lock:
+                self._connect_status = {"state": "connected", "ssid": ssid, "error": None}
+        else:
+            with self._connect_lock:
+                self._connect_status = {
+                    "state": "failed", "ssid": ssid,
+                    "error": "nmcli reported success but the connection isn't active",
+                }
+
+    def _is_ssid_active(self, ssid: str) -> bool:
+        try:
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "ACTIVE,SSID", "device", "wifi"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except Exception:
+            return False
+        for line in result.stdout.strip().splitlines():
+            active, line_ssid = _split_terse_line(line, 2)
+            if active == "yes" and line_ssid == ssid:
+                return True
+        return False

--- a/src/routes/network.py
+++ b/src/routes/network.py
@@ -1,0 +1,34 @@
+from flask import Blueprint, jsonify, request
+
+bp = Blueprint('network', __name__, url_prefix='/network')
+
+
+@bp.route('/status', methods=['GET'])
+def status():
+    from app import network_mgr
+    return jsonify(network_mgr.get_network_status(client_ip=request.remote_addr))
+
+
+@bp.route('/wifi/scan', methods=['GET'])
+def wifi_scan():
+    from app import network_mgr
+    return jsonify({"networks": network_mgr.scan_wifi()})
+
+
+@bp.route('/wifi/connect', methods=['POST'])
+def wifi_connect():
+    from app import network_mgr
+
+    data = request.get_json(silent=True) or {}
+    ssid = (data.get('ssid') or '').strip()
+    if not ssid:
+        return jsonify({"success": False, "error": "Missing 'ssid' field"}), 400
+
+    network_mgr.connect_wifi(ssid, data.get('password'), bool(data.get('hidden')))
+    return jsonify({"success": True})
+
+
+@bp.route('/wifi/connect/status', methods=['GET'])
+def wifi_connect_status():
+    from app import network_mgr
+    return jsonify(network_mgr.get_connect_status())

--- a/templates/config.html
+++ b/templates/config.html
@@ -95,6 +95,7 @@
         <a href="#ssh">SSH access</a>
         <a href="#cloud">Cloud services</a>
         <a href="#wizard">Setup wizard</a>
+        <a href="#network">Network</a>
     </aside>
 
     {# ── Main ── #}
@@ -354,6 +355,66 @@
             </div>
         </section>
 
+        {# ── Network ── #}
+        <section id="network" class="cfg-section">
+            <div class="cfg-section-head">
+                <h2>Network</h2>
+                <span class="desc">Connect or switch this node's WiFi network.</span>
+            </div>
+            <div class="cfg-body">
+                <div class="cfg-row" style="padding:0;border:0;margin-bottom:14px;">
+                    <div class="label-col"><label>Ethernet</label></div>
+                    <div id="netEthernetStatus" class="desc">Checking…</div>
+                </div>
+                <div class="cfg-row" style="padding:0;border:0;margin-bottom:14px;">
+                    <div class="label-col"><label>WiFi</label></div>
+                    <div id="netWifiStatus" class="desc">Checking…</div>
+                </div>
+
+                <div class="divider"></div>
+
+                <div class="ds-label-micro" style="margin-bottom:10px;">What are you trying to do?</div>
+                <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:10px;">
+                    <label style="display:flex;align-items:flex-start;gap:8px;font-size:13.5px;cursor:pointer;">
+                        <input type="radio" name="netMode" id="netModeSame" value="same_network" checked style="margin-top:3px;">
+                        <span>
+                            <strong>Use this network's WiFi</strong> — I'm wired into a router and want this node on its WiFi too, then I'll unplug the cable.
+                            <span id="netModeSameDisabledHint" style="display:none;color:var(--ink-3);"> (connect an Ethernet cable to use this)</span>
+                        </span>
+                    </label>
+                    <label style="display:flex;align-items:flex-start;gap:8px;font-size:13.5px;cursor:pointer;">
+                        <input type="radio" name="netMode" id="netModeDifferent" value="different_network" style="margin-top:3px;">
+                        <span><strong>Switch to a different network</strong> — I'm moving this node to a new router entirely.</span>
+                    </label>
+                </div>
+
+                <div id="netMode2Warning" style="display:none;background:var(--accent-soft);border:1px solid var(--accent-edge);border-radius:var(--r-md);padding:10px 14px;margin-bottom:14px;font-size:13px;"></div>
+
+                <div class="divider"></div>
+
+                <div id="netScanRow" style="display:flex;gap:8px;align-items:flex-start;margin-bottom:10px;">
+                    <select id="netSsidSelect" class="ds-select" style="flex:1;min-width:0;">
+                        <option value="">Scanning…</option>
+                    </select>
+                    <button type="button" class="ds-btn ghost" id="netRescanBtn" title="Rescan">
+                        <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2v6h-6"/><path d="M3 11a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 13a9 9 0 0 1-15 6.7L3 16"/></svg>
+                    </button>
+                </div>
+                <div id="netManualRow" style="display:none;margin-bottom:10px;">
+                    <input type="text" id="netSsidManual" class="ds-input" placeholder="Network name (SSID)">
+                </div>
+                <a href="#" id="netManualToggle" style="font-size:12.5px;display:inline-block;margin-bottom:14px;">Enter network name manually</a>
+
+                <input type="password" id="netPassword" class="ds-input" placeholder="Password" style="margin-bottom:10px;display:none;">
+
+                <div style="display:flex;align-items:center;gap:10px;">
+                    <button type="button" class="ds-btn primary" id="netConnectBtn">Connect</button>
+                    <span class="spinner-border spinner-border-sm" id="netConnectSpinner" style="display:none;width:.9em;height:.9em;border-width:1.5px;"></span>
+                    <span id="netConnectStatus" style="font-size:13px;"></span>
+                </div>
+            </div>
+        </section>
+
         {# ── Save bar (bottom of all sections) ── #}
         {% if retina_installed %}
         <div class="savebar">
@@ -453,6 +514,190 @@
             });
         });
     }
+})();
+
+// Network panel — status, scan, manual entry toggle, connect + poll
+(function() {
+    var section = document.getElementById('network');
+    if (!section) return;
+
+    var csrf = document.querySelector('meta[name="csrf-token"]').content;
+    var ethStatus = document.getElementById('netEthernetStatus');
+    var wifiStatus = document.getElementById('netWifiStatus');
+    var select = document.getElementById('netSsidSelect');
+    var rescanBtn = document.getElementById('netRescanBtn');
+    var manualRow = document.getElementById('netManualRow');
+    var manualInput = document.getElementById('netSsidManual');
+    var manualToggle = document.getElementById('netManualToggle');
+    var passwordInput = document.getElementById('netPassword');
+    var connectBtn = document.getElementById('netConnectBtn');
+    var spinner = document.getElementById('netConnectSpinner');
+    var connectStatus = document.getElementById('netConnectStatus');
+    var modeSame = document.getElementById('netModeSame');
+    var modeDifferent = document.getElementById('netModeDifferent');
+    var modeSameDisabledHint = document.getElementById('netModeSameDisabledHint');
+    var mode2Warning = document.getElementById('netMode2Warning');
+    var manualMode = false;
+    var scanned = [];
+    var pollTimer = null;
+    var lastStatus = { ethernet_connected: false, client_on_wifi: false };
+
+    function currentMode() {
+        return modeDifferent.checked ? 'different_network' : 'same_network';
+    }
+
+    function refreshModeUI() {
+        modeSame.disabled = !lastStatus.ethernet_connected;
+        modeSameDisabledHint.style.display = lastStatus.ethernet_connected ? 'none' : '';
+        if (!lastStatus.ethernet_connected && modeSame.checked) {
+            modeSame.checked = false;
+            modeDifferent.checked = true;
+        }
+
+        if (currentMode() === 'different_network' && (!lastStatus.ethernet_connected || lastStatus.client_on_wifi)) {
+            var lines = [];
+            if (!lastStatus.ethernet_connected) {
+                lines.push("No Ethernet connection detected. Switching networks will disconnect this device from its current WiFi, so if the new network doesn't work out, you'll need to join it yourself to regain access. We recommend connecting Ethernet first as a fallback.");
+            }
+            if (lastStatus.client_on_wifi) {
+                lines.push("You also appear to be viewing this page over the WiFi network you're about to change — this page itself may stop responding the moment the switch happens.");
+            }
+            mode2Warning.innerHTML = lines.map(function(l) { return '<div>' + l + '</div>'; }).join('');
+            mode2Warning.style.display = '';
+        } else {
+            mode2Warning.style.display = 'none';
+        }
+    }
+
+    function loadStatus() {
+        fetch('/network/status').then(function(r) { return r.json(); }).then(function(d) {
+            ethStatus.textContent = d.ethernet_connected ? 'Connected' : 'Not connected';
+            wifiStatus.textContent = d.wifi_connected ? ('Connected to ' + d.wifi_ssid) : 'Not connected';
+            lastStatus = d;
+            refreshModeUI();
+        }).catch(function() {
+            ethStatus.textContent = 'Unknown';
+            wifiStatus.textContent = 'Unknown';
+        });
+    }
+
+    modeSame.addEventListener('change', refreshModeUI);
+    modeDifferent.addEventListener('change', refreshModeUI);
+
+    function updatePasswordVisibility() {
+        if (manualMode) {
+            passwordInput.style.display = '';
+            return;
+        }
+        var opt = select.options[select.selectedIndex];
+        passwordInput.style.display = (opt && opt.dataset.secured === '1') ? '' : 'none';
+    }
+
+    function renderScan() {
+        select.innerHTML = '';
+        if (scanned.length === 0) {
+            var o = document.createElement('option');
+            o.value = '';
+            o.textContent = 'No networks found';
+            select.appendChild(o);
+            return;
+        }
+        scanned.forEach(function(net) {
+            var o = document.createElement('option');
+            o.value = net.ssid;
+            o.textContent = net.ssid + (net.secured ? ' (secured)' : ' (open)') + ' — ' + net.signal + '%';
+            o.dataset.secured = net.secured ? '1' : '0';
+            select.appendChild(o);
+        });
+        updatePasswordVisibility();
+    }
+
+    function scan() {
+        select.innerHTML = '<option value="">Scanning…</option>';
+        fetch('/network/wifi/scan').then(function(r) { return r.json(); }).then(function(d) {
+            scanned = d.networks || [];
+            renderScan();
+        }).catch(function() {
+            select.innerHTML = '<option value="">Scan failed</option>';
+        });
+    }
+
+    select.addEventListener('change', updatePasswordVisibility);
+    rescanBtn.addEventListener('click', scan);
+
+    manualToggle.addEventListener('click', function(e) {
+        e.preventDefault();
+        manualMode = !manualMode;
+        document.getElementById('netScanRow').style.display = manualMode ? 'none' : 'flex';
+        manualRow.style.display = manualMode ? '' : 'none';
+        manualToggle.textContent = manualMode ? 'Choose from scanned networks' : 'Enter network name manually';
+        updatePasswordVisibility();
+    });
+
+    function pollConnectStatus() {
+        fetch('/network/wifi/connect/status').then(function(r) { return r.json(); }).then(function(d) {
+            if (d.state === 'connecting') {
+                pollTimer = setTimeout(pollConnectStatus, 2000);
+                return;
+            }
+            spinner.style.display = 'none';
+            connectBtn.disabled = false;
+            if (d.state === 'connected') {
+                connectStatus.style.color = 'var(--ok)';
+                if (currentMode() === 'same_network') {
+                    connectStatus.textContent = 'Connected to ' + d.ssid + ' — verified active. You can safely disconnect Ethernet now.';
+                } else if (lastStatus.ethernet_connected) {
+                    connectStatus.textContent = 'Connected to ' + d.ssid + ' — verified active. This device may now only be reachable from ' + d.ssid + '. Keep Ethernet connected for now, join ' + d.ssid + ' with your own computer, and confirm http://retina.local loads there. Once confirmed, it\'s safe to disconnect Ethernet.';
+                } else {
+                    connectStatus.textContent = 'Connected to ' + d.ssid + ' — verified active. Join ' + d.ssid + ' with your own computer now and confirm http://retina.local loads there.';
+                }
+                loadStatus();
+            } else if (d.state === 'failed') {
+                connectStatus.style.color = 'var(--danger)';
+                connectStatus.textContent = (d.error || 'Connection failed') + ' — nothing was removed from your existing network.';
+            }
+        }).catch(function() {
+            spinner.style.display = 'none';
+            connectBtn.disabled = false;
+            connectStatus.style.color = 'var(--danger)';
+            connectStatus.textContent = "Lost connection to the node — if you just changed WiFi networks, rejoin the new network and reload this page to confirm.";
+        });
+    }
+
+    connectBtn.addEventListener('click', function() {
+        var ssid = manualMode ? manualInput.value.trim() : select.value;
+        if (!ssid) return;
+        clearTimeout(pollTimer);
+        connectBtn.disabled = true;
+        spinner.style.display = 'inline-block';
+        connectStatus.style.color = '';
+        connectStatus.textContent = 'Connecting…';
+        fetch('/network/wifi/connect', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+            body: JSON.stringify({ ssid: ssid, password: passwordInput.value, hidden: manualMode })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(d) {
+            if (d.success) {
+                pollConnectStatus();
+            } else {
+                spinner.style.display = 'none';
+                connectBtn.disabled = false;
+                connectStatus.style.color = 'var(--danger)';
+                connectStatus.textContent = d.error || 'Failed to start connection';
+            }
+        })
+        .catch(function(e) {
+            spinner.style.display = 'none';
+            connectBtn.disabled = false;
+            connectStatus.style.color = 'var(--danger)';
+            connectStatus.textContent = 'Error: ' + e.message;
+        });
+    });
+
+    loadStatus();
+    scan();
 })();
 
 // Auto-apply after successful save redirect
@@ -590,7 +835,7 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
 
 // Side-nav scrollspy
 (function() {
-    var sectionIds = ['mode','location','capture','truth','tar1090','ssh','cloud','wizard'];
+    var sectionIds = ['mode','location','capture','truth','tar1090','ssh','cloud','wizard','network'];
     var links = {};
     sectionIds.forEach(function(id) {
         var a = document.querySelector('.side a[href="#' + id + '"]');

--- a/templates/config.html
+++ b/templates/config.html
@@ -371,6 +371,11 @@
                     <div id="netWifiStatus" class="desc">Checking…</div>
                 </div>
 
+                <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;">
+                    <button type="button" class="ds-btn ghost" id="netRecheckBtn">Re-run network check</button>
+                    <span class="spinner-border spinner-border-sm" id="netRecheckSpinner" style="display:none;width:.9em;height:.9em;border-width:1.5px;"></span>
+                </div>
+
                 <div class="divider"></div>
 
                 <div class="ds-label-micro" style="margin-bottom:10px;">What are you trying to do?</div>
@@ -537,6 +542,8 @@
     var modeDifferent = document.getElementById('netModeDifferent');
     var modeSameDisabledHint = document.getElementById('netModeSameDisabledHint');
     var mode2Warning = document.getElementById('netMode2Warning');
+    var recheckBtn = document.getElementById('netRecheckBtn');
+    var recheckSpinner = document.getElementById('netRecheckSpinner');
     var manualMode = false;
     var scanned = [];
     var pollTimer = null;
@@ -570,7 +577,7 @@
     }
 
     function loadStatus() {
-        fetch('/network/status').then(function(r) { return r.json(); }).then(function(d) {
+        return fetch('/network/status').then(function(r) { return r.json(); }).then(function(d) {
             ethStatus.textContent = d.ethernet_connected ? 'Connected' : 'Not connected';
             wifiStatus.textContent = d.wifi_connected ? ('Connected to ' + d.wifi_ssid) : 'Not connected';
             lastStatus = d;
@@ -583,6 +590,17 @@
 
     modeSame.addEventListener('change', refreshModeUI);
     modeDifferent.addEventListener('change', refreshModeUI);
+
+    recheckBtn.addEventListener('click', function() {
+        recheckBtn.disabled = true;
+        recheckSpinner.style.display = 'inline-block';
+        ethStatus.textContent = 'Checking…';
+        wifiStatus.textContent = 'Checking…';
+        loadStatus().finally(function() {
+            recheckBtn.disabled = false;
+            recheckSpinner.style.display = 'none';
+        });
+    });
 
     function updatePasswordVisibility() {
         if (manualMode) {

--- a/templates/config.html
+++ b/templates/config.html
@@ -620,6 +620,12 @@
             select.appendChild(o);
             return;
         }
+        var placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Choose your WiFi network';
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        select.appendChild(placeholder);
         scanned.forEach(function(net) {
             var o = document.createElement('option');
             o.value = net.ssid;

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,262 @@
+"""Tests for network_manager.py and the /network routes."""
+import json
+import subprocess
+from unittest.mock import patch, MagicMock
+
+from network_manager import NetworkManager, _split_terse_line
+
+
+class TestSplitTerseLine:
+
+    def test_simple_split(self):
+        assert _split_terse_line("ethernet:connected", 2) == ["ethernet", "connected"]
+
+    def test_unescapes_colon_in_field(self):
+        # nmcli escapes literal colons within a field as '\:'
+        assert _split_terse_line("My\\:SSID:80:WPA2", 3) == ["My:SSID", "80", "WPA2"]
+
+    def test_pads_missing_trailing_fields(self):
+        assert _split_terse_line("OpenNet:60", 3) == ["OpenNet", "60", ""]
+
+
+class TestGetNetworkStatus:
+
+    @patch('subprocess.run')
+    def test_ethernet_and_wifi_disconnected(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="ethernet:disconnected\nwifi:disconnected\n")
+        mgr = NetworkManager(dev_mode=False)
+        status = mgr.get_network_status()
+        assert status == {"ethernet_connected": False, "wifi_connected": False, "wifi_ssid": None, "client_on_wifi": False}
+
+    @patch('subprocess.run')
+    def test_ethernet_connected(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="ethernet:connected\nwifi:disconnected\n")
+        mgr = NetworkManager(dev_mode=False)
+        status = mgr.get_network_status()
+        assert status["ethernet_connected"] is True
+        assert status["wifi_connected"] is False
+
+    @patch('subprocess.run')
+    def test_wifi_connected_resolves_ssid(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="ethernet:disconnected\nwifi:connected\n"),
+            MagicMock(returncode=0, stdout="no:OtherNet\nyes:HomeNet\n"),
+        ]
+        mgr = NetworkManager(dev_mode=False)
+        status = mgr.get_network_status()
+        assert status["wifi_connected"] is True
+        assert status["wifi_ssid"] == "HomeNet"
+
+    @patch('subprocess.run')
+    def test_nmcli_failure_returns_safe_defaults(self, mock_run):
+        mock_run.side_effect = Exception("nmcli not found")
+        mgr = NetworkManager(dev_mode=False)
+        status = mgr.get_network_status()
+        assert status == {"ethernet_connected": False, "wifi_connected": False, "wifi_ssid": None, "client_on_wifi": False}
+
+    def test_dev_mode_reflects_simulated_connect(self):
+        mgr = NetworkManager(dev_mode=True)
+        assert mgr.get_network_status()["wifi_connected"] is False
+        mgr._dev_wifi_ssid = "DevNet"
+        status = mgr.get_network_status()
+        assert status["wifi_connected"] is True
+        assert status["wifi_ssid"] == "DevNet"
+
+
+class TestClientOnWifiDetection:
+    """Warns the user when their own browser session is riding the WiFi
+    network they're about to reconfigure (it won't survive the switch)."""
+
+    @patch('subprocess.run')
+    def test_client_ip_inside_wifi_subnet_is_flagged(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="ethernet:disconnected\nwifi:connected\n"),
+            MagicMock(returncode=0, stdout="yes:HomeNet\n"),
+            MagicMock(returncode=0, stdout="wlan0:wifi\neth0:ethernet\n"),
+            MagicMock(returncode=0, stdout="IP4.ADDRESS[1]:192.168.1.50/24\n"),
+        ]
+        mgr = NetworkManager(dev_mode=False)
+        status = mgr.get_network_status(client_ip="192.168.1.77")
+        assert status["client_on_wifi"] is True
+
+    @patch('subprocess.run')
+    def test_client_ip_outside_wifi_subnet_is_not_flagged(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="ethernet:disconnected\nwifi:connected\n"),
+            MagicMock(returncode=0, stdout="yes:HomeNet\n"),
+            MagicMock(returncode=0, stdout="wlan0:wifi\neth0:ethernet\n"),
+            MagicMock(returncode=0, stdout="IP4.ADDRESS[1]:192.168.1.50/24\n"),
+        ]
+        mgr = NetworkManager(dev_mode=False)
+        status = mgr.get_network_status(client_ip="10.0.0.5")
+        assert status["client_on_wifi"] is False
+
+    @patch('subprocess.run')
+    def test_no_client_ip_is_not_flagged(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="ethernet:disconnected\nwifi:connected\n"),
+            MagicMock(returncode=0, stdout="yes:HomeNet\n"),
+        ]
+        mgr = NetworkManager(dev_mode=False)
+        status = mgr.get_network_status(client_ip=None)
+        assert status["client_on_wifi"] is False
+        assert mock_run.call_count == 2  # never bothers checking subnet without a client IP
+
+    @patch('subprocess.run')
+    def test_wifi_not_connected_short_circuits_without_extra_calls(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="ethernet:disconnected\nwifi:disconnected\n")
+        mgr = NetworkManager(dev_mode=False)
+        status = mgr.get_network_status(client_ip="192.168.1.77")
+        assert status["client_on_wifi"] is False
+        assert mock_run.call_count == 1  # only the initial device-status check
+
+    def test_dev_mode_never_flags_client(self):
+        mgr = NetworkManager(dev_mode=True)
+        status = mgr.get_network_status(client_ip="192.168.1.77")
+        assert status["client_on_wifi"] is False
+
+
+class TestScanWifi:
+
+    @patch('subprocess.run')
+    def test_parses_and_sorts_by_signal(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Weak:20:WPA2\nStrong:90:\nMid:50:WPA2\n",
+        )
+        mgr = NetworkManager(dev_mode=False)
+        networks = mgr.scan_wifi()
+        assert [n["ssid"] for n in networks] == ["Strong", "Mid", "Weak"]
+        assert networks[0]["secured"] is False
+        assert networks[1]["secured"] is True
+
+    @patch('subprocess.run')
+    def test_dedupes_by_ssid_keeping_strongest(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="SameNet:30:WPA2\nSameNet:75:WPA2\n",
+        )
+        mgr = NetworkManager(dev_mode=False)
+        networks = mgr.scan_wifi()
+        assert len(networks) == 1
+        assert networks[0]["signal"] == 75
+
+    @patch('subprocess.run')
+    def test_drops_hidden_blank_ssid(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout=":40:WPA2\nVisible:60:\n")
+        mgr = NetworkManager(dev_mode=False)
+        networks = mgr.scan_wifi()
+        assert [n["ssid"] for n in networks] == ["Visible"]
+
+    @patch('subprocess.run')
+    def test_scan_failure_returns_empty_list(self, mock_run):
+        mock_run.side_effect = Exception("boom")
+        mgr = NetworkManager(dev_mode=False)
+        assert mgr.scan_wifi() == []
+
+    def test_dev_mode_returns_fake_networks(self):
+        mgr = NetworkManager(dev_mode=True)
+        networks = mgr.scan_wifi()
+        assert len(networks) > 0
+        assert all("ssid" in n for n in networks)
+
+
+class TestConnectWifi:
+
+    @patch('subprocess.run')
+    def test_successful_connect_verifies_active_before_marking_connected(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),  # nmcli connect
+            MagicMock(returncode=0, stdout="no:Other\nyes:NewNet\n"),  # verification scan
+        ]
+        mgr = NetworkManager(dev_mode=False)
+        mgr._run_connect("NewNet", "secret", False)
+        status = mgr.get_connect_status()
+        assert status == {"state": "connected", "ssid": "NewNet", "error": None}
+
+    @patch('subprocess.run')
+    def test_connect_command_failure_marks_failed_and_keeps_message(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="Secrets were required, but not provided")
+        mgr = NetworkManager(dev_mode=False)
+        mgr._run_connect("NewNet", "wrong", False)
+        status = mgr.get_connect_status()
+        assert status["state"] == "failed"
+        assert "Secrets" in status["error"]
+
+    @patch('subprocess.run')
+    def test_connect_exit_zero_but_not_active_marks_failed(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="yes:SomeOtherNet\n"),  # never activated the requested SSID
+        ]
+        mgr = NetworkManager(dev_mode=False)
+        mgr._run_connect("NewNet", "secret", False)
+        status = mgr.get_connect_status()
+        assert status["state"] == "failed"
+
+    @patch('subprocess.run')
+    def test_connect_timeout_marks_failed(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd='nmcli', timeout=45)
+        mgr = NetworkManager(dev_mode=False)
+        mgr._run_connect("NewNet", "secret", False)
+        status = mgr.get_connect_status()
+        assert status["state"] == "failed"
+        assert "timed out" in status["error"].lower()
+
+    @patch('subprocess.run')
+    def test_old_profile_not_touched_on_connect(self, mock_run):
+        """connect_wifi only ever calls nmcli for the new SSID — never touches another profile."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="yes:NewNet\n"),
+        ]
+        mgr = NetworkManager(dev_mode=False)
+        mgr._run_connect("NewNet", "secret", False)
+        connect_call = mock_run.call_args_list[0][0][0]
+        assert connect_call == ["nmcli", "device", "wifi", "connect", "NewNet", "password", "secret"]
+
+    def test_dev_mode_connect_eventually_succeeds(self):
+        mgr = NetworkManager(dev_mode=True)
+        mgr._dev_connect("DevNet")
+        status = mgr.get_connect_status()
+        assert status == {"state": "connected", "ssid": "DevNet", "error": None}
+
+
+class TestNetworkRoutes:
+
+    @patch('subprocess.run')
+    def test_status_endpoint(self, mock_run, app_client):
+        mock_run.return_value = MagicMock(returncode=0, stdout="ethernet:connected\nwifi:disconnected\n")
+        response = app_client.get('/network/status')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["ethernet_connected"] is True
+
+    @patch('subprocess.run')
+    def test_scan_endpoint(self, mock_run, app_client):
+        mock_run.return_value = MagicMock(returncode=0, stdout="Net1:80:WPA2\n")
+        response = app_client.get('/network/wifi/scan')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["networks"][0]["ssid"] == "Net1"
+
+    def test_connect_missing_ssid_returns_400(self, app_client):
+        response = app_client.post('/network/wifi/connect',
+                                   data=json.dumps({}),
+                                   content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.data)["success"] is False
+
+    @patch('subprocess.run')
+    def test_connect_accepts_request_and_returns_immediately(self, mock_run, app_client):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        response = app_client.post('/network/wifi/connect',
+                                   data=json.dumps({"ssid": "NewNet", "password": "secret"}),
+                                   content_type='application/json')
+        assert response.status_code == 200
+        assert json.loads(response.data)["success"] is True
+
+    def test_connect_status_endpoint_defaults_to_idle(self, app_client):
+        response = app_client.get('/network/wifi/connect/status')
+        assert response.status_code == 200
+        assert json.loads(response.data)["state"] == "idle"


### PR DESCRIPTION
# Network config: WiFi panel + Ethernet-aware captive portal

Adds a self-service Network panel to `/config` so a node can be switched onto a new WiFi network (or checked for Ethernet) without SSH access, and teaches the OS-level captive portal to stay out of the way once a wired connection is present.

## retina-gui

- **Network panel on `/config`** (`templates/config.html`): new "Network" section showing live Ethernet/WiFi status, a WiFi scan dropdown, manual (hidden network) entry, and a connect flow with password visibility tied to whether the selected network is secured. Warns the user if their own browser session appears to be riding the WiFi network they're about to reconfigure.
- **`src/network_manager.py`** (new): wraps `nmcli` for status, scan, and connect — mirrors the subprocess-wrapping style already used by `mender.py`. Connecting to a new SSID never deletes another saved connection profile, so a previously-working network is still available for autoconnect if the new one fails. Includes a `dev_mode` fake-network path for local development without real hardware.
- **`src/routes/network.py`** (new): `GET /network/status`, `GET /network/wifi/scan`, `POST /network/wifi/connect`, `GET /network/wifi/connect/status` — connect runs in a background thread so the request returns immediately and the UI polls for progress.
- **Re-run network check button**: re-triggers the status check in place without a full page reload.
- **Dropdown placeholder fix**: the WiFi select now opens on a disabled "Choose your WiFi network" placeholder instead of silently defaulting to the first scanned network, so a user can't accidentally connect to the wrong SSID by clicking Connect without picking one.
- **`tests/test_network.py`** (new): coverage for the manager and routes above.