### PR TITLE
20260717 tower selection config

### DIFF
--- a/src/device_state.py
+++ b/src/device_state.py
@@ -361,6 +361,28 @@ class DeviceState:
             "towers": towers,
         })
 
+    def add_tower_to_cache(self, tower: dict):
+        """Append a manually-entered tower to the cache, creating it if none
+        exists yet (e.g. the wizard's location step was never run)."""
+        data = self.get_towers_cache() or {"lat": None, "lon": None, "towers": []}
+        data["towers"] = (data.get("towers") or []) + [tower]
+        data["cached_at"] = datetime.now().isoformat()
+        self._write_towers_cache(data)
+
+    def remove_tower_from_cache(self, index: int) -> bool:
+        """Remove a tower by its position in the cached list.
+
+        Returns False if there's no cache or the index is out of range.
+        """
+        data = self.get_towers_cache()
+        towers = (data or {}).get("towers") or []
+        if not data or not (0 <= index < len(towers)):
+            return False
+        towers.pop(index)
+        data["cached_at"] = datetime.now().isoformat()
+        self._write_towers_cache(data)
+        return True
+
     def _write_towers_cache(self, data: dict):
         os.makedirs(os.path.dirname(self.towers_cache_file), exist_ok=True)
         with open(self.towers_cache_file, "w") as f:

--- a/src/device_state.py
+++ b/src/device_state.py
@@ -47,6 +47,7 @@ class DeviceState:
         self.mender_conf_backup_path = mender_conf_backup_path
         self.setup_wizard_file = os.path.join(data_dir, "setup-wizard.json")
         self.setup_wizard_completed_flag = os.path.join(data_dir, "setup-wizard-completed")
+        self.towers_cache_file = os.path.join(data_dir, "towers-cache.json")
         self.dev_mode = dev_mode
 
     # ── State Queries ──────────────────────────────────────────
@@ -345,6 +346,35 @@ class DeviceState:
         """Clear wizard state (called on completion)."""
         if os.path.exists(self.setup_wizard_file):
             os.remove(self.setup_wizard_file)
