### PR TITLE
20260708 - Add Retina Dashboard link to nav bar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,10 @@
             <a class="nav-tab{% if active_page == 'config' %} active{% endif %}" href="/config">Config</a>
         </div>
         <div class="nav-spacer"></div>
+        <a class="ds-btn ghost sm" href="https://dash.retina.fm" target="_blank" rel="noopener">
+            <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h7v7"/><path d="M21 3l-9 9"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>
+            Retina Dashboard
+        </a>
     </nav>
     {% endblock %}
 


### PR DESCRIPTION
Add a button in the top nav (base.html) linking out to the hosted fleet dashboard at https://dash.retina.fm, opening in a new tab. Placed after nav-spacer so it sits at the top-right on every page, reusing the existing ds-btn ghost styling and external-link icon.