### PR TITLE
20260629 - Add SDRconnect as a third node mode

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -84,6 +84,13 @@ if config_mgr.is_retina_node_installed():
     except Exception:
         pass
 
+# Same for sdrconnect.service — never leave a node stuck serving SDRconnect
+# after a GUI restart.
+try:
+    subprocess.run(['systemctl', 'stop', 'sdrconnect.service'], capture_output=True, timeout=30)
+except Exception:
+    pass
+
 
 def get_node_id():
     """Get node_id from Mender device identity file."""

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -8,12 +8,12 @@ _mode_cache = 'radar'  # default mode if file read fails (e.g. dev environment w
 
 
 def get_current_mode():
-    """Read persisted mode. Returns 'radar' or 'spectrum'."""
+    """Read persisted mode. Returns 'radar', 'spectrum', or 'sdrconnect'."""
     from app import DATA_DIR
     try:
         with open(os.path.join(DATA_DIR, 'mode.txt')) as f:
             mode = f.read().strip()
-            return mode if mode in ('radar', 'spectrum') else 'radar'
+            return mode if mode in ('radar', 'spectrum', 'sdrconnect') else 'radar'
     except (FileNotFoundError, OSError):
         return _mode_cache
 
@@ -44,7 +44,7 @@ def run_config_merger_and_restart(retina_node_path: str) -> str | None:
     if result.returncode != 0:
         return f'config-merger failed: {result.stderr or result.stdout}'
 
-    if get_current_mode() == 'spectrum':
+    if get_current_mode() in ('spectrum', 'sdrconnect'):
         return None
 
     # Defensive: ensure retina-spectrum is stopped before bringing the radar stack up.
@@ -85,14 +85,15 @@ def set_mode():
 
     data = request.get_json(silent=True) or {}
     mode = data.get('mode')
-    if mode not in ('radar', 'spectrum'):
+    if mode not in ('radar', 'spectrum', 'sdrconnect'):
         return jsonify({'success': False, 'error': 'Invalid mode'}), 400
 
     node_installed = config_mgr.is_retina_node_installed()
+    current_mode = get_current_mode()
 
     try:
         if not node_installed:
-            # Dev / pre-deployment: persist mode but skip docker commands
+            # Dev / pre-deployment: persist mode but skip docker/systemctl commands
             _write_mode(mode)
             return jsonify({'success': True, 'mode': mode})
 
@@ -100,15 +101,20 @@ def set_mode():
             # Write mode first so the watchdog guard fires immediately and cannot
             # see blah2 stopped mid-transition and trigger a spurious stack restart.
             _write_mode(mode)
-            result = subprocess.run(
-                ['docker', 'compose', '-p', 'retina-node', 'stop',
-                 'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
-                cwd=RETINA_NODE_PATH,
-                capture_output=True, text=True, timeout=60
-            )
-            if result.returncode != 0:
-                return jsonify({'success': False,
-                                'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
+
+            if current_mode == 'sdrconnect':
+                subprocess.run(['systemctl', 'stop', 'sdrconnect.service'],
+                               capture_output=True, timeout=30)
+            else:
+                result = subprocess.run(
+                    ['docker', 'compose', '-p', 'retina-node', 'stop',
+                     'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
+                    cwd=RETINA_NODE_PATH,
+                    capture_output=True, text=True, timeout=60
+                )
+                if result.returncode != 0:
+                    return jsonify({'success': False,
+                                    'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
 
             result = subprocess.run(
                 ['docker', 'compose', '-p', 'retina-node', '--profile', 'spectrum', 'up', '-d', 'retina-spectrum'],
@@ -119,23 +125,58 @@ def set_mode():
                 return jsonify({'success': False,
                                 'error': f'Failed to start retina-spectrum: {result.stderr or result.stdout}'}), 500
 
-        else:  # radar
-            result = subprocess.run(
-                ['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
-                cwd=RETINA_NODE_PATH,
-                capture_output=True, text=True, timeout=60
-            )
+        elif mode == 'sdrconnect':
+            # Write mode first, same reasoning as the spectrum transition above.
+            _write_mode(mode)
+
+            if current_mode == 'spectrum':
+                subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                               cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
+                subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                               cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
+            else:
+                result = subprocess.run(
+                    ['docker', 'compose', '-p', 'retina-node', 'stop',
+                     'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
+                    cwd=RETINA_NODE_PATH,
+                    capture_output=True, text=True, timeout=60
+                )
+                if result.returncode != 0:
+                    return jsonify({'success': False,
+                                    'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
+
+            # Force a clean sdrplay_apiService restart so the USB device is
+            # properly re-initialised before SDRconnect claims it.  Non-fatal.
+            subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
+                           capture_output=True, timeout=30)
+
+            result = subprocess.run(['systemctl', 'start', 'sdrconnect.service'],
+                                    capture_output=True, text=True, timeout=30)
             if result.returncode != 0:
                 return jsonify({'success': False,
-                                'error': f'Failed to stop retina-spectrum: {result.stderr or result.stdout}'}), 500
+                                'error': f'Failed to start sdrconnect.service: {result.stderr or result.stdout}'}), 500
 
-            # Remove the stopped container so it cannot be auto-restarted and
-            # so the SDR device is cleanly released before blah2 starts.
-            subprocess.run(
-                ['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
-                cwd=RETINA_NODE_PATH,
-                capture_output=True, text=True, timeout=30
-            )
+        else:  # radar
+            if current_mode == 'sdrconnect':
+                subprocess.run(['systemctl', 'stop', 'sdrconnect.service'],
+                               capture_output=True, timeout=30)
+            else:
+                result = subprocess.run(
+                    ['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                    cwd=RETINA_NODE_PATH,
+                    capture_output=True, text=True, timeout=60
+                )
+                if result.returncode != 0:
+                    return jsonify({'success': False,
+                                    'error': f'Failed to stop retina-spectrum: {result.stderr or result.stdout}'}), 500
+
+                # Remove the stopped container so it cannot be auto-restarted and
+                # so the SDR device is cleanly released before blah2 starts.
+                subprocess.run(
+                    ['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                    cwd=RETINA_NODE_PATH,
+                    capture_output=True, text=True, timeout=30
+                )
 
             # Force a clean sdrplay_apiService restart so the USB device is
             # properly re-initialised before blah2 claims it.  Non-fatal.
@@ -181,8 +222,19 @@ def spectrum_ready():
         return jsonify({'ready': False})
 
 
+@bp.route('/api/sdrconnect/ready', methods=['GET'])
+def sdrconnect_ready():
+    """Probe sdrconnect.service to see if it is up yet.
+
+    SDRconnect has no HTTP port to probe, so this checks systemd unit state.
+    """
+    result = subprocess.run(['systemctl', 'is-active', 'sdrconnect.service'],
+                            capture_output=True, timeout=5)
+    return jsonify({'ready': result.returncode == 0})
+
+
 def enforce_radar_mode(retina_node_path: str) -> None:
-    """Stop retina-spectrum and bring the radar stack up unconditionally.
+    """Stop retina-spectrum/sdrconnect and bring the radar stack up unconditionally.
 
     Called on wizard completion so the node is always left in a clean radar
     state regardless of what happened during the wizard flow. Non-fatal: errors
@@ -197,6 +249,8 @@ def enforce_radar_mode(retina_node_path: str) -> None:
             ['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
             cwd=retina_node_path, capture_output=True, timeout=30
         )
+        subprocess.run(['systemctl', 'stop', 'sdrconnect.service'],
+                       capture_output=True, timeout=30)
         subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
                        capture_output=True, timeout=30)
         subprocess.run(

--- a/static/common.css
+++ b/static/common.css
@@ -397,6 +397,34 @@ h1, h2, h3, h4, h5, h6 {
 .ds-switch input:disabled + .ds-switch-track { opacity: 0.5; cursor: not-allowed; }
 
 /* ══════════════════════════════════════════════
+   SEGMENTED CONTROL
+   ══════════════════════════════════════════════ */
+.ds-segmented {
+    display: inline-flex;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface-2);
+    padding: 2px;
+    gap: 2px;
+}
+.ds-segmented-btn {
+    border: none;
+    background: transparent;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font: inherit;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--ink-2);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background .12s, color .12s;
+}
+.ds-segmented-btn:hover:not([disabled]):not(.active) { color: var(--ink); }
+.ds-segmented-btn.active { background: var(--surface); color: var(--ink); box-shadow: var(--shadow-md); }
+.ds-segmented-btn[disabled] { cursor: not-allowed; opacity: 0.5; }
+
+/* ══════════════════════════════════════════════
    PILLS / STATUS
    ══════════════════════════════════════════════ */
 .ds-pill {

--- a/systemd/sdrconnect.service
+++ b/systemd/sdrconnect.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=SDRconnect Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/opt/sdrconnect/SDRconnect --server
+Restart=on-failure
+RestartSec=5

--- a/templates/config.html
+++ b/templates/config.html
@@ -126,17 +126,18 @@
         <section id="mode" class="cfg-section">
             <div class="cfg-section-head">
                 <h2>Mode</h2>
-                <span class="desc">Switch the node between passive radar and spectrum analysis.</span>
+                <span class="desc">Switch the node between passive radar, spectrum analysis, and SDRconnect.</span>
             </div>
             <div class="cfg-body">
                 <div class="toggle-row" style="padding:0;border:0;">
-                    <label class="ds-switch">
-                        <input type="checkbox" id="modeToggle">
-                        <span class="ds-switch-track"></span>
-                    </label>
+                    <div class="ds-segmented" id="modeSegmented" role="group" aria-label="Mode">
+                        <button type="button" class="ds-segmented-btn" data-mode="radar">Radar</button>
+                        <button type="button" class="ds-segmented-btn" data-mode="spectrum">Spectrum</button>
+                        <button type="button" class="ds-segmented-btn" data-mode="sdrconnect">SDRconnect</button>
+                    </div>
                     <div class="body">
                         <div class="name" id="modeLabel">Radar</div>
-                        <div class="desc">Radar runs the blah2 passive radar pipeline. Spectrum stops blah2 and starts retina-spectrum.</div>
+                        <div class="desc">Radar runs the blah2 passive radar pipeline. Spectrum stops blah2 and starts retina-spectrum. SDRconnect stops both and starts the SDRconnect server for a remote desktop client.</div>
                     </div>
                     <span class="spinner-border spinner-border-sm" id="modeSpinner" style="display:none;width:.9em;height:.9em;border-width:1.5px;flex-shrink:0;"></span>
                 </div>
@@ -460,39 +461,48 @@
 
 {% block scripts %}
 <script>
-// Mode toggle — change is staged; applied when user clicks Apply changes
+// Mode segmented control — change is staged; applied when user clicks Apply changes
 (function() {
-    var toggle  = document.getElementById('modeToggle');
-    var label   = document.getElementById('modeLabel');
-    var spinner = document.getElementById('modeSpinner');
-    var csrf    = document.querySelector('meta[name="csrf-token"]').content;
+    var segmented = document.getElementById('modeSegmented');
+    var buttons   = Array.prototype.slice.call(segmented.querySelectorAll('.ds-segmented-btn'));
+    var label     = document.getElementById('modeLabel');
+    var spinner   = document.getElementById('modeSpinner');
+    var csrf      = document.querySelector('meta[name="csrf-token"]').content;
     var loadedMode = 'radar'; // the mode currently active on the device
+    var selectedMode = 'radar';
 
-    function setLabel(mode) {
-        label.textContent = mode === 'spectrum' ? 'Spectrum' : 'Radar';
+    var MODE_LABELS = { radar: 'Radar', spectrum: 'Spectrum', sdrconnect: 'SDRconnect' };
+
+    function setSelected(mode) {
+        selectedMode = mode;
+        label.textContent = MODE_LABELS[mode] || 'Radar';
+        buttons.forEach(function(btn) {
+            btn.classList.toggle('active', btn.dataset.mode === mode);
+        });
     }
 
     fetch('/api/mode')
         .then(function(r) { return r.json(); })
         .then(function(d) {
             loadedMode = d.mode || 'radar';
-            toggle.checked = loadedMode === 'spectrum';
-            setLabel(loadedMode);
+            setSelected(loadedMode);
         })
         .catch(function() {});
 
-    toggle.addEventListener('change', function() {
-        setLabel(toggle.checked ? 'spectrum' : 'radar');
+    buttons.forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            setSelected(btn.dataset.mode);
+        });
     });
 
     // Apply mode change as part of the form submit triggered by Apply changes
     var form = document.getElementById('configForm');
     if (form) {
         form.addEventListener('submit', function(e) {
-            var newMode = toggle.checked ? 'spectrum' : 'radar';
+            var newMode = selectedMode;
             if (newMode === loadedMode) return; // no mode change — let form submit normally
             e.preventDefault();
-            toggle.disabled = true;
+            buttons.forEach(function(btn) { btn.disabled = true; });
             spinner.style.display = 'inline-block';
             fetch('/api/mode', {
                 method: 'POST',
@@ -505,16 +515,14 @@
                     loadedMode = newMode;
                     form.submit(); // HTMLFormElement.submit() bypasses the submit event
                 } else {
-                    toggle.checked = loadedMode === 'spectrum';
-                    setLabel(loadedMode);
+                    setSelected(loadedMode);
                 }
             })
             .catch(function() {
-                toggle.checked = loadedMode === 'spectrum';
-                setLabel(loadedMode);
+                setSelected(loadedMode);
             })
             .finally(function() {
-                toggle.disabled = false;
+                buttons.forEach(function(btn) { btn.disabled = false; });
                 spinner.style.display = 'none';
             });
         });

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,6 +60,35 @@
             <iframe id="spectrumFrame" class="spectrum-frame" src="" frameborder="0" style="display:none"></iframe>
         </div>
     </section>
+    {% elif mode == 'sdrconnect' %}
+    <section>
+        <div class="section-head"><h2>SDRconnect</h2></div>
+        <div class="svc-card" style="max-width:480px;">
+            <div class="svc-head">
+                <div class="svc-icon">
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="3" y="11" width="18" height="9" rx="2"/>
+                        <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                    </svg>
+                </div>
+                <div class="svc-name">SDRconnect server</div>
+                <span class="ds-pill" id="sdrconnectStatus">
+                    <span class="ds-pill-dot" style="background:var(--ink-3);"></span>
+                    Starting…
+                </span>
+            </div>
+            <div class="svc-desc">
+                Open the SDRconnect client app on your computer and connect to:
+            </div>
+            <div class="svc-desc" style="font-weight:600;color:var(--ink);" id="sdrconnectAddress"></div>
+            <div class="svc-desc">
+                Radar and the spectrum analyser are paused while SDRconnect mode is active.
+            </div>
+            <button type="button" class="ds-btn ghost" id="sdrconnectExitBtn" style="align-self:flex-start;">
+                Switch back to Radar
+            </button>
+        </div>
+    </section>
     {% else %}
     <section>
         <div class="section-head"><h2>Services</h2></div>
@@ -177,6 +206,60 @@ document.querySelectorAll('.svc-card[data-port]').forEach(function(el) {
     }
 
     poll();
+})();
+</script>
+{% endif %}
+{% if mode == 'sdrconnect' %}
+<script>
+(function() {
+    var statusPill = document.getElementById('sdrconnectStatus');
+    var address     = document.getElementById('sdrconnectAddress');
+    var exitBtn     = document.getElementById('sdrconnectExitBtn');
+    var csrf        = document.querySelector('meta[name="csrf-token"]').content;
+    var maxAttempts = 30; // 30 × 2 s = 60 s before giving up
+    var attempt = 0;
+
+    address.textContent = window.location.hostname;
+
+    function setStatus(text, color) {
+        statusPill.innerHTML = '<span class="ds-pill-dot" style="background:' + color + ';"></span>' + text;
+    }
+
+    function poll() {
+        fetch('/api/sdrconnect/ready')
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                if (d.ready) {
+                    setStatus('Running', 'var(--ok)');
+                } else if (attempt < maxAttempts) {
+                    attempt++;
+                    setTimeout(poll, 2000);
+                } else {
+                    setStatus('Not responding', 'var(--danger)');
+                }
+            })
+            .catch(function() {
+                if (attempt < maxAttempts) { attempt++; setTimeout(poll, 2000); }
+                else { setStatus('Not responding', 'var(--danger)'); }
+            });
+    }
+
+    poll();
+
+    exitBtn.addEventListener('click', function() {
+        exitBtn.disabled = true;
+        exitBtn.textContent = 'Switching to Radar…';
+        fetch('/api/mode', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+            body: JSON.stringify({ mode: 'radar' })
+        })
+        .then(function() { window.location.reload(); })
+        .catch(function() {
+            exitBtn.disabled = false;
+            exitBtn.textContent = 'Switch back to Radar';
+        });
+    });
 })();
 </script>
 {% endif %}


### PR DESCRIPTION
## Add SDRconnect as a third node mode

### Summary
Extends the existing radar/spectrum mode toggle with a third mode, `sdrconnect`,
so a node can stream to a remote SDRconnect desktop client without SSH access
or manual `docker compose`/binary juggling (previously documented in
`sdrconnect_setup.md` as an entirely manual workflow).

SDRconnect is a bare binary (`/opt/sdrconnect/SDRconnect`, installed separately
by owl-os), not a docker service, so it's wrapped in a new on-demand systemd
unit and managed by the same code path that already handles the
radar↔spectrum handoff.

### Changes
- **`systemd/sdrconnect.service`** (new) — wraps `SDRconnect --server`.
  Deliberately has no `[Install]`/`WantedBy`, so it never auto-starts at boot —
  only `systemctl start`/`stop`, driven by the mode switcher.
- **`src/routes/mode.py`** — `sdrconnect` is now a valid persisted mode.
  `POST /api/mode` handles all transition pairs between radar/spectrum/sdrconnect
  (tear down whichever consumer was previously running, restart `sdrplay.service`
  for a clean device handoff, then start the target). New
  `GET /api/sdrconnect/ready` (checks `systemctl is-active`, since SDRconnect
  has no HTTP port to probe like spectrum does). `enforce_radar_mode()` now
  also stops `sdrconnect.service`.
- **`src/app.py`** — boot-time cleanup also stops `sdrconnect.service`,
  preserving the existing guarantee that a GUI/app restart always reverts the
  node to radar mode.
- **`templates/config.html`** + **`static/common.css`** — Mode toggle is now a
  3-way segmented control (Radar / Spectrum / SDRconnect) instead of a binary
  switch.
- **`templates/index.html`** — new status card shown in place of the Services
  grid while in SDRconnect mode: live running/starting/not-responding badge,
  the address to connect a client to, and a "Switch back to Radar" button.