### PR TITLE
20260707 - Link Max-Hold and Controller views on the home dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -110,7 +110,39 @@
                         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h7v7"/><path d="M21 3l-9 9"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>
                     </span>
                 </div>
-                <div class="svc-desc">Delay-Doppler radar display.</div>
+                <div class="svc-desc">Live radar data.</div>
+            </a>
+            <a class="svc-card" href="#" data-port="49152" data-path="/display/maxhold" target="_blank">
+                <div class="svc-head">
+                    <div class="svc-icon">
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M4 18 L12 5 L20 18"/>
+                            <path d="M4 18 L20 18" opacity=".35" stroke-dasharray="2 2"/>
+                            <circle cx="4" cy="18" r="1.8" fill="currentColor" stroke="none"/>
+                            <circle cx="20" cy="18" r="1.8" fill="currentColor" stroke="none"/>
+                        </svg>
+                    </div>
+                    <div class="svc-name">Max-Hold</div>
+                    <span class="svc-arrow">
+                        <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h7v7"/><path d="M21 3l-9 9"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>
+                    </span>
+                </div>
+                <div class="svc-desc">~10s rolling peak-hold view.</div>
+            </a>
+            <a class="svc-card" href="#" data-port="49152" data-path="/controller/" target="_blank">
+                <div class="svc-head">
+                    <div class="svc-icon">
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="3" y="4" width="18" height="12" rx="2"/>
+                            <path d="M8 20h8M12 16v4"/>
+                        </svg>
+                    </div>
+                    <div class="svc-name">Controller</div>
+                    <span class="svc-arrow">
+                        <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h7v7"/><path d="M21 3l-9 9"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>
+                    </span>
+                </div>
+                <div class="svc-desc">All available views and data.</div>
             </a>
             <a class="svc-card" href="#" data-port="8078" target="_blank">
                 <div class="svc-head">
@@ -168,7 +200,7 @@
 {% block scripts %}
 <script>
 document.querySelectorAll('.svc-card[data-port]').forEach(function(el) {
-    el.href = 'http://' + window.location.hostname + ':' + el.dataset.port;
+    el.href = 'http://' + window.location.hostname + ':' + el.dataset.port + (el.dataset.path || '');
 });
 </script>
 {% if mode == 'spectrum' %}


### PR DESCRIPTION
Add service cards for blah2's Max-Hold (/display/maxhold) and Controller (/controller/) pages, which already ship on the backend but weren't surfaced from the GUI home page. Extend the anchor-rewriting script to append an optional data-path so a card can target a sub-path on a service's port instead of only the bare host:port. Reword the radar card's description for consistency with the new cards.