+
+    def save_towers_cache(self, lat: float, lon: float, towers: list):
+        """Cache the wizard's tower-finder search results.
+
+        No expiry: broadcast tower frequencies/locations essentially never
+        change, and a re-run of the wizard's tower step just overwrites this
+        file with a fresh search.
+        """
+        self._write_towers_cache({
+            "lat": lat,
+            "lon": lon,
+            "cached_at": datetime.now().isoformat(),
+            "towers": towers,
+        })
+
+    def _write_towers_cache(self, data: dict):
+        os.makedirs(os.path.dirname(self.towers_cache_file), exist_ok=True)
+        with open(self.towers_cache_file, "w") as f:
+            json.dump(data, f)
+
+    def get_towers_cache(self) -> dict | None:
+        """Get the cached tower search results, or None if never cached."""
+        if not os.path.exists(self.towers_cache_file):
+            return None
+        try:
+            with open(self.towers_cache_file) as f:
+                return json.load(f)
+        except Exception:
+            return None
 
     def has_completed_setup_wizard(self) -> bool:
         """Whether the wizard has ever been completed on this device.

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -22,7 +22,7 @@ def _check_wizard_not_active():
 @bp.route("/config")
 def config_page():
     """Configuration page with all settings."""
-    from app import config_mgr, ssh_keys, DEV_MODE
+    from app import config_mgr, ssh_keys, DEV_MODE, device_state
 
     config = config_mgr.load_merged_config()
     retina_installed = config_mgr.is_retina_node_installed() or DEV_MODE or request.args.get('demo') == '1'
@@ -45,6 +45,7 @@ def config_page():
                            location_fields=location_fields,
                            truth_fields=truth_fields,
                            tar1090_fields=tar1090_fields,
+                           towers_cache=device_state.get_towers_cache(),
                            ssh_keys=ssh_keys.get_keys())
 
 
@@ -104,13 +105,14 @@ def save_config():
             all_errors.update(ConfigManager.format_validation_errors(e, 'tar1090'))
 
     if all_errors:
-        from app import ssh_keys, DEV_MODE
+        from app import ssh_keys, DEV_MODE, device_state
         return render_template("config.html",
                                retina_installed=config_mgr.is_retina_node_installed() or DEV_MODE or request.args.get('demo') == '1',
                                capture_fields=schema_to_form_fields(CaptureFormConfig, capture_flat),
                                location_fields=schema_to_form_fields(LocationFormConfig, location_flat),
                                truth_fields=schema_to_form_fields(AdsbTruthConfig, truth_data),
                                tar1090_fields=schema_to_form_fields(Tar1090Config, tar1090_data),
+                               towers_cache=device_state.get_towers_cache(),
                                config_errors=all_errors,
                                ssh_keys=ssh_keys.get_keys())
 

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -8,6 +8,12 @@ from config_manager import ConfigManager
 
 bp = Blueprint('towers', __name__, url_prefix='/towers')
 
+# The tower-finder API already ranks results best-first (signal match, or
+# geography if no measurements); the wizard's own map/table can show all of
+# them, but the cache backing /config's Tower preset picker only needs the
+# best few — capping here keeps that dropdown/manage-list usable.
+MAX_CACHED_TOWERS = 5
+
 
 @bp.route("/search", methods=["POST"])
 def search():
@@ -65,7 +71,7 @@ def search():
         towers = result.get("towers") or []
         if towers:
             try:
-                device_state.save_towers_cache(body["lat"], body["lon"], towers)
+                device_state.save_towers_cache(body["lat"], body["lon"], towers[:MAX_CACHED_TOWERS])
             except Exception as e:
                 app.logger.warning(f"Failed to cache tower search results: {e}")
         return jsonify(result)

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -12,7 +12,7 @@ bp = Blueprint('towers', __name__, url_prefix='/towers')
 @bp.route("/search", methods=["POST"])
 def search():
     """Proxy RF-profile tower search to Tower-Finder API."""
-    from app import app, TOWER_FINDER_URL
+    from app import app, TOWER_FINDER_URL, device_state
 
     body = request.get_json()
     if not body:
@@ -61,7 +61,14 @@ def search():
                 timeout=90,
             )
         resp.raise_for_status()
-        return jsonify(resp.json())
+        result = resp.json()
+        towers = result.get("towers") or []
+        if towers:
+            try:
+                device_state.save_towers_cache(body["lat"], body["lon"], towers)
+            except Exception as e:
+                app.logger.warning(f"Failed to cache tower search results: {e}")
+        return jsonify(result)
     except http_requests.Timeout:
         return jsonify({"error": "Tower search timed out — try again"}), 504
     except http_requests.RequestException as e:

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -79,6 +79,65 @@ def search():
         return jsonify({"error": "Tower search failed — check server logs"}), 500
 
 
+@bp.route("/cache/add", methods=["POST"])
+def cache_add():
+    """Manually add a tower to the cached tower-preset list."""
+    from app import device_state
+
+    body = request.get_json()
+    if not body:
+        return jsonify({"success": False, "error": "Missing JSON body"}), 400
+
+    callsign = (body.get("callsign") or "").strip()
+    try:
+        frequency_mhz = float(body.get("frequency_mhz"))
+        latitude = float(body.get("latitude"))
+        longitude = float(body.get("longitude"))
+        altitude_m = float(body.get("altitude_m") or 0)
+    except (TypeError, ValueError):
+        return jsonify({"success": False, "error": "Frequency, latitude, longitude, and altitude must be numbers"}), 400
+
+    if not callsign:
+        return jsonify({"success": False, "error": "Name/callsign is required"}), 400
+    if not (-90 <= latitude <= 90):
+        return jsonify({"success": False, "error": "Latitude must be between -90 and 90"}), 400
+    if not (-180 <= longitude <= 180):
+        return jsonify({"success": False, "error": "Longitude must be between -180 and 180"}), 400
+
+    device_state.add_tower_to_cache({
+        "callsign": callsign,
+        "name": callsign,
+        "frequency_mhz": frequency_mhz,
+        "latitude": latitude,
+        "longitude": longitude,
+        "altitude_m": altitude_m,
+        "source": "manual",
+    })
+    cache = device_state.get_towers_cache()
+    return jsonify({"success": True, "towers": cache["towers"], "cached_at": cache["cached_at"]})
+
+
+@bp.route("/cache/remove", methods=["POST"])
+def cache_remove():
+    """Remove a tower from the cached tower-preset list by its position."""
+    from app import device_state
+
+    body = request.get_json()
+    if not body or body.get("index") is None:
+        return jsonify({"success": False, "error": "Missing index"}), 400
+
+    try:
+        index = int(body["index"])
+    except (TypeError, ValueError):
+        return jsonify({"success": False, "error": "index must be an integer"}), 400
+
+    if not device_state.remove_tower_from_cache(index):
+        return jsonify({"success": False, "error": "Tower not found"}), 404
+
+    cache = device_state.get_towers_cache() or {}
+    return jsonify({"success": True, "towers": cache.get("towers", []), "cached_at": cache.get("cached_at")})
+
+
 @bp.route("/spectrum/events")
 def spectrum_events():
     """Proxy SSE stream from retina-spectrum."""

--- a/static/common.css
+++ b/static/common.css
@@ -824,6 +824,13 @@ h1, h2, h3, h4, h5, h6 {
 .ssh-key  { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3);
             white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
+/* Manage-list row matching the form's current transmitter (see Tower section JS) */
+#towerManageList .ssh-item.selected {
+    background: var(--accent-soft);
+    border-color: var(--accent-edge);
+    box-shadow: inset 3px 0 0 var(--accent);
+}
+
 /* Sticky save bar */
 .savebar {
     position: sticky; bottom: 0;

--- a/templates/config.html
+++ b/templates/config.html
@@ -147,22 +147,22 @@
         </section>
 
         {# ── Tower ── #}
+        {% set towers = towers_cache.towers if towers_cache else [] %}
         <section id="tower" class="cfg-section">
             <div class="cfg-section-head">
                 <h2>Tower</h2>
-                <span class="desc">Pick a broadcast tower from your setup wizard's search results — updates the transmitter location and center frequency below.</span>
+                <span class="desc">Pick a broadcast tower from your setup wizard's search results — updates the transmitter location and center frequency below. Add or remove towers from this cached list manually.</span>
             </div>
             <div class="cfg-body" {% if not retina_installed %}style="opacity:.5;pointer-events:none;"{% endif %}>
-                {% if towers_cache and towers_cache.towers %}
-                <div class="cfg-row" style="padding:0;border:0;">
+                <div class="cfg-row" id="towerPresetRow" style="padding:0;border:0;{% if not towers %}display:none;{% endif %}">
                     <div class="label-col">
                         <label for="towerPresetSelect">Tower preset</label>
-                        <span class="help">From your setup wizard's tower search{% if towers_cache.cached_at %} (cached {{ towers_cache.cached_at[:10] }}){% endif %}.</span>
+                        <span class="help" id="towerPresetHelp">{% if towers_cache and towers_cache.cached_at %}From your setup wizard's tower search (cached {{ towers_cache.cached_at[:10] }}).{% endif %}</span>
                     </div>
                     <div>
                         <select id="towerPresetSelect" class="ds-input">
                             <option value="">Select a tower…</option>
-                            {% for tower in towers_cache.towers %}
+                            {% for tower in towers %}
                             <option value="{{ loop.index0 }}"
                                     data-callsign="{{ tower.get('callsign') or '' }}"
                                     data-name="{{ tower.get('name') or '' }}"
@@ -174,9 +174,27 @@
                         </select>
                     </div>
                 </div>
-                {% else %}
-                <div class="help">No cached tower search results yet. Run the Location step of the Setup Wizard to search for towers near you — results are cached here automatically.</div>
-                {% endif %}
+                <div class="help" id="towerEmptyMsg" {% if towers %}style="display:none;"{% endif %}>No cached tower search results yet. Run the Location step of the Setup Wizard to search for towers near you, or add one manually below.</div>
+
+                <div class="divider"></div>
+
+                <div class="ds-label-micro" style="margin-bottom:10px;">Manage cached towers</div>
+                <div class="ssh-list" id="towerManageList">
+                    {% for tower in towers %}
+                    <div class="ssh-item" data-index="{{ loop.index0 }}">
+                        <div class="ssh-meta">
+                            <div class="ssh-key">{{ tower.get('callsign') or tower.get('name') or 'Tower' }} — {{ tower.get('frequency_mhz') }} MHz</div>
+                        </div>
+                        <button type="button" class="ds-btn danger-ghost sm tower-remove-btn" data-index="{{ loop.index0 }}">Remove</button>
+                    </div>
+                    {% endfor %}
+                </div>
+
+                <button type="button" class="ds-btn ghost" style="margin-top:12px;" data-bs-toggle="modal" data-bs-target="#addTowerModal">
+                    <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M12 5v14M5 12h14"></path></svg>
+                    Add tower
+                </button>
+                <div id="towerManageError" style="font-size:13px;color:var(--danger);display:none;margin-top:8px;"></div>
             </div>
         </section>
 
@@ -474,6 +492,47 @@
     </main>
 </div>
 
+{# Bootstrap modal for manually adding a cached tower #}
+<div class="modal fade" id="addTowerModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="addTowerForm">
+                <div class="modal-header">
+                    <h5 class="modal-title">Add Tower</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="cfg-row" style="padding:0;border:0;">
+                        <div class="label-col"><label for="towerAddCallsign">Name / Callsign</label></div>
+                        <div><input type="text" id="towerAddCallsign" name="callsign" class="ds-input" required></div>
+                    </div>
+                    <div class="cfg-row" style="padding:0;border:0;">
+                        <div class="label-col"><label for="towerAddFrequency">Frequency</label><span class="help">MHz</span></div>
+                        <div><input type="number" id="towerAddFrequency" name="frequency_mhz" class="ds-input mono" step="any" min="0" required></div>
+                    </div>
+                    <div class="cfg-row" style="padding:0;border:0;">
+                        <div class="label-col"><label for="towerAddLatitude">Latitude</label><span class="help">decimal degrees</span></div>
+                        <div><input type="number" id="towerAddLatitude" name="latitude" class="ds-input mono" step="any" min="-90" max="90" required></div>
+                    </div>
+                    <div class="cfg-row" style="padding:0;border:0;">
+                        <div class="label-col"><label for="towerAddLongitude">Longitude</label><span class="help">decimal degrees</span></div>
+                        <div><input type="number" id="towerAddLongitude" name="longitude" class="ds-input mono" step="any" min="-180" max="180" required></div>
+                    </div>
+                    <div class="cfg-row" style="padding:0;border:0;">
+                        <div class="label-col"><label for="towerAddAltitude">Altitude</label><span class="help">meters</span></div>
+                        <div><input type="number" id="towerAddAltitude" name="altitude_m" class="ds-input mono" step="any" value="0"></div>
+                    </div>
+                    <div id="towerAddError" style="font-size:13px;color:var(--danger);display:none;margin-top:8px;"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="ds-btn ghost" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="ds-btn primary">Add tower</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 {# Bootstrap modal for cloud services disable confirmation #}
 <div class="modal fade" id="disableCloudModal" tabindex="-1">
     <div class="modal-dialog">
@@ -573,11 +632,67 @@
     }
 })();
 
-// Tower preset — fills in Location (transmitter) + Capture (center frequency) from a cached search result
+// Tower — preset select fills in Location (transmitter) + Capture (center frequency).
+// Manage list add/remove persists straight to the cache file, independent of the
+// staged config form below (same "takes effect immediately" model as SSH keys).
 (function() {
-    var select = document.getElementById('towerPresetSelect');
-    if (!select) return;
-    var form = document.getElementById('configForm');
+    var presetSelect = document.getElementById('towerPresetSelect');
+    if (!presetSelect) return;
+
+    var csrf         = document.querySelector('meta[name="csrf-token"]').content;
+    var form         = document.getElementById('configForm');
+    var presetRow    = document.getElementById('towerPresetRow');
+    var presetHelp   = document.getElementById('towerPresetHelp');
+    var emptyMsg     = document.getElementById('towerEmptyMsg');
+    var manageList   = document.getElementById('towerManageList');
+    var manageError  = document.getElementById('towerManageError');
+    var addModalEl   = document.getElementById('addTowerModal');
+    var addForm      = document.getElementById('addTowerForm');
+    var addError     = document.getElementById('towerAddError');
+
+    function esc(s) {
+        var d = document.createElement('div');
+        d.textContent = s == null ? '' : String(s);
+        return d.innerHTML;
+    }
+
+    function towerLabel(t) {
+        var label = esc(t.callsign || t.name || 'Tower') + ' — ' + esc(t.frequency_mhz) + ' MHz';
+        if (t.distance_km !== undefined && t.distance_km !== null) {
+            label += ' (' + esc(t.distance_km) + ' km' + (t.distance_class ? ', ' + esc(t.distance_class) : '') + ')';
+        }
+        return label;
+    }
+
+    // Rebuild the preset dropdown + manage list from a fresh towers array —
+    // called after every successful add/remove so both stay in sync without a reload.
+    function renderTowers(towers, cachedAt) {
+        towers = towers || [];
+        presetRow.style.display = towers.length ? '' : 'none';
+        emptyMsg.style.display = towers.length ? 'none' : '';
+        if (cachedAt) {
+            presetHelp.textContent = 'From your setup wizard\'s tower search (cached ' + cachedAt.slice(0, 10) + ').';
+        }
+
+        presetSelect.innerHTML = '<option value="">Select a tower…</option>' + towers.map(function(t, i) {
+            return '<option value="' + i + '"' +
+                ' data-callsign="' + esc(t.callsign || '') + '"' +
+                ' data-name="' + esc(t.name || '') + '"' +
+                ' data-lat="' + esc(t.latitude != null ? t.latitude : '') + '"' +
+                ' data-lon="' + esc(t.longitude != null ? t.longitude : '') + '"' +
+                ' data-altitude="' + esc(t.altitude_m != null ? t.altitude_m : 0) + '"' +
+                ' data-frequency="' + esc(t.frequency_mhz != null ? t.frequency_mhz : '') + '">' +
+                towerLabel(t) + '</option>';
+        }).join('');
+
+        manageList.innerHTML = towers.map(function(t, i) {
+            var label = esc(t.callsign || t.name || 'Tower') + ' — ' + esc(t.frequency_mhz) + ' MHz';
+            return '<div class="ssh-item" data-index="' + i + '">' +
+                '<div class="ssh-meta"><div class="ssh-key">' + label + '</div></div>' +
+                '<button type="button" class="ds-btn danger-ghost sm tower-remove-btn" data-index="' + i + '">Remove</button>' +
+            '</div>';
+        }).join('');
+    }
 
     function setField(name, value) {
         var el = form.querySelector('[name="' + name + '"]');
@@ -587,8 +702,8 @@
         el.dispatchEvent(new Event('change', { bubbles: true }));
     }
 
-    select.addEventListener('change', function() {
-        var opt = select.options[select.selectedIndex];
+    presetSelect.addEventListener('change', function() {
+        var opt = presetSelect.options[presetSelect.selectedIndex];
         if (!opt || !opt.value) return;
 
         var name = opt.dataset.callsign || opt.dataset.name || 'Tower';
@@ -600,6 +715,82 @@
             setField('capture.fc', Math.round(parseFloat(opt.dataset.frequency) * 1000000));
         }
     });
+
+    manageList.addEventListener('click', function(e) {
+        var btn = e.target.closest('.tower-remove-btn');
+        if (!btn) return;
+        manageError.style.display = 'none';
+        btn.disabled = true;
+
+        fetch('/towers/cache/remove', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+            body: JSON.stringify({ index: parseInt(btn.dataset.index, 10) })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(d) {
+            if (d.success) {
+                renderTowers(d.towers, d.cached_at);
+            } else {
+                manageError.textContent = d.error || 'Failed to remove tower';
+                manageError.style.display = '';
+                btn.disabled = false;
+            }
+        })
+        .catch(function() {
+            manageError.textContent = 'Failed to reach the server — check your connection.';
+            manageError.style.display = '';
+            btn.disabled = false;
+        });
+    });
+
+    if (addForm) {
+        addForm.addEventListener('submit', function(e) {
+            e.preventDefault();
+            addError.style.display = 'none';
+            var submitBtn = addForm.querySelector('button[type="submit"]');
+            submitBtn.disabled = true;
+
+            var payload = {
+                callsign: document.getElementById('towerAddCallsign').value.trim(),
+                frequency_mhz: document.getElementById('towerAddFrequency').value,
+                latitude: document.getElementById('towerAddLatitude').value,
+                longitude: document.getElementById('towerAddLongitude').value,
+                altitude_m: document.getElementById('towerAddAltitude').value || 0,
+            };
+
+            fetch('/towers/cache/add', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+                body: JSON.stringify(payload)
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                submitBtn.disabled = false;
+                if (d.success) {
+                    renderTowers(d.towers, d.cached_at);
+                    addForm.reset();
+                    try {
+                        var modal = bootstrap.Modal.getInstance(addModalEl);
+                        if (modal) modal.hide();
+                    } catch (err) {}
+                } else {
+                    addError.textContent = d.error || 'Failed to add tower';
+                    addError.style.display = '';
+                }
+            })
+            .catch(function() {
+                submitBtn.disabled = false;
+                addError.textContent = 'Failed to reach the server — check your connection.';
+                addError.style.display = '';
+            });
+        });
+
+        addModalEl.addEventListener('hidden.bs.modal', function() {
+            addForm.reset();
+            addError.style.display = 'none';
+        });
+    }
 })();
 
 // Network panel — status, scan, manual entry toggle, connect + poll

--- a/templates/config.html
+++ b/templates/config.html
@@ -181,7 +181,10 @@
                 <div class="ds-label-micro" style="margin-bottom:10px;">Manage cached towers</div>
                 <div class="ssh-list" id="towerManageList">
                     {% for tower in towers %}
-                    <div class="ssh-item" data-index="{{ loop.index0 }}">
+                    <div class="ssh-item" data-index="{{ loop.index0 }}"
+                         data-lat="{{ tower.get('latitude') if tower.get('latitude') is not none else '' }}"
+                         data-lon="{{ tower.get('longitude') if tower.get('longitude') is not none else '' }}"
+                         data-frequency="{{ tower.get('frequency_mhz') if tower.get('frequency_mhz') is not none else '' }}">
                         <div class="ssh-meta">
                             <div class="ssh-key">{{ tower.get('callsign') or tower.get('name') or 'Tower' }} — {{ tower.get('frequency_mhz') }} MHz</div>
                         </div>
@@ -687,11 +690,40 @@
 
         manageList.innerHTML = towers.map(function(t, i) {
             var label = esc(t.callsign || t.name || 'Tower') + ' — ' + esc(t.frequency_mhz) + ' MHz';
-            return '<div class="ssh-item" data-index="' + i + '">' +
+            return '<div class="ssh-item" data-index="' + i + '"' +
+                ' data-lat="' + esc(t.latitude != null ? t.latitude : '') + '"' +
+                ' data-lon="' + esc(t.longitude != null ? t.longitude : '') + '"' +
+                ' data-frequency="' + esc(t.frequency_mhz != null ? t.frequency_mhz : '') + '">' +
                 '<div class="ssh-meta"><div class="ssh-key">' + label + '</div></div>' +
                 '<button type="button" class="ds-btn danger-ghost sm tower-remove-btn" data-index="' + i + '">Remove</button>' +
             '</div>';
         }).join('');
+        updateSelectedHighlight();
+    }
+
+    // Highlights whichever manage-list row's lat/lon/frequency matches the
+    // form's current transmitter fields — kept live so it tracks preset
+    // picks, manual edits, and add/remove without a reload.
+    function floatsMatch(a, b) {
+        return Number.isFinite(a) && Number.isFinite(b) && Math.abs(a - b) < 1e-5;
+    }
+
+    function updateSelectedHighlight() {
+        var latEl = form.querySelector('[name="location.tx_latitude"]');
+        var lonEl = form.querySelector('[name="location.tx_longitude"]');
+        var fcEl = form.querySelector('[name="capture.fc"]');
+        var txLat = latEl ? parseFloat(latEl.value) : NaN;
+        var txLon = lonEl ? parseFloat(lonEl.value) : NaN;
+        var fc = fcEl ? parseInt(fcEl.value, 10) : NaN;
+
+        manageList.querySelectorAll('.ssh-item').forEach(function(row) {
+            var rowFreq = parseFloat(row.dataset.frequency);
+            var rowFc = Number.isFinite(rowFreq) ? Math.round(rowFreq * 1000000) : NaN;
+            var isSelected = floatsMatch(parseFloat(row.dataset.lat), txLat) &&
+                              floatsMatch(parseFloat(row.dataset.lon), txLon) &&
+                              Number.isFinite(rowFc) && rowFc === fc;
+            row.classList.toggle('selected', isSelected);
+        });
     }
 
     function setField(name, value) {
@@ -791,6 +823,15 @@
             addError.style.display = 'none';
         });
     }
+
+    // Keep the highlight live for hand-edits too, not just preset picks —
+    // setField() above already fires these same events, so this one
+    // listener set covers both paths.
+    ['location.tx_latitude', 'location.tx_longitude', 'capture.fc'].forEach(function(name) {
+        var el = form.querySelector('[name="' + name + '"]');
+        if (el) el.addEventListener('input', updateSelectedHighlight);
+    });
+    updateSelectedHighlight();
 })();
 
 // Network panel — status, scan, manual entry toggle, connect + poll

--- a/templates/config.html
+++ b/templates/config.html
@@ -87,6 +87,7 @@
         <h3>Node</h3>
         <a href="#mode">Mode</a>
         <h3>Radar</h3>
+        <a href="#tower">Tower</a>
         <a href="#location">Location</a>
         <a href="#capture">Capture</a>
         <a href="#truth">ADS-B truth</a>
@@ -142,6 +143,40 @@
                     <span class="spinner-border spinner-border-sm" id="modeSpinner" style="display:none;width:.9em;height:.9em;border-width:1.5px;flex-shrink:0;"></span>
                 </div>
                 <div id="modeErrorMsg" style="font-size:13px;color:var(--danger);display:none;margin-top:6px;"></div>
+            </div>
+        </section>
+
+        {# ── Tower ── #}
+        <section id="tower" class="cfg-section">
+            <div class="cfg-section-head">
+                <h2>Tower</h2>
+                <span class="desc">Pick a broadcast tower from your setup wizard's search results — updates the transmitter location and center frequency below.</span>
+            </div>
+            <div class="cfg-body" {% if not retina_installed %}style="opacity:.5;pointer-events:none;"{% endif %}>
+                {% if towers_cache and towers_cache.towers %}
+                <div class="cfg-row" style="padding:0;border:0;">
+                    <div class="label-col">
+                        <label for="towerPresetSelect">Tower preset</label>
+                        <span class="help">From your setup wizard's tower search{% if towers_cache.cached_at %} (cached {{ towers_cache.cached_at[:10] }}){% endif %}.</span>
+                    </div>
+                    <div>
+                        <select id="towerPresetSelect" class="ds-input">
+                            <option value="">Select a tower…</option>
+                            {% for tower in towers_cache.towers %}
+                            <option value="{{ loop.index0 }}"
+                                    data-callsign="{{ tower.get('callsign') or '' }}"
+                                    data-name="{{ tower.get('name') or '' }}"
+                                    data-lat="{{ tower.get('latitude') if tower.get('latitude') is not none else '' }}"
+                                    data-lon="{{ tower.get('longitude') if tower.get('longitude') is not none else '' }}"
+                                    data-altitude="{{ tower.get('altitude_m') if tower.get('altitude_m') is not none else 0 }}"
+                                    data-frequency="{{ tower.get('frequency_mhz') if tower.get('frequency_mhz') is not none else '' }}">{{ tower.get('callsign') or tower.get('name') or 'Tower' }} — {{ tower.get('frequency_mhz') }} MHz{% if tower.get('distance_km') is not none %} ({{ tower.get('distance_km') }} km{% if tower.get('distance_class') %}, {{ tower.get('distance_class') }}{% endif %}){% endif %}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                {% else %}
+                <div class="help">No cached tower search results yet. Run the Location step of the Setup Wizard to search for towers near you — results are cached here automatically.</div>
+                {% endif %}
             </div>
         </section>
 
@@ -538,6 +573,35 @@
     }
 })();
 
+// Tower preset — fills in Location (transmitter) + Capture (center frequency) from a cached search result
+(function() {
+    var select = document.getElementById('towerPresetSelect');
+    if (!select) return;
+    var form = document.getElementById('configForm');
+
+    function setField(name, value) {
+        var el = form.querySelector('[name="' + name + '"]');
+        if (!el) return;
+        el.value = value;
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    select.addEventListener('change', function() {
+        var opt = select.options[select.selectedIndex];
+        if (!opt || !opt.value) return;
+
+        var name = opt.dataset.callsign || opt.dataset.name || 'Tower';
+        setField('location.tx_name', name);
+        if (opt.dataset.lat) setField('location.tx_latitude', opt.dataset.lat);
+        if (opt.dataset.lon) setField('location.tx_longitude', opt.dataset.lon);
+        setField('location.tx_altitude', opt.dataset.altitude || 0);
+        if (opt.dataset.frequency) {
+            setField('capture.fc', Math.round(parseFloat(opt.dataset.frequency) * 1000000));
+        }
+    });
+})();
+
 // Network panel — status, scan, manual entry toggle, connect + poll
 (function() {
     var section = document.getElementById('network');
@@ -876,7 +940,7 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
 
 // Side-nav scrollspy
 (function() {
-    var sectionIds = ['mode','location','capture','truth','tar1090','ssh','cloud','wizard','network'];
+    var sectionIds = ['mode','tower','location','capture','truth','tar1090','ssh','cloud','wizard','network'];
     var links = {};
     sectionIds.forEach(function(id) {
         var a = document.querySelector('.side a[href="#' + id + '"]');

--- a/tests/test_device_state.py
+++ b/tests/test_device_state.py
@@ -367,3 +367,31 @@ class TestSetupWizardState:
         with open(ds.setup_wizard_file, "w") as f:
             f.write("not json")
         assert ds.get_setup_wizard_step() is None
+
+
+class TestTowersCache:
+    """Test the tower-preset cache populated by the wizard's tower search."""
+
+    def test_get_returns_none_when_never_cached(self, ds):
+        assert ds.get_towers_cache() is None
+
+    def test_save_and_get(self, ds):
+        ds.save_towers_cache(-33.8688, 151.2093, [{"callsign": "A", "frequency_mhz": 100.0}])
+        cache = ds.get_towers_cache()
+        assert cache["lat"] == -33.8688
+        assert cache["lon"] == 151.2093
+        assert cache["towers"] == [{"callsign": "A", "frequency_mhz": 100.0}]
+
+    def test_save_overwrites_previous_search(self, ds):
+        ds.save_towers_cache(1, 1, [{"callsign": "Old", "frequency_mhz": 1.0}])
+        ds.save_towers_cache(2, 2, [{"callsign": "New", "frequency_mhz": 2.0}])
+        cache = ds.get_towers_cache()
+        assert cache["lat"] == 2
+        assert len(cache["towers"]) == 1
+        assert cache["towers"][0]["callsign"] == "New"
+
+    def test_malformed_cache_file_treated_as_none(self, ds):
+        os.makedirs(os.path.dirname(ds.towers_cache_file), exist_ok=True)
+        with open(ds.towers_cache_file, "w") as f:
+            f.write("not json")
+        assert ds.get_towers_cache() is None

