### PR TITLE
20260707 user config descriptions

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -114,15 +114,19 @@ def _readonly_field(**kwargs):
 
 class CaptureFormConfig(BaseModel):
     """Flat capture config for form display."""
-    fs: int = Field(title="Sample Rate", description="Hz")
-    fc: int = Field(title="Center Frequency", description="Hz")
+    fs: Literal[62500, 125000, 250000, 500000, 1000000, 2000000] = Field(
+        title="Sample Rate",
+        description="Hz. How much of the broadcast signal the radar captures. 2000000 gives the sharpest "
+                    "range detail (recommended); lower values blur range but reduce processing load."
+    )
+    fc: int = Field(title="Center Frequency", description="Hz. Set based on the tower you have chosen.")
     device_type: str = _readonly_field(title="Device Type")
-    device_agcSetPoint: int = Field(le=0, title="AGC Set Point", description="dBFS")
-    device_gainReductionA: int = Field(ge=20, le=59, title="Gain Reduction (Reference)", description="20-59 dB, higher=less gain")
-    device_gainReductionB: int = Field(ge=20, le=59, title="Gain Reduction (Surveillance)", description="20-59 dB, higher=less gain")
-    device_lnaState: int = Field(ge=1, le=9, title="LNA State", description="1=max gain, 9=min gain")
-    device_dabNotch: bool = Field(title="DAB Notch Filter")
-    device_rfNotch: bool = Field(title="RF Notch Filter")
+    device_agcSetPoint: int = Field(le=0, title="AGC Set Point", description="dBFS. Not recommended to be changed.")
+    device_gainReductionA: int = Field(ge=20, le=59, title="Reference Gain Reduction", description="20-59 dB, higher=less gain")
+    device_gainReductionB: int = Field(ge=20, le=59, title="Surveillance Gain Reduction", description="20-59 dB, higher=less gain")
+    device_lnaState: int = Field(ge=1, le=9, title="Low Noise Amplifier State", description="1=max gain, 9=min gain. RF attenuator block also used similarly to gain.")
+    device_dabNotch: bool = Field(title="DAB Notch Filter", description="Not recommended to enable unless you are sure.")
+    device_rfNotch: bool = Field(title="RF Notch Filter", description="Not recommended to enable unless you are sure.")
     device_bandwidthNumber: Literal[0, 5, 50, 100] = Field(
         title="Bandwidth Number",
         description="AGC loop bandwidth (Hz). 0 disables AGC — gain is fixed by Gain Reduction/LNA State. "
@@ -152,10 +156,10 @@ class LocationFormConfig(BaseModel):
 class AdsbTruthConfig(BaseModel):
     """ADS-B ground truth matching settings (flat for form display)."""
     enabled: bool = Field(title="Enabled")
-    tar1090: str = Field(title="tar1090 Server")
-    adsb2dd: str = Field(title="adsb2dd Address")
-    delay_tolerance: float = Field(gt=0, title="Delay Tolerance")
-    doppler_tolerance: float = Field(gt=0, title="Doppler Tolerance")
+    tar1090: str = Field(title="tar1090 Server", description="Used to access ADSB data")
+    adsb2dd: str = Field(title="adsb2dd Address", description="Local URL to view your local ADSB data")
+    delay_tolerance: float = Field(gt=0, title="Delay Tolerance", description="km. Maximum bistatic range error allowed when matching a radar detection to an ADS-B aircraft position.")
+    doppler_tolerance: float = Field(gt=0, title="Doppler Tolerance", description="Hz. Maximum bistatic Doppler error allowed when matching a radar detection to an ADS-B aircraft position.")
 
 
 # ============================================================================

--- a/templates/config.html
+++ b/templates/config.html
@@ -285,7 +285,7 @@
         <section id="ssh" class="cfg-section" style="margin-top:12px;">
             <div class="cfg-section-head">
                 <h2>SSH access</h2>
-                <span class="desc">Public keys allowed to SSH into this node.</span>
+                <span class="desc">Public keys allowed to SSH into this node. To add SSH keys for use, please review the related GitHub file: <a href="https://github.com/offworldlabs/owl-os/blob/main/ssh_pub_keys/README.txt" target="_blank" rel="noopener">owl-os/ssh_pub_keys/README.txt</a></span>
             </div>
             <div class="cfg-body">
                 <form action="/ssh-keys" method="post">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def sample_merged_config():
     """
     return {
         'capture': {
-            'fs': 4000000,
+            'fs': 2000000,
             'fc': 503000000,
             'device': {
                 'type': 'RspDuo',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -129,7 +129,7 @@ class TestConfigPageRoute:
         """Capture values from user.yml should appear."""
         response = app_client.get('/config')
         assert response.status_code == 200
-        assert b'4000000' in response.data  # fs value
+        assert b'value="2000000" selected' in response.data  # fs value (select)
         assert b'503000000' in response.data  # fc value
         assert b'RspDuo' in response.data  # device type
 
@@ -187,7 +187,7 @@ class TestConfigSaveRoute:
     def test_save_valid_config(self, app_client, user_config_file):
         """Valid config should be saved to user.yml."""
         response = app_client.post('/config/save', data={
-            'capture.fs': '5000000',
+            'capture.fs': '1000000',
             'capture.fc': '500000000',
             'capture.device_type': 'RspDuo',
             'capture.device_agcSetPoint': '-40',
@@ -205,7 +205,7 @@ class TestConfigSaveRoute:
         # Check file was updated
         with open(user_config_file) as f:
             saved = yaml.safe_load(f)
-        assert saved['capture']['fs'] == 5000000
+        assert saved['capture']['fs'] == 1000000
         assert saved['capture']['fc'] == 500000000
         assert saved['capture']['device']['gainReduction'] == [35, 30]
         assert saved['capture']['device']['lnaState'] == 5
@@ -213,7 +213,7 @@ class TestConfigSaveRoute:
     def test_save_unchecked_checkbox(self, app_client, user_config_file):
         """Unchecked checkboxes should be saved as False."""
         response = app_client.post('/config/save', data={
-            'capture.fs': '4000000',
+            'capture.fs': '2000000',
             'capture.fc': '503000000',
             'capture.device_type': 'RspDuo',
             'capture.device_agcSetPoint': '-50',
@@ -234,7 +234,7 @@ class TestConfigSaveRoute:
     def test_save_invalid_gain_reduction(self, app_client):
         """Invalid gain reduction should show validation error."""
         response = app_client.post('/config/save', data={
-            'capture.fs': '4000000',
+            'capture.fs': '2000000',
             'capture.fc': '503000000',
             'capture.device_type': 'RspDuo',
             'capture.device_agcSetPoint': '-50',
@@ -254,7 +254,7 @@ class TestConfigSaveRoute:
     def test_save_invalid_lna_state(self, app_client):
         """Invalid LNA state should show validation error."""
         response = app_client.post('/config/save', data={
-            'capture.fs': '4000000',
+            'capture.fs': '2000000',
             'capture.fc': '503000000',
             'capture.device_type': 'RspDuo',
             'capture.device_agcSetPoint': '-50',
@@ -273,7 +273,7 @@ class TestConfigSaveRoute:
     def test_save_invalid_agc_set_point(self, app_client):
         """Positive AGC set point should show validation error."""
         response = app_client.post('/config/save', data={
-            'capture.fs': '4000000',
+            'capture.fs': '2000000',
             'capture.fc': '503000000',
             'capture.device_type': 'RspDuo',
             'capture.device_agcSetPoint': '10',  # Invalid: > 0
@@ -299,7 +299,7 @@ class TestConfigSaveRoute:
 
         # Save capture config
         response = app_client.post('/config/save', data={
-            'capture.fs': '6000000',
+            'capture.fs': '500000',
             'capture.fc': '503000000',
             'capture.device_type': 'RspDuo',
             'capture.device_agcSetPoint': '-50',
@@ -318,7 +318,7 @@ class TestConfigSaveRoute:
         # Other section should still exist
         assert saved.get('other_section') == {'foo': 'bar'}
         # Capture should be updated
-        assert saved['capture']['fs'] == 6000000
+        assert saved['capture']['fs'] == 500000
 
 
 class TestLocationSave:
@@ -625,14 +625,14 @@ class TestParseFlatFormData:
         from config_manager import ConfigManager
 
         capture, location, truth, tar1090 = ConfigManager.parse_flat_form_data({
-            'capture.fs': '4000000',
+            'capture.fs': '2000000',
             'capture.fc': '503000000',
             'capture.device_type': 'RspDuo',
             'capture.device_gainReductionA': '40',
             'capture.device_gainReductionB': '35'
         })
 
-        assert capture['fs'] == 4000000
+        assert capture['fs'] == 2000000
         assert capture['fc'] == 503000000
         assert capture['device_type'] == 'RspDuo'
         assert capture['device_gainReductionA'] == 40

--- a/tests/test_form_utils.py
+++ b/tests/test_form_utils.py
@@ -80,7 +80,7 @@ class TestSchemaToFormFields:
     def test_basic_field_conversion(self):
         """Test basic field properties are converted."""
         values = {
-            'fs': 4000000,
+            'fs': 2000000,
             'fc': 503000000,
             'device_type': 'RspDuo',
             'device_agcSetPoint': -50,
@@ -96,17 +96,17 @@ class TestSchemaToFormFields:
         # Should have all flat fields
         assert len(fields) == 10
 
-        # Check fs field
+        # Check fs field (Literal -> select with fixed options)
         fs_field = next(f for f in fields if f['name'] == 'fs')
         assert fs_field['title'] == 'Sample Rate'
-        assert fs_field['type'] == 'number'
-        assert fs_field['value'] == 4000000
-        assert fs_field['description'] == 'Hz'
+        assert fs_field['type'] == 'select'
+        assert fs_field['value'] == 2000000
+        assert fs_field['options'] == [62500, 125000, 250000, 500000, 1000000, 2000000]
 
     def test_checkbox_field(self):
         """Boolean fields should be checkboxes."""
         values = {
-            'fs': 4000000,
+            'fs': 2000000,
             'fc': 503000000,
             'device_type': 'RspDuo',
             'device_agcSetPoint': -50,
@@ -139,7 +139,7 @@ class TestSchemaToFormFields:
     def test_values_from_dict_not_defaults(self):
         """Values should come from provided dict, not schema defaults."""
         values = {
-            'fs': 8000000,  # Different from typical default
+            'fs': 1000000,  # Different from typical default
             'fc': 100000000,
             'device_type': 'CustomDevice',
             'device_agcSetPoint': -30,
@@ -153,7 +153,7 @@ class TestSchemaToFormFields:
         fields = schema_to_form_fields(CaptureFormConfig, values)
 
         fs_field = next(f for f in fields if f['name'] == 'fs')
-        assert fs_field['value'] == 8000000
+        assert fs_field['value'] == 1000000
 
         type_field = next(f for f in fields if f['name'] == 'device_type')
         assert type_field['value'] == 'CustomDevice'
@@ -169,13 +169,13 @@ class TestSchemaToFormFields:
     def test_partial_values(self):
         """Partial values should work."""
         values = {
-            'fs': 4000000,
+            'fs': 2000000,
             # Missing other fields
         }
         fields = schema_to_form_fields(CaptureFormConfig, values)
 
         fs_field = next(f for f in fields if f['name'] == 'fs')
-        assert fs_field['value'] == 4000000
+        assert fs_field['value'] == 2000000
 
         fc_field = next(f for f in fields if f['name'] == 'fc')
         assert fc_field['value'] is None
@@ -230,7 +230,7 @@ class TestSchemaToFormFields:
 
     def test_readonly_field(self):
         """Fields with readonly=True should have readonly in output."""
-        values = {'fs': 4000000, 'device_type': 'RspDuo'}
+        values = {'fs': 2000000, 'device_type': 'RspDuo'}
         fields = schema_to_form_fields(CaptureFormConfig, values)
 
         # device_type has readonly=True in schema


### PR DESCRIPTION
Capture section
Sample Rate (fs): converted from a free-text number input to a constrained dropdown of the six values the RSPduo hardware actually supports (62,500 / 125,000 / 250,000 / 500,000 / 1,000,000 / 2,000,000 Hz). Previously any integer was accepted, including values that would crash the radar service on startup. Description now explains the trade-off in plain terms: higher = sharper range detail (2,000,000 recommended), lower = less processing load.
Center Frequency: added guidance that this should be set based on the chosen tower.
AGC Set Point: added a caution that it's not recommended to change.
Gain Reduction (Reference) → renamed Reference Gain Reduction.
Gain Reduction (Surveillance) → renamed Surveillance Gain Reduction.
LNA State → renamed Low Noise Amplifier State, with an added note that the RF attenuator block serves a similar gain-control purpose.
DAB Notch Filter and RF Notch Filter: both now carry a caution that enabling is not recommended unless the user is sure.

ADS-B truth section — four fields that previously had no help text now do:
tar1090 Server: "Used to access ADSB data"
adsb2dd Address: "Local URL to view your local ADSB data"
Delay Tolerance: now documents units and meaning (km; max bistatic range error for matching a detection to an ADS-B position)
Doppler Tolerance: likewise (Hz; max bistatic Doppler error for matching)

SSH access section — subtitle now links out to owl-os/ssh_pub_keys/README.txt on GitHub with instructions for adding keys.

Test values for fs spanned beyond 2MHz so have been amended.