### PR TITLE
20260701 - Auto-run spectrum sweep on wizard location step

### DIFF
--- a/static/setup.js
+++ b/static/setup.js
@@ -214,6 +214,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     var connectRfSse = null; // defined inside enterHooks.location on first entry
     var locationActive = false;    // guards against dangling fetch resolving after leave
     var pendingModeSwitch = null;  // tracks in-flight /api/mode POST so the leave hook can serialise the revert
+    var spectrumGating = false;    // true while scan is in progress; gates Find Towers
 
     // Step 1: Agreements
     enterHooks.agreements = function() {
@@ -614,10 +615,9 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         // Start retina-spectrum on every entry (idempotent — no-op if already in
         // spectrum mode or if retina-node is not yet installed).
         locationActive = true;
-        var scanBtn = document.getElementById('scanRfBtn');
+        spectrumGating = true;
+        document.getElementById('findTowersBtn').disabled = true;
         var scanStatus = document.getElementById('scanStatus');
-        scanBtn.disabled = true;
-        scanBtn.textContent = 'Starting analyser…';
         scanStatus.textContent = 'Starting spectrum analyser…';
         scanStatus.style.display = '';
         pendingModeSwitch = fetch('/api/mode')
@@ -632,7 +632,11 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             })
             .catch(function() {
                 if (!locationActive) return;
-                scanStatus.textContent = 'Analyser unavailable — RF scan disabled';
+                scanStatus.textContent = 'Spectrum analyser unavailable — will search by location only';
+                spectrumGating = false;
+                var lat = parseFloat(document.getElementById('rxLat').value);
+                var lon = parseFloat(document.getElementById('rxLon').value);
+                document.getElementById('findTowersBtn').disabled = isNaN(lat) || isNaN(lon);
             });
 
         // Event listeners and inner state set up only once
@@ -662,7 +666,6 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         var scanResult = document.getElementById('scanResult');
         var rfMeasurements = [];
         var rfPhase = 'idle'; // idle | waiting | scanning | done
-        var rfHwReady = false;
 
         function normaliseBand(id) {
             if (id === 'fm') return 'FM';
@@ -673,30 +676,27 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
         function updateRfUI() {
             var n = rfMeasurements.length;
-            if (rfPhase === 'idle' || rfPhase === 'waiting') {
-                scanStatus.textContent = rfPhase === 'waiting' ? 'Waiting for sweep to start…' : '';
-                scanStatus.style.display = rfPhase === 'waiting' ? '' : 'none';
+            if (rfPhase === 'waiting') {
+                scanStatus.textContent = 'Waiting for sweep to start — this will take about 1 minute…';
+                scanStatus.style.display = '';
                 scanResult.style.display = 'none';
-                scanBtn.disabled = !rfHwReady;
-                scanBtn.textContent = 'Scan RF signals';
             } else if (rfPhase === 'scanning') {
                 scanStatus.textContent = 'Scanning…' + (n > 0 ? ' — ' + n + ' signal' + (n !== 1 ? 's' : '') + ' found' : '');
                 scanStatus.style.display = '';
                 scanResult.style.display = 'none';
-                scanBtn.disabled = true;
-                scanBtn.textContent = 'Scanning…';
             } else if (rfPhase === 'done') {
                 scanStatus.style.display = 'none';
                 scanResult.textContent = n + ' signal' + (n !== 1 ? 's' : '') + ' detected';
                 scanResult.style.display = '';
-                scanBtn.disabled = false;
-                scanBtn.textContent = 'Rescan';
             }
         }
 
         // Assign to outer-scope var so leaveHooks.location and re-entries can reach it
         connectRfSse = function() {
             if (rfSse) return;
+            rfMeasurements = [];
+            rfPhase = 'waiting';
+            updateRfUI();
             rfSse = new EventSource('/towers/spectrum/events');
             rfSse.onmessage = function(e) {
                 var msg = JSON.parse(e.data);
@@ -706,7 +706,6 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     rfPhase = 'scanning';
                     updateRfUI();
                 } else if (msg.type === 'step') {
-                    if (!rfHwReady) { rfHwReady = true; updateRfUI(); }
                     if (rfPhase !== 'scanning') return;
                     if (msg.channels) {
                         msg.channels.forEach(function(ch) {
@@ -726,7 +725,9 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 } else if (msg.type === 'complete') {
                     if (rfPhase !== 'scanning') return;
                     rfPhase = 'done';
+                    spectrumGating = false;
                     updateRfUI();
+                    updateFindBtn();
                 }
             };
             rfSse.onerror = function() {
@@ -735,17 +736,11 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             };
         };
 
-        scanBtn.addEventListener('click', function() {
-            rfMeasurements = [];
-            rfPhase = 'waiting';
-            updateRfUI();
-        });
-
-        // Enable Find Towers when lat/lon filled
+        // Enable Find Towers when lat/lon filled AND RF scan done (or unavailable)
         function updateFindBtn() {
             var lat = parseFloat(rxLat.value);
             var lon = parseFloat(rxLon.value);
-            findBtn.disabled = isNaN(lat) || isNaN(lon);
+            findBtn.disabled = isNaN(lat) || isNaN(lon) || spectrumGating;
         }
         rxLat.addEventListener('input', updateFindBtn);
         rxLon.addEventListener('input', updateFindBtn);

--- a/templates/setup/_location.html
+++ b/templates/setup/_location.html
@@ -2,7 +2,7 @@
 <div data-step="location" class="step-panel" style="display:none;">
     <div class="wiz-title-row">
         <h1>Where is your receiver?</h1>
-        <p>Set the coordinates of the radar receiver site.</p>
+        <p>Set the coordinates of the radar receiver site. While you do, the spectrum analyser will scan your RF environment to improve tower search results.</p>
     </div>
     <div class="step-stack">
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;">
@@ -30,12 +30,8 @@
         -->
 
         <div class="ds-field">
-            <button type="button" class="ds-btn ghost sm" id="scanRfBtn" style="width:100%;">
-                <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
-                Scan RF signals
-            </button>
-            <p id="scanStatus" style="display:none;font-size:13px;color:var(--ink-2);margin:4px 0 0;"></p>
-            <p id="scanResult" style="display:none;font-size:13px;color:var(--ok);margin:4px 0 0;"></p>
+            <p id="scanStatus" style="display:none;font-size:13px;color:var(--ink-2);margin:0;"></p>
+            <p id="scanResult" style="display:none;font-size:13px;color:var(--ok);margin:0;"></p>
         </div>
     </div>
 


### PR DESCRIPTION
Previously the user had to manually click "Scan RF signals" to start the spectrum analyser and could proceed to tower search before the sweep had completed. This change makes the scan happen automatically and gates the Find Towers button until it finishes.