--- a/tests/test_device_state.py
+++ b/tests/test_device_state.py
@@ -370,7 +370,7 @@ class TestSetupWizardState:
 
 
 class TestTowersCache:
-    """Test the tower-preset cache populated by the wizard's tower search."""
+    """Test the tower-preset cache: search-populated, manually added/removed."""
 
     def test_get_returns_none_when_never_cached(self, ds):
         assert ds.get_towers_cache() is None
@@ -389,6 +389,36 @@ class TestTowersCache:
         assert cache["lat"] == 2
         assert len(cache["towers"]) == 1
         assert cache["towers"][0]["callsign"] == "New"
+
+    def test_add_tower_creates_cache_when_none_exists(self, ds):
+        ds.add_tower_to_cache({"callsign": "Manual", "frequency_mhz": 95.5})
+        cache = ds.get_towers_cache()
+        assert cache["towers"] == [{"callsign": "Manual", "frequency_mhz": 95.5}]
+        assert cache["lat"] is None
+
+    def test_add_tower_appends_to_existing_cache(self, ds):
+        ds.save_towers_cache(1, 1, [{"callsign": "A", "frequency_mhz": 100.0}])
+        ds.add_tower_to_cache({"callsign": "B", "frequency_mhz": 200.0})
+        towers = ds.get_towers_cache()["towers"]
+        assert [t["callsign"] for t in towers] == ["A", "B"]
+
+    def test_remove_tower_by_index(self, ds):
+        ds.save_towers_cache(1, 1, [
+            {"callsign": "A", "frequency_mhz": 100.0},
+            {"callsign": "B", "frequency_mhz": 200.0},
+        ])
+        removed = ds.remove_tower_from_cache(0)
+        assert removed is True
+        towers = ds.get_towers_cache()["towers"]
+        assert [t["callsign"] for t in towers] == ["B"]
+
+    def test_remove_tower_out_of_range_returns_false(self, ds):
+        ds.save_towers_cache(1, 1, [{"callsign": "A", "frequency_mhz": 100.0}])
+        assert ds.remove_tower_from_cache(5) is False
+        assert len(ds.get_towers_cache()["towers"]) == 1
+
+    def test_remove_tower_with_no_cache_returns_false(self, ds):
+        assert ds.remove_tower_from_cache(0) is False
 
     def test_malformed_cache_file_treated_as_none(self, ds):
         os.makedirs(os.path.dirname(ds.towers_cache_file), exist_ok=True)

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -111,6 +111,36 @@ class TestTowerSearch:
         assert forwarded['altitude'] == 50
         assert forwarded['source'] == 'us'
 
+    @patch('routes.towers.http_requests.get')
+    def test_search_caches_results(self, mock_get, app_client):
+        """A successful search with towers populates the device_state cache."""
+        import app as app_module
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = SAMPLE_TOWER_RESPONSE
+        mock_get.return_value = mock_resp
+
+        app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
+
+        cached = app_module.device_state.get_towers_cache()
+        assert cached is not None
+        assert cached['lat'] == -33.8688
+        assert cached['towers'][0]['callsign'] == 'ATN6'
+
+    @patch('routes.towers.http_requests.get')
+    def test_search_does_not_cache_empty_results(self, mock_get, app_client):
+        """An empty/no-towers response must not overwrite an existing cache
+        with nothing."""
+        import app as app_module
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"towers": [], "count": 0}
+        mock_get.return_value = mock_resp
+
+        app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
+
+        assert app_module.device_state.get_towers_cache() is None
+
 
 class TestTowerSelect:
     """Tests for POST /towers/select route."""

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -142,6 +142,100 @@ class TestTowerSearch:
         assert app_module.device_state.get_towers_cache() is None
 
 
+class TestTowerCacheAdd:
+    """Tests for POST /towers/cache/add route."""
+
+    def test_add_creates_cache_when_none_exists(self, app_client):
+        """Adding a tower manually works even if the wizard was never run."""
+        import app as app_module
+        assert app_module.device_state.get_towers_cache() is None
+
+        resp = app_client.post('/towers/cache/add', json={
+            'callsign': 'Manual FM', 'frequency_mhz': 95.5,
+            'latitude': -33.9, 'longitude': 151.2, 'altitude_m': 30,
+        })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is True
+        assert data['towers'] == [{
+            'callsign': 'Manual FM', 'name': 'Manual FM', 'frequency_mhz': 95.5,
+            'latitude': -33.9, 'longitude': 151.2, 'altitude_m': 30.0, 'source': 'manual',
+        }]
+
+    def test_add_appends_to_existing_cache(self, app_client):
+        import app as app_module
+        app_module.device_state.save_towers_cache(-33.8688, 151.2093, SAMPLE_TOWER_RESPONSE['towers'])
+
+        resp = app_client.post('/towers/cache/add', json={
+            'callsign': 'Manual FM', 'frequency_mhz': 95.5, 'latitude': -33.9, 'longitude': 151.2,
+        })
+
+        assert resp.status_code == 200
+        towers = resp.get_json()['towers']
+        assert len(towers) == 2
+        assert towers[0]['callsign'] == 'ATN6'
+        assert towers[1]['callsign'] == 'Manual FM'
+
+    def test_add_rejects_missing_callsign(self, app_client):
+        resp = app_client.post('/towers/cache/add', json={
+            'callsign': '', 'frequency_mhz': 95.5, 'latitude': -33.9, 'longitude': 151.2,
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()['success'] is False
+
+    def test_add_rejects_out_of_range_latitude(self, app_client):
+        resp = app_client.post('/towers/cache/add', json={
+            'callsign': 'Bad', 'frequency_mhz': 95.5, 'latitude': 999, 'longitude': 151.2,
+        })
+        assert resp.status_code == 400
+        assert 'Latitude' in resp.get_json()['error']
+
+    def test_add_rejects_non_numeric_frequency(self, app_client):
+        resp = app_client.post('/towers/cache/add', json={
+            'callsign': 'Bad', 'frequency_mhz': 'not-a-number', 'latitude': -33.9, 'longitude': 151.2,
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()['success'] is False
+
+
+class TestTowerCacheRemove:
+    """Tests for POST /towers/cache/remove route."""
+
+    def test_remove_by_index(self, app_client):
+        import app as app_module
+        app_module.device_state.save_towers_cache(-33.8688, 151.2093, [
+            {'callsign': 'A', 'frequency_mhz': 100.0},
+            {'callsign': 'B', 'frequency_mhz': 200.0},
+        ])
+
+        resp = app_client.post('/towers/cache/remove', json={'index': 0})
+
+        assert resp.status_code == 200
+        towers = resp.get_json()['towers']
+        assert len(towers) == 1
+        assert towers[0]['callsign'] == 'B'
+
+    def test_remove_out_of_range_index_fails(self, app_client):
+        import app as app_module
+        app_module.device_state.save_towers_cache(-33.8688, 151.2093, [
+            {'callsign': 'A', 'frequency_mhz': 100.0},
+        ])
+
+        resp = app_client.post('/towers/cache/remove', json={'index': 5})
+
+        assert resp.status_code == 404
+        assert resp.get_json()['success'] is False
+
+    def test_remove_with_no_cache_fails(self, app_client):
+        import app as app_module
+        assert app_module.device_state.get_towers_cache() is None
+
+        resp = app_client.post('/towers/cache/remove', json={'index': 0})
+
+        assert resp.status_code == 404
+
+
 class TestTowerSelect:
     """Tests for POST /towers/select route."""
 

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -141,6 +141,30 @@ class TestTowerSearch:
 
         assert app_module.device_state.get_towers_cache() is None
 
+    @patch('routes.towers.http_requests.get')
+    def test_search_caches_only_the_best_few(self, mock_get, app_client):
+        """The tower-finder can return dozens of results (its own default,
+        uncapped by the wizard's search request) — only the best
+        MAX_CACHED_TOWERS get cached, keeping /config's Tower picker usable.
+        The full, uncapped list still goes back to the wizard's own response."""
+        import app as app_module
+        many_towers = [
+            {"callsign": f"T{i}", "frequency_mhz": 100.0 + i, "latitude": 0, "longitude": 0}
+            for i in range(50)
+        ]
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"towers": many_towers, "count": 50}
+        mock_get.return_value = mock_resp
+
+        resp = app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
+
+        assert len(resp.get_json()['towers']) == 50
+
+        cached = app_module.device_state.get_towers_cache()
+        assert len(cached['towers']) == 5
+        assert [t['callsign'] for t in cached['towers']] == ['T0', 'T1', 'T2', 'T3', 'T4']
+
 
 class TestTowerCacheAdd:
     """Tests for POST /towers/cache/add route."""


### PR DESCRIPTION
## Summary

Adds a **Tower** section to the config page for picking/managing broadcast tower presets, built on top of a new cache of the setup wizard's tower search results.

- Caches the setup wizard's `/towers/search` results (`towers-cache.json` via `device_state`) — write path only at first, capped to the best 5 results (tower-finder already ranks best-first) after a live test on `owl` showed the API's uncapped default returning up to 100 results.
- New **Tower** section on `/config` (before Location/Capture, since it feeds both): a dropdown of cached towers that fills in Location's transmitter name/lat/lon/altitude and Capture's center frequency client-side — staged like every other field, nothing persists until "Apply changes".
- Manual **add/remove** for the cache (`/towers/cache/add`, `/towers/cache/remove`), independent of the staged form — persists immediately via fetch, same model as SSH key management elsewhere on the page. Add is a single-screen modal (name/callsign, frequency, lat/lon, altitude).
- The manage-list row matching the current transmitter (lat/lon/frequency) gets a blue highlight, live-updated on preset picks, hand-edits, and add/remove.