### PR TITLE
Add tracker-preview (real-data tracking verification) + retina-tracker sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Python-based web GUI baked into owl-os and deployed to every Retina node. Served
 - **Quick links** to deployed services (Passive Radar / blah2, ADS-B Map / tar1090)
 - **Radar config editor** — schema-driven UI for updating node configuration
 - **Onboarding wizard** — guided setup flow covering OS updates, radar stack install, location, and tower selection
+- **Tracker Preview** — live delay/Doppler plot of blah2's detections and confirmed tracks (via [retina-tracker](https://github.com/offworldlabs/retina-tracker)), for verifying tracking against real data
 - **SSH key management** — add and remove public keys for local access
 - **Cloud services toggle** — enable or disable Mender OTA updates and remote access
 
@@ -38,4 +39,4 @@ pip install pytest
 pytest tests/
 ```
 
-Tests cover routes, device state, install flow, config schema, form generation, Mender client, SSH key validation, and tower search.
+Tests cover routes, device state, install flow, config schema, form generation, Mender client, SSH key validation, tower search, and the tracker-preview capture service.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ flask-wtf
 pydantic
 requests
 pyyaml
+matplotlib
+git+https://github.com/offworldlabs/retina-tracker.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ flask-wtf
 pydantic
 requests
 pyyaml
-git+https://github.com/offworldlabs/retina-tracker.git
+git+https://github.com/offworldlabs/retina-tracker.git@v0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ flask-wtf
 pydantic
 requests
 pyyaml
-matplotlib
 git+https://github.com/offworldlabs/retina-tracker.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ flask-wtf
 pydantic
 requests
 pyyaml
-git+https://github.com/offworldlabs/retina-tracker.git@v0.1.0

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@ from flask import Flask
 from flask_wtf.csrf import CSRFProtect
 import os
 import subprocess
+import sys
 
 from config_manager import ConfigManager
 from device_state import DeviceState
@@ -33,6 +34,9 @@ RETINA_NODE_PATH = os.environ.get('RETINA_NODE_PATH', '/data/mender-docker-compo
 RETINA_SPECTRUM_URL = os.environ.get('RETINA_SPECTRUM_URL', 'http://localhost:3020')
 NODE_ID_FILE = os.environ.get('NODE_ID_FILE', '/data/mender/node_id')
 TOWER_FINDER_URL = os.environ.get('TOWER_FINDER_URL', 'https://tower-finder.retina.fm')
+# blah2_api runs with network_mode: host and listens directly on this port —
+# NOT the :8080 blah2_host nginx proxy, which doesn't forward /capture/* at all.
+BLAH2_API_URL = os.environ.get('BLAH2_API_URL', 'http://localhost:3000')
 DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
 
 # Shared services
@@ -92,6 +96,20 @@ except Exception:
     pass
 
 
+from blah2_client import Blah2Client
+from tracker_capture import TrackerCaptureService
+
+blah2_client = Blah2Client(BLAH2_API_URL)
+tracker_capture = TrackerCaptureService(blah2_client)
+# Never auto-start under pytest: conftest.py's app_client fixture reloads this
+# module per-test, and start() spawns a permanent, never-stopped background
+# thread — under pytest that would leak one such thread per test (each making
+# real requests.get() calls that can race with any test mocking requests
+# globally).
+if "pytest" not in sys.modules:
+    tracker_capture.start()
+
+
 def get_node_id():
     """Get node_id from Mender device identity file."""
     try:
@@ -125,6 +143,7 @@ from routes.setup import bp as setup_bp
 from routes.towers import bp as towers_bp
 from routes.mode import bp as mode_bp
 from routes.network import bp as network_bp
+from routes.tracker_preview import bp as tracker_preview_bp
 
 app.register_blueprint(home_bp)
 app.register_blueprint(config_bp)
@@ -133,6 +152,7 @@ app.register_blueprint(setup_bp)
 app.register_blueprint(towers_bp)
 app.register_blueprint(mode_bp)
 app.register_blueprint(network_bp)
+app.register_blueprint(tracker_preview_bp)
 
 
 if __name__ == "__main__":

--- a/src/app.py
+++ b/src/app.py
@@ -37,6 +37,16 @@ TOWER_FINDER_URL = os.environ.get('TOWER_FINDER_URL', 'https://tower-finder.reti
 # blah2_api runs with network_mode: host and listens directly on this port —
 # NOT the :8080 blah2_host nginx proxy, which doesn't forward /capture/* at all.
 BLAH2_API_URL = os.environ.get('BLAH2_API_URL', 'http://localhost:3000')
+# retina-tracker sidecar (network_mode: host, see retina-node's docker-compose.yml)
+RETINA_TRACKER_HOST = os.environ.get('RETINA_TRACKER_HOST', 'localhost')
+RETINA_TRACKER_PORT = int(os.environ.get('RETINA_TRACKER_PORT', '30100'))
+# Path the sidecar streams JSONL track events to (-s flag, see its compose
+# command) — tailed rather than read over the TCP socket, since retina-tracker's
+# --tcp mode is input-only (see retina_tracker_client.py's module docstring).
+RETINA_TRACKER_EVENTS_PATH = os.environ.get('RETINA_TRACKER_EVENTS_PATH',
+    os.path.join(PROJECT_ROOT, 'dev_data', 'retina-tracker-events.jsonl') if DEV_MODE
+    else '/data/retina-node/retina-tracker/output/events.jsonl'
+)
 DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
 
 # Shared services
@@ -97,10 +107,13 @@ except Exception:
 
 
 from blah2_client import Blah2Client
+from retina_tracker_client import RetinaTrackerClient
 from tracker_capture import TrackerCaptureService
 
 blah2_client = Blah2Client(BLAH2_API_URL)
-tracker_capture = TrackerCaptureService(blah2_client)
+retina_tracker_client = RetinaTrackerClient(
+    RETINA_TRACKER_HOST, RETINA_TRACKER_PORT, RETINA_TRACKER_EVENTS_PATH)
+tracker_capture = TrackerCaptureService(blah2_client, retina_tracker_client)
 # Never auto-start under pytest: conftest.py's app_client fixture reloads this
 # module per-test, and start() spawns a permanent, never-stopped background
 # thread — under pytest that would leak one such thread per test (each making

--- a/src/blah2_client.py
+++ b/src/blah2_client.py
@@ -1,6 +1,6 @@
 """HTTP client for the blah2_api service.
 
-Isolates all blah2_api HTTP calls so the calibrator logic can be tested
+Isolates all blah2_api HTTP calls so tracker_capture's logic can be tested
 against a fake client. All getters return parsed JSON dicts or None on any
 transport/parse failure — callers treat None as "no data yet".
 """
@@ -23,45 +23,6 @@ class Blah2Client:
         except (requests.RequestException, ValueError):
             return None
 
-    def retune(self, fc, gain_a, gain_b):
-        """Request a live retune. Returns (generation, error)."""
-        try:
-            resp = requests.post(
-                f"{self.base_url}/capture/retune",
-                json={
-                    "fc": int(fc),
-                    "gainReductionA": int(gain_a),
-                    "gainReductionB": int(gain_b),
-                },
-                timeout=self.timeout,
-            )
-            body = resp.json()
-            if resp.status_code == 200 and body.get("success"):
-                return body.get("generation"), None
-            return None, body.get("error") or f"HTTP {resp.status_code}"
-        except requests.RequestException as e:
-            return None, str(e)
-        except ValueError:
-            return None, "invalid response from blah2_api"
-
-    def get_retune_status(self):
-        """Last retune blah2 actually applied: {generation, fc, ..., appliedAt}."""
-        return self._get_json("/capture/retune/status")
-
-    def get_rf_status(self):
-        """Per-tuner RF overload state: {overloadA, overloadB, timestamp}."""
-        return self._get_json("/capture/rf-status")
-
     def get_detection(self):
         """Latest per-CPI CFAR detections: {timestamp, delay[], doppler[], snr[]}."""
         return self._get_json("/api/detection")
-
-    def get_tracker(self):
-        """Latest track snapshot: {timestamp, nActive, ..., data[]}."""
-        return self._get_json("/api/tracker")
-
-    def get_adsb_tracks(self):
-        """Current ADS-B aircraft, extrapolated to expected delay/doppler for
-        this node's rx/tx geometry and fc — {hex: {delay, doppler, ...}}.
-        None on failure or if truth.adsb.enabled is false on the node."""
-        return self._get_json("/api/adsb2dd")

--- a/src/blah2_client.py
+++ b/src/blah2_client.py
@@ -1,0 +1,67 @@
+"""HTTP client for the blah2_api service.
+
+Isolates all blah2_api HTTP calls so the calibrator logic can be tested
+against a fake client. All getters return parsed JSON dicts or None on any
+transport/parse failure — callers treat None as "no data yet".
+"""
+
+import requests
+
+
+class Blah2Client:
+    """Thin wrapper over blah2_api's HTTP endpoints."""
+
+    def __init__(self, base_url, timeout=3):
+        self.base_url = base_url.rstrip('/')
+        self.timeout = timeout
+
+    def _get_json(self, path):
+        try:
+            resp = requests.get(f"{self.base_url}{path}", timeout=self.timeout)
+            resp.raise_for_status()
+            return resp.json()
+        except (requests.RequestException, ValueError):
+            return None
+
+    def retune(self, fc, gain_a, gain_b):
+        """Request a live retune. Returns (generation, error)."""
+        try:
+            resp = requests.post(
+                f"{self.base_url}/capture/retune",
+                json={
+                    "fc": int(fc),
+                    "gainReductionA": int(gain_a),
+                    "gainReductionB": int(gain_b),
+                },
+                timeout=self.timeout,
+            )
+            body = resp.json()
+            if resp.status_code == 200 and body.get("success"):
+                return body.get("generation"), None
+            return None, body.get("error") or f"HTTP {resp.status_code}"
+        except requests.RequestException as e:
+            return None, str(e)
+        except ValueError:
+            return None, "invalid response from blah2_api"
+
+    def get_retune_status(self):
+        """Last retune blah2 actually applied: {generation, fc, ..., appliedAt}."""
+        return self._get_json("/capture/retune/status")
+
+    def get_rf_status(self):
+        """Per-tuner RF overload state: {overloadA, overloadB, timestamp}."""
+        return self._get_json("/capture/rf-status")
+
+    def get_detection(self):
+        """Latest per-CPI CFAR detections: {timestamp, delay[], doppler[], snr[]}."""
+        return self._get_json("/api/detection")
+
+    def get_tracker(self):
+        """Latest track snapshot: {timestamp, nActive, ..., data[]}."""
+        return self._get_json("/api/tracker")
+
+    def get_adsb_tracks(self):
+        """Current ADS-B aircraft, extrapolated to expected delay/doppler for
+        this node's rx/tx geometry and fc — {hex: {delay, doppler, ...}}.
+        None on failure or if truth.adsb.enabled is false on the node."""
+        return self._get_json("/api/adsb2dd")

--- a/src/retina_tracker_client.py
+++ b/src/retina_tracker_client.py
@@ -1,0 +1,137 @@
+"""Client for the retina-tracker sidecar container.
+
+Talks directly to retina-tracker's own --tcp server mode — no intermediary
+supervisor process. Its --tcp mode is input-only over the socket (see
+retina_tracker/server.py::run_tcp_server — it never writes back on the
+accepted connection); track events always go through -s/--stream-output,
+which the sidecar is configured to point at a file instead of stdout. So
+this client has two independent halves: push detection frames over TCP,
+and tail that output file for track events.
+"""
+
+import json
+import os
+import socket
+import threading
+import time
+
+
+class RetinaTrackerClient:
+    """Best-effort TCP sender + JSONL file tailer for retina-tracker."""
+
+    def __init__(self, host, port, events_path, poll_interval=0.2, connect_timeout=3):
+        self._host = host
+        self._port = port
+        self._events_path = events_path
+        self._poll_interval = poll_interval
+        self._connect_timeout = connect_timeout
+        self._send_lock = threading.Lock()
+        self._sock = None
+        self._tail_thread = None
+        self._stop = threading.Event()
+
+    # ── Sending frames ─────────────────────────────────────────
+
+    def send_frame(self, frame):
+        """Best-effort push of one raw blah2 detection frame ({timestamp,
+        delay[], doppler[], snr[]}) to retina-tracker's TCP ingest port.
+        Swallows connection errors — same posture as Blah2Client toward
+        blah2 itself; a sidecar outage degrades to "no track evidence",
+        not a crash. Lazily (re)connects on failure."""
+        line = (json.dumps(frame) + "\n").encode()
+        with self._send_lock:
+            if self._sock is None and not self._connect():
+                return
+            try:
+                self._sock.sendall(line)
+                return
+            except OSError:
+                self._close_sock()
+            if self._connect():
+                try:
+                    self._sock.sendall(line)
+                except OSError:
+                    self._close_sock()
+
+    def _connect(self):
+        try:
+            self._sock = socket.create_connection(
+                (self._host, self._port), timeout=self._connect_timeout)
+            return True
+        except OSError:
+            self._sock = None
+            return False
+
+    def _close_sock(self):
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+
+    # ── Tailing track events ───────────────────────────────────
+
+    def start(self, on_event):
+        """Begin tailing the events file on a background thread, calling
+        on_event(event_dict) for each new JSONL line. Call once."""
+        if self._tail_thread is not None and self._tail_thread.is_alive():
+            return
+        self._stop.clear()
+        self._tail_thread = threading.Thread(
+            target=self._tail_loop, args=(on_event,), daemon=True)
+        self._tail_thread.start()
+
+    def stop(self):
+        self._stop.set()
+        with self._send_lock:
+            self._close_sock()
+
+    def _tail_loop(self, on_event):
+        # Start from current EOF, not 0 — a fresh attach shouldn't replay
+        # a run's entire history, only events from here on.
+        try:
+            offset = os.path.getsize(self._events_path)
+        except OSError:
+            offset = 0
+
+        while not self._stop.is_set():
+            try:
+                size = os.path.getsize(self._events_path)
+            except OSError:
+                time.sleep(self._poll_interval)
+                continue
+
+            if size < offset:
+                # Sidecar restarted — TrackEventWriter opens its output
+                # file in "w" mode on process start, truncating it.
+                offset = 0
+
+            if size > offset:
+                try:
+                    with open(self._events_path, "rb") as f:
+                        f.seek(offset)
+                        chunk = f.read()
+                except OSError:
+                    time.sleep(self._poll_interval)
+                    continue
+
+                offset += len(chunk)
+                lines = chunk.split(b"\n")
+                if not chunk.endswith(b"\n"):
+                    # Writer mid-line — hold this partial line back so
+                    # it's re-read whole (combined with its rest) next tick.
+                    partial = lines.pop()
+                    offset -= len(partial)
+
+                for raw_line in lines:
+                    raw_line = raw_line.strip()
+                    if not raw_line:
+                        continue
+                    try:
+                        event = json.loads(raw_line.decode("utf-8"))
+                    except (UnicodeDecodeError, json.JSONDecodeError):
+                        continue
+                    on_event(event)
+
+            time.sleep(self._poll_interval)

--- a/src/routes/tracker_preview.py
+++ b/src/routes/tracker_preview.py
@@ -1,6 +1,6 @@
 import queue
 
-from flask import Blueprint, Response, render_template, stream_with_context
+from flask import Blueprint, Response, jsonify, render_template, stream_with_context
 
 bp = Blueprint('tracker_preview', __name__, url_prefix='/tracker-preview')
 
@@ -22,7 +22,7 @@ def index():
 
 @bp.route("/events")
 def events():
-    """SSE stream: one message per newly-rendered plot. The connection's
+    """SSE stream: one message per newly-refreshed data snapshot. The connection's
     lifetime IS the capture session's lifetime — attach() on connect,
     detach() in finally (tab close / network drop) so the background
     capture thread only ever runs while this is open."""
@@ -51,12 +51,21 @@ def events():
     )
 
 
-@bp.route("/image.png")
-def image():
-    """Latest rendered plot, or a 404 before the first render completes."""
+@bp.route("/data.json")
+def data():
+    """Latest tracker-history snapshot as JSON, rendered client-side by
+    Plotly. Always 200 — even before the first refresh this is a
+    well-shaped empty snapshot ({"raw": [], "tracks": {}})."""
     from app import tracker_capture
 
-    data = tracker_capture.latest_image()
-    if data is None:
-        return "No plot yet — still capturing", 404
-    return Response(data, mimetype="image/png")
+    return jsonify(tracker_capture.latest_data())
+
+
+@bp.route("/clear", methods=["POST"])
+def clear():
+    """Wipe the display buffer only — the underlying retina-tracker Tracker
+    keeps running unmodified; see TrackerCaptureService.request_clear."""
+    from app import tracker_capture
+
+    tracker_capture.request_clear()
+    return jsonify({"success": True})

--- a/src/routes/tracker_preview.py
+++ b/src/routes/tracker_preview.py
@@ -1,0 +1,62 @@
+import queue
+
+from flask import Blueprint, Response, render_template, stream_with_context
+
+bp = Blueprint('tracker_preview', __name__, url_prefix='/tracker-preview')
+
+# How often to send an SSE heartbeat when there's nothing new to report.
+# Without this, q.get() would block forever whenever no render happens (node
+# unreachable, or simply no detections yet) — the generator would never get
+# a chance to notice a closed connection, so a viewer could never be detached
+# and the capture thread would keep running for the full MAX_SESSION_S
+# regardless of whether anyone is still watching.
+HEARTBEAT_SECONDS = 15
+
+
+@bp.route("")
+def index():
+    """Live tracker-preview page — see src/tracker_capture.py for the
+    viewer-lifecycle-gated background capture this page drives."""
+    return render_template("tracker_preview.html")
+
+
+@bp.route("/events")
+def events():
+    """SSE stream: one message per newly-rendered plot. The connection's
+    lifetime IS the capture session's lifetime — attach() on connect,
+    detach() in finally (tab close / network drop) so the background
+    capture thread only ever runs while this is open."""
+    from app import tracker_capture
+
+    def generate():
+        q = tracker_capture.attach()
+        try:
+            while True:
+                try:
+                    seq = q.get(timeout=HEARTBEAT_SECONDS)
+                    yield f"data: {{\"seq\": {seq}}}\n\n"
+                except queue.Empty:
+                    # SSE comment line — not a "message", just keeps the
+                    # connection alive and gives this generator a chance to
+                    # notice (via the next write failing) that the client
+                    # already disconnected.
+                    yield ": keepalive\n\n"
+        finally:
+            tracker_capture.detach(q)
+
+    return Response(
+        stream_with_context(generate()),
+        content_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@bp.route("/image.png")
+def image():
+    """Latest rendered plot, or a 404 before the first render completes."""
+    from app import tracker_capture
+
+    data = tracker_capture.latest_image()
+    if data is None:
+        return "No plot yet — still capturing", 404
+    return Response(data, mimetype="image/png")

--- a/src/tracker_capture.py
+++ b/src/tracker_capture.py
@@ -11,16 +11,18 @@ beyond a ~5 second merge window (see its tracker.py: `all_tracks` is pruned
 to `_MERGE_WINDOW_MS = 5000`, purely so a briefly-dropped track can
 reconnect — not for history), so it can't answer "what was tracked 3 hours
 ago" no matter how long it's been running. HistoryBuffer below builds that
-archive ourselves via the `event_writer` hook (the same duck-typed
-interface retina-tracker's own JSONL streaming output uses).
+archive ourselves via the `write_event` hook (the same duck-typed interface
+retina-tracker's own JSONL streaming output uses).
+
+retina-tracker itself runs out-of-process, as a sidecar container (see
+retina_tracker_client.py) — detections are pushed to it over TCP, and its
+track events are tailed from a JSONL file it streams to, rather than
+calling a local Tracker object directly.
 """
 
 import queue
 import threading
 import time
-
-from retina_tracker.config import get_config
-from retina_tracker.tracker import Tracker
 
 POLL_INTERVAL_S = 0.2
 RENDER_INTERVAL_S = 3.0
@@ -49,82 +51,88 @@ def frame_to_detections(frame):
 class HistoryBuffer:
     """Bounded rolling history: raw detections + per-track points.
 
-    Only ever touched from the single capture thread (written during
-    capture, read during refresh — both synchronous on that thread), so no
-    locking is needed here; only TrackerCaptureService's `_latest_data`
-    crosses threads.
+    Touched from two threads now that retina-tracker runs as a sidecar:
+    the capture thread (add_raw, prune, clear, to_dict) and the
+    RetinaTrackerClient tailer thread (write_event, via
+    TrackerCaptureService.on_track_event) — so every method below is
+    lock-guarded.
 
-    `write_event` matches retina-tracker's event_writer duck type, called
-    once per confirmed-track update with a rolling window of that track's
-    most recent points (each carrying its own timestamp — see
-    Track.get_recent_detections). Accumulated incrementally by only
-    appending genuinely-new timestamps, so full continuous per-track
-    history builds up over time even though any single call only supplies
-    a short window.
+    `write_event` matches retina-tracker's event_writer duck type (and the
+    sidecar's own JSONL track-event schema), called once per confirmed-track
+    update with a rolling window of that track's most recent points (each
+    carrying its own timestamp — see Track.get_recent_detections).
+    Accumulated incrementally by only appending genuinely-new timestamps,
+    so full continuous per-track history builds up over time even though
+    any single call only supplies a short window.
     """
 
     def __init__(self, window_s=WINDOW_S):
+        self._lock = threading.Lock()
         self.window_s = window_s
         self.raw_points = []  # (timestamp_ms, delay, doppler, snr)
         self.tracks = {}  # track_id -> [(timestamp_ms, delay, doppler, snr), ...]
         self._last_track_timestamp = {}  # track_id -> last recorded timestamp_ms
 
     def add_raw(self, timestamp_ms, delay, doppler, snr):
-        self.raw_points.append((timestamp_ms, delay, doppler, snr))
+        with self._lock:
+            self.raw_points.append((timestamp_ms, delay, doppler, snr))
 
     def write_event(self, track_id, timestamp, length, detections, **kwargs):
-        last_seen = self._last_track_timestamp.get(track_id)
-        points = self.tracks.setdefault(track_id, [])
-        newest = last_seen
-        for det in detections:
-            ts = det["timestamp"]
-            if last_seen is not None and ts <= last_seen:
-                continue
-            points.append((ts, det["delay"], det["doppler"], det.get("snr", 0.0)))
-            if newest is None or ts > newest:
-                newest = ts
-        if newest is not None:
-            self._last_track_timestamp[track_id] = newest
+        with self._lock:
+            last_seen = self._last_track_timestamp.get(track_id)
+            points = self.tracks.setdefault(track_id, [])
+            newest = last_seen
+            for det in detections:
+                ts = det["timestamp"]
+                if last_seen is not None and ts <= last_seen:
+                    continue
+                points.append((ts, det["delay"], det["doppler"], det.get("snr", 0.0)))
+                if newest is None or ts > newest:
+                    newest = ts
+            if newest is not None:
+                self._last_track_timestamp[track_id] = newest
 
     def prune(self, now_ms):
-        cutoff = now_ms - self.window_s * 1000
-        self.raw_points = [p for p in self.raw_points if p[0] >= cutoff]
-        empty = []
-        for track_id, points in self.tracks.items():
-            kept = [p for p in points if p[0] >= cutoff]
-            if kept:
-                self.tracks[track_id] = kept
-            else:
-                empty.append(track_id)
-        for track_id in empty:
-            del self.tracks[track_id]
-            self._last_track_timestamp.pop(track_id, None)
+        with self._lock:
+            cutoff = now_ms - self.window_s * 1000
+            self.raw_points = [p for p in self.raw_points if p[0] >= cutoff]
+            empty = []
+            for track_id, points in self.tracks.items():
+                kept = [p for p in points if p[0] >= cutoff]
+                if kept:
+                    self.tracks[track_id] = kept
+                else:
+                    empty.append(track_id)
+            for track_id in empty:
+                del self.tracks[track_id]
+                self._last_track_timestamp.pop(track_id, None)
 
     def clear(self):
-        """Wipe all buffered history. Capture-thread-only, same invariant
-        as add_raw/write_event/prune above."""
-        self.raw_points = []
-        self.tracks = {}
-        self._last_track_timestamp = {}
+        """Wipe all buffered history."""
+        with self._lock:
+            self.raw_points = []
+            self.tracks = {}
+            self._last_track_timestamp = {}
 
     def to_dict(self):
         """JSON-serializable snapshot sent to the browser on every refresh
         tick. Values already originate as plain JSON floats (traced through
         retina-tracker's Track.update() -> frame_to_detections() above), so
         no numpy-safe encoding is needed here."""
-        return {
-            "raw": [
-                {"t": t, "delay": delay, "doppler": doppler, "snr": snr}
-                for (t, delay, doppler, snr) in self.raw_points
-            ],
-            "tracks": {
-                track_id: [
+        with self._lock:
+            return {
+                "raw": [
                     {"t": t, "delay": delay, "doppler": doppler, "snr": snr}
-                    for (t, delay, doppler, snr) in points
-                ]
-                for track_id, points in self.tracks.items()
-            },
-        }
+                    for (t, delay, doppler, snr) in self.raw_points
+                ],
+                "tracks": {
+                    track_id: [
+                        {"t": t, "delay": delay, "doppler": doppler, "snr": snr}
+                        for (t, delay, doppler, snr) in points
+                    ]
+                    for track_id, points in self.tracks.items()
+                },
+            }
 
 
 class TrackerCaptureService:
@@ -132,8 +140,9 @@ class TrackerCaptureService:
     stays lazy, gated to only run while at least one viewer is attached.
     """
 
-    def __init__(self, blah2_client):
+    def __init__(self, blah2_client, retina_tracker_client):
         self._client = blah2_client
+        self._tracker_client = retina_tracker_client
         self._lock = threading.Lock()
         self._thread = None
         self._viewers = []  # list of queue.Queue, one per attached viewer
@@ -150,6 +159,14 @@ class TrackerCaptureService:
             if self._thread is None or not self._thread.is_alive():
                 self._thread = threading.Thread(target=self._run, daemon=True)
                 self._thread.start()
+        self._tracker_client.start(self.on_track_event)
+
+    def on_track_event(self, event):
+        """Called from RetinaTrackerClient's tailer thread whenever the
+        sidecar streams a new track event. Field names line up exactly
+        with retina-tracker's TrackEventWriter schema, so no translation
+        is needed."""
+        self.history.write_event(**event)
 
     def attach(self):
         """Register a new viewer. Does not start capture (already running
@@ -176,12 +193,11 @@ class TrackerCaptureService:
     def request_clear(self):
         """Request that HistoryBuffer be wiped on the capture thread's next
         loop tick (cross-thread signal, mirroring attach()'s
-        _refresh_requested flag). Deliberately does NOT touch the
-        underlying retina_tracker Tracker — it keeps running and tracking
-        unmodified; only the display buffer is reset. Any still-active
-        track will repopulate on its own within a few refresh ticks, since
-        retina-tracker resends its own recent-history window on the next
-        confirmed update."""
+        _refresh_requested flag). Deliberately does NOT touch the sidecar's
+        own Tracker — it keeps running and tracking unmodified; only the
+        display buffer is reset. Any still-active track will repopulate on
+        its own within a few refresh ticks, since retina-tracker resends
+        its own recent-history window on the next confirmed update."""
         with self._lock:
             self._clear_requested = True
 
@@ -197,7 +213,6 @@ class TrackerCaptureService:
             q.put(seq)
 
     def _run(self):
-        tracker = Tracker(config=get_config(), event_writer=self.history)
         last_timestamp = None
         last_render = 0.0
         last_prune = time.monotonic()
@@ -232,7 +247,7 @@ class TrackerCaptureService:
                 detections = frame_to_detections(frame)
                 for det in detections:
                     self.history.add_raw(ts, det["delay"], det["doppler"], det.get("snr", 0.0))
-                tracker.process_frame(detections, ts)
+                self._tracker_client.send_frame(frame)
                 new_frames_since_render += 1
 
             now = time.monotonic()

--- a/src/tracker_capture.py
+++ b/src/tracker_capture.py
@@ -1,9 +1,10 @@
-"""Live tracker-preview capture service: always-on capture, lazy rendering.
+"""Live tracker-preview capture service: always-on capture, lazy data refresh.
 
 Capture + tracking runs permanently once the app boots, feeding a bounded
 4-hour rolling buffer so loading /tracker-preview shows recent history
-immediately. Rendering (the expensive matplotlib step) stays lazy — it
-only happens while at least one browser has the page open.
+immediately. Building the JSON snapshot the browser renders (client-side,
+via Plotly) stays lazy — it only happens while at least one browser has the
+page open.
 
 retina-tracker's own Tracker object doesn't retain completed-track history
 beyond a ~5 second merge window (see its tracker.py: `all_tracks` is pruned
@@ -14,7 +15,6 @@ archive ourselves via the `event_writer` hook (the same duck-typed
 interface retina-tracker's own JSONL streaming output uses).
 """
 
-import io
 import queue
 import threading
 import time
@@ -50,8 +50,8 @@ class HistoryBuffer:
     """Bounded rolling history: raw detections + per-track points.
 
     Only ever touched from the single capture thread (written during
-    capture, read during render — both synchronous on that thread), so no
-    locking is needed here; only TrackerCaptureService's `_latest_image`
+    capture, read during refresh — both synchronous on that thread), so no
+    locking is needed here; only TrackerCaptureService's `_latest_data`
     crosses threads.
 
     `write_event` matches retina-tracker's event_writer duck type, called
@@ -100,10 +100,36 @@ class HistoryBuffer:
             del self.tracks[track_id]
             self._last_track_timestamp.pop(track_id, None)
 
+    def clear(self):
+        """Wipe all buffered history. Capture-thread-only, same invariant
+        as add_raw/write_event/prune above."""
+        self.raw_points = []
+        self.tracks = {}
+        self._last_track_timestamp = {}
+
+    def to_dict(self):
+        """JSON-serializable snapshot sent to the browser on every refresh
+        tick. Values already originate as plain JSON floats (traced through
+        retina-tracker's Track.update() -> frame_to_detections() above), so
+        no numpy-safe encoding is needed here."""
+        return {
+            "raw": [
+                {"t": t, "delay": delay, "doppler": doppler, "snr": snr}
+                for (t, delay, doppler, snr) in self.raw_points
+            ],
+            "tracks": {
+                track_id: [
+                    {"t": t, "delay": delay, "doppler": doppler, "snr": snr}
+                    for (t, delay, doppler, snr) in points
+                ]
+                for track_id, points in self.tracks.items()
+            },
+        }
+
 
 class TrackerCaptureService:
-    """Runs capture+tracking permanently from start(); rendering stays lazy,
-    gated to only run while at least one viewer is attached.
+    """Runs capture+tracking permanently from start(); the JSON data refresh
+    stays lazy, gated to only run while at least one viewer is attached.
     """
 
     def __init__(self, blah2_client):
@@ -111,10 +137,11 @@ class TrackerCaptureService:
         self._lock = threading.Lock()
         self._thread = None
         self._viewers = []  # list of queue.Queue, one per attached viewer
-        self._render_requested = False
-        self._latest_image = None  # bytes, or None before the first render
-        self._seq = 0
+        self._refresh_requested = False
+        self._clear_requested = False
         self.history = HistoryBuffer()
+        self._latest_data = self.history.to_dict()  # always a valid snapshot, never None
+        self._seq = 0
 
     def start(self):
         """Begin permanent capture — call once at app boot, independent of
@@ -126,25 +153,37 @@ class TrackerCaptureService:
 
     def attach(self):
         """Register a new viewer. Does not start capture (already running
-        from start()) — only makes rendering eligible and requests an
-        immediate render so this viewer doesn't wait for the next cadence
+        from start()) — only makes data refresh eligible and requests an
+        immediate refresh so this viewer doesn't wait for the next cadence
         tick if history already exists."""
         q = queue.Queue()
         with self._lock:
             self._viewers.append(q)
-            self._render_requested = True
+            self._refresh_requested = True
         return q
 
     def detach(self, q):
         """Unregister a viewer. Capture keeps running regardless — only
-        rendering stops once no viewers remain."""
+        the data refresh stops once no viewers remain."""
         with self._lock:
             if q in self._viewers:
                 self._viewers.remove(q)
 
-    def latest_image(self):
+    def latest_data(self):
         with self._lock:
-            return self._latest_image
+            return self._latest_data
+
+    def request_clear(self):
+        """Request that HistoryBuffer be wiped on the capture thread's next
+        loop tick (cross-thread signal, mirroring attach()'s
+        _refresh_requested flag). Deliberately does NOT touch the
+        underlying retina_tracker Tracker — it keeps running and tracking
+        unmodified; only the display buffer is reset. Any still-active
+        track will repopulate on its own within a few refresh ticks, since
+        retina-tracker resends its own recent-history window on the next
+        confirmed update."""
+        with self._lock:
+            self._clear_requested = True
 
     def is_running(self):
         return self._thread is not None and self._thread.is_alive()
@@ -165,6 +204,27 @@ class TrackerCaptureService:
         new_frames_since_render = 0
 
         while True:
+            # Clear check runs first, before this tick's frame is even
+            # polled, so a frame that arrives later in this same tick lands
+            # in the now-empty buffer rather than being wiped right after
+            # being added. Runs unconditionally (independent of
+            # has_viewers), same reasoning as prune()'s independence below —
+            # a clear should be visible immediately, not wait for the
+            # viewer-gated refresh cadence.
+            with self._lock:
+                do_clear = self._clear_requested
+                if do_clear:
+                    self._clear_requested = False
+            if do_clear:
+                try:
+                    self.history.clear()
+                    with self._lock:
+                        self._latest_data = self.history.to_dict()
+                    new_frames_since_render = 0
+                    self._broadcast()
+                except Exception:
+                    pass  # a failed clear must not kill the capture loop
+
             frame = self._client.get_detection()
             if frame is not None and frame.get("timestamp") != last_timestamp:
                 last_timestamp = frame.get("timestamp")
@@ -190,71 +250,26 @@ class TrackerCaptureService:
             with self._lock:
                 has_viewers = bool(self._viewers)
                 do_render = has_viewers and (
-                    self._render_requested
+                    self._refresh_requested
                     or (new_frames_since_render > 0 and now - last_render >= RENDER_INTERVAL_S)
                 )
                 if do_render:
-                    self._render_requested = False
+                    self._refresh_requested = False
 
             if do_render:
                 last_render = now
                 new_frames_since_render = 0
                 try:
-                    self._render(self.history)
+                    self._refresh_data(self.history)
                     self._broadcast()
                 except Exception:
-                    pass  # a failed render shouldn't kill the capture loop
+                    pass  # a failed refresh shouldn't kill the capture loop
 
             time.sleep(POLL_INTERVAL_S)
 
-    def _render(self, history, tracks_only=False):
-        import matplotlib.pyplot as plt
-        import numpy as np
-
-        fig, ax = plt.subplots(figsize=(14, 10))
-        try:
-            colors = plt.cm.tab20(np.linspace(0, 1, 20))
-            track_items = list(history.tracks.items())
-
-            for i, (track_id, points) in enumerate(track_items):
-                if not points:
-                    continue
-                color = colors[i % 20]
-                delays = [p[1] for p in points]
-                dopplers = [p[2] for p in points]
-                ax.plot(delays, dopplers, "-", color="black", linewidth=0.5, alpha=0.3, zorder=1)
-                ax.scatter(delays, dopplers, c=[color] * len(delays), s=35, alpha=0.8,
-                           edgecolors="none", zorder=2, label=f"Track {track_id}")
-
-            if not tracks_only and history.raw_points:
-                all_delays = [p[1] for p in history.raw_points]
-                all_dopplers = [p[2] for p in history.raw_points]
-                all_snrs = [p[3] for p in history.raw_points]
-                scatter = ax.scatter(all_delays, all_dopplers, c=all_snrs, cmap="coolwarm",
-                                     s=5, alpha=0.4, zorder=3, label="Detections")
-                plt.colorbar(scatter, ax=ax, label="SNR (dB)")
-
-            ax.set_xlabel("Delay", fontsize=12)
-            ax.set_ylabel("Doppler (Hz)", fontsize=12)
-            ax.set_title("Radar Tracks Only" if tracks_only else "Radar Tracks",
-                        fontsize=14, fontweight="bold")
-            ax.grid(True, alpha=0.3)
-
-            if track_items:
-                if len(track_items) <= 15:
-                    ax.legend(loc="upper right", fontsize=8, ncol=2)
-                else:
-                    handles, labels = ax.get_legend_handles_labels()
-                    ax.legend(handles[:15], labels[:15], loc="upper right", fontsize=8, ncol=2)
-
-            plt.tight_layout()
-            buf = io.BytesIO()
-            fig.savefig(buf, dpi=150, bbox_inches="tight")
-            buf.seek(0)
-            with self._lock:
-                self._latest_image = buf.getvalue()
-        finally:
-            # Called every few seconds for the life of the process — an
-            # unclosed Figure per call would leak memory permanently now
-            # that this isn't bounded to a 30-minute session anymore.
-            plt.close("all")
+    def _refresh_data(self, history):
+        """Build a fresh JSON snapshot and publish it for readers on other
+        threads. Called only from the capture thread."""
+        snapshot = history.to_dict()
+        with self._lock:
+            self._latest_data = snapshot

--- a/src/tracker_capture.py
+++ b/src/tracker_capture.py
@@ -1,0 +1,260 @@
+"""Live tracker-preview capture service: always-on capture, lazy rendering.
+
+Capture + tracking runs permanently once the app boots, feeding a bounded
+4-hour rolling buffer so loading /tracker-preview shows recent history
+immediately. Rendering (the expensive matplotlib step) stays lazy — it
+only happens while at least one browser has the page open.
+
+retina-tracker's own Tracker object doesn't retain completed-track history
+beyond a ~5 second merge window (see its tracker.py: `all_tracks` is pruned
+to `_MERGE_WINDOW_MS = 5000`, purely so a briefly-dropped track can
+reconnect — not for history), so it can't answer "what was tracked 3 hours
+ago" no matter how long it's been running. HistoryBuffer below builds that
+archive ourselves via the `event_writer` hook (the same duck-typed
+interface retina-tracker's own JSONL streaming output uses).
+"""
+
+import io
+import queue
+import threading
+import time
+
+from retina_tracker.config import get_config
+from retina_tracker.tracker import Tracker
+
+POLL_INTERVAL_S = 0.2
+RENDER_INTERVAL_S = 3.0
+PRUNE_INTERVAL_S = 60
+WINDOW_S = 4 * 3600  # 4 hours of retained history
+
+
+def frame_to_detections(frame):
+    """Convert a Blah2Client.get_detection() frame into retina-tracker's
+    per-detection dicts. Mirrors retina_tracker's own
+    server.py::process_streaming_frame conversion."""
+    delays = frame.get("delay", [])
+    dopplers = frame.get("doppler", [])
+    snrs = frame.get("snr", [])
+    adsb_list = frame.get("adsb", [])
+
+    detections = []
+    for idx, (delay, doppler, snr) in enumerate(zip(delays, dopplers, snrs)):
+        detection = {"delay": delay, "doppler": doppler, "snr": snr}
+        if adsb_list and idx < len(adsb_list) and adsb_list[idx] is not None:
+            detection["adsb"] = adsb_list[idx]
+        detections.append(detection)
+    return detections
+
+
+class HistoryBuffer:
+    """Bounded rolling history: raw detections + per-track points.
+
+    Only ever touched from the single capture thread (written during
+    capture, read during render — both synchronous on that thread), so no
+    locking is needed here; only TrackerCaptureService's `_latest_image`
+    crosses threads.
+
+    `write_event` matches retina-tracker's event_writer duck type, called
+    once per confirmed-track update with a rolling window of that track's
+    most recent points (each carrying its own timestamp — see
+    Track.get_recent_detections). Accumulated incrementally by only
+    appending genuinely-new timestamps, so full continuous per-track
+    history builds up over time even though any single call only supplies
+    a short window.
+    """
+
+    def __init__(self, window_s=WINDOW_S):
+        self.window_s = window_s
+        self.raw_points = []  # (timestamp_ms, delay, doppler, snr)
+        self.tracks = {}  # track_id -> [(timestamp_ms, delay, doppler, snr), ...]
+        self._last_track_timestamp = {}  # track_id -> last recorded timestamp_ms
+
+    def add_raw(self, timestamp_ms, delay, doppler, snr):
+        self.raw_points.append((timestamp_ms, delay, doppler, snr))
+
+    def write_event(self, track_id, timestamp, length, detections, **kwargs):
+        last_seen = self._last_track_timestamp.get(track_id)
+        points = self.tracks.setdefault(track_id, [])
+        newest = last_seen
+        for det in detections:
+            ts = det["timestamp"]
+            if last_seen is not None and ts <= last_seen:
+                continue
+            points.append((ts, det["delay"], det["doppler"], det.get("snr", 0.0)))
+            if newest is None or ts > newest:
+                newest = ts
+        if newest is not None:
+            self._last_track_timestamp[track_id] = newest
+
+    def prune(self, now_ms):
+        cutoff = now_ms - self.window_s * 1000
+        self.raw_points = [p for p in self.raw_points if p[0] >= cutoff]
+        empty = []
+        for track_id, points in self.tracks.items():
+            kept = [p for p in points if p[0] >= cutoff]
+            if kept:
+                self.tracks[track_id] = kept
+            else:
+                empty.append(track_id)
+        for track_id in empty:
+            del self.tracks[track_id]
+            self._last_track_timestamp.pop(track_id, None)
+
+
+class TrackerCaptureService:
+    """Runs capture+tracking permanently from start(); rendering stays lazy,
+    gated to only run while at least one viewer is attached.
+    """
+
+    def __init__(self, blah2_client):
+        self._client = blah2_client
+        self._lock = threading.Lock()
+        self._thread = None
+        self._viewers = []  # list of queue.Queue, one per attached viewer
+        self._render_requested = False
+        self._latest_image = None  # bytes, or None before the first render
+        self._seq = 0
+        self.history = HistoryBuffer()
+
+    def start(self):
+        """Begin permanent capture — call once at app boot, independent of
+        any viewer ever connecting."""
+        with self._lock:
+            if self._thread is None or not self._thread.is_alive():
+                self._thread = threading.Thread(target=self._run, daemon=True)
+                self._thread.start()
+
+    def attach(self):
+        """Register a new viewer. Does not start capture (already running
+        from start()) — only makes rendering eligible and requests an
+        immediate render so this viewer doesn't wait for the next cadence
+        tick if history already exists."""
+        q = queue.Queue()
+        with self._lock:
+            self._viewers.append(q)
+            self._render_requested = True
+        return q
+
+    def detach(self, q):
+        """Unregister a viewer. Capture keeps running regardless — only
+        rendering stops once no viewers remain."""
+        with self._lock:
+            if q in self._viewers:
+                self._viewers.remove(q)
+
+    def latest_image(self):
+        with self._lock:
+            return self._latest_image
+
+    def is_running(self):
+        return self._thread is not None and self._thread.is_alive()
+
+    def _broadcast(self):
+        with self._lock:
+            self._seq += 1
+            seq = self._seq
+            viewers = list(self._viewers)
+        for q in viewers:
+            q.put(seq)
+
+    def _run(self):
+        tracker = Tracker(config=get_config(), event_writer=self.history)
+        last_timestamp = None
+        last_render = 0.0
+        last_prune = time.monotonic()
+        new_frames_since_render = 0
+
+        while True:
+            frame = self._client.get_detection()
+            if frame is not None and frame.get("timestamp") != last_timestamp:
+                last_timestamp = frame.get("timestamp")
+                ts = frame["timestamp"]
+                detections = frame_to_detections(frame)
+                for det in detections:
+                    self.history.add_raw(ts, det["delay"], det["doppler"], det.get("snr", 0.0))
+                tracker.process_frame(detections, ts)
+                new_frames_since_render += 1
+
+            now = time.monotonic()
+
+            # Pruning runs on its own fixed cadence, independent of viewer
+            # presence — capture is unconditional now, so this is the only
+            # thing keeping memory bounded. Tying it to the (viewer-gated)
+            # render cycle instead would mean the buffer grows unbounded
+            # for as long as nobody's watching, exactly backwards from the
+            # point of a fixed-size window.
+            if now - last_prune >= PRUNE_INTERVAL_S:
+                last_prune = now
+                self.history.prune(int(time.time() * 1000))
+
+            with self._lock:
+                has_viewers = bool(self._viewers)
+                do_render = has_viewers and (
+                    self._render_requested
+                    or (new_frames_since_render > 0 and now - last_render >= RENDER_INTERVAL_S)
+                )
+                if do_render:
+                    self._render_requested = False
+
+            if do_render:
+                last_render = now
+                new_frames_since_render = 0
+                try:
+                    self._render(self.history)
+                    self._broadcast()
+                except Exception:
+                    pass  # a failed render shouldn't kill the capture loop
+
+            time.sleep(POLL_INTERVAL_S)
+
+    def _render(self, history, tracks_only=False):
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        fig, ax = plt.subplots(figsize=(14, 10))
+        try:
+            colors = plt.cm.tab20(np.linspace(0, 1, 20))
+            track_items = list(history.tracks.items())
+
+            for i, (track_id, points) in enumerate(track_items):
+                if not points:
+                    continue
+                color = colors[i % 20]
+                delays = [p[1] for p in points]
+                dopplers = [p[2] for p in points]
+                ax.plot(delays, dopplers, "-", color="black", linewidth=0.5, alpha=0.3, zorder=1)
+                ax.scatter(delays, dopplers, c=[color] * len(delays), s=35, alpha=0.8,
+                           edgecolors="none", zorder=2, label=f"Track {track_id}")
+
+            if not tracks_only and history.raw_points:
+                all_delays = [p[1] for p in history.raw_points]
+                all_dopplers = [p[2] for p in history.raw_points]
+                all_snrs = [p[3] for p in history.raw_points]
+                scatter = ax.scatter(all_delays, all_dopplers, c=all_snrs, cmap="coolwarm",
+                                     s=5, alpha=0.4, zorder=3, label="Detections")
+                plt.colorbar(scatter, ax=ax, label="SNR (dB)")
+
+            ax.set_xlabel("Delay", fontsize=12)
+            ax.set_ylabel("Doppler (Hz)", fontsize=12)
+            ax.set_title("Radar Tracks Only" if tracks_only else "Radar Tracks",
+                        fontsize=14, fontweight="bold")
+            ax.grid(True, alpha=0.3)
+
+            if track_items:
+                if len(track_items) <= 15:
+                    ax.legend(loc="upper right", fontsize=8, ncol=2)
+                else:
+                    handles, labels = ax.get_legend_handles_labels()
+                    ax.legend(handles[:15], labels[:15], loc="upper right", fontsize=8, ncol=2)
+
+            plt.tight_layout()
+            buf = io.BytesIO()
+            fig.savefig(buf, dpi=150, bbox_inches="tight")
+            buf.seek(0)
+            with self._lock:
+                self._latest_image = buf.getvalue()
+        finally:
+            # Called every few seconds for the life of the process — an
+            # unclosed Figure per call would leak memory permanently now
+            # that this isn't bounded to a 30-minute session anymore.
+            plt.close("all")

--- a/templates/index.html
+++ b/templates/index.html
@@ -160,6 +160,24 @@
                 </div>
                 <div class="svc-desc">tar1090 live aircraft map.</div>
             </a>
+            <a class="svc-card" href="/tracker-preview">
+                <div class="svc-head">
+                    <div class="svc-icon">
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="5" cy="17" r="1.6" fill="currentColor" stroke="none"/>
+                            <circle cx="10" cy="10" r="1.6" fill="currentColor" stroke="none"/>
+                            <circle cx="15" cy="13" r="1.6" fill="currentColor" stroke="none"/>
+                            <circle cx="20" cy="6" r="1.6" fill="currentColor" stroke="none"/>
+                            <path d="M5 17 L10 10 L15 13 L20 6" opacity=".6"/>
+                        </svg>
+                    </div>
+                    <div class="svc-name">Tracker Preview</div>
+                    <span class="svc-arrow">
+                        <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h7v7"/><path d="M21 3l-9 9"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>
+                    </span>
+                </div>
+                <div class="svc-desc">Live delay/Doppler tracks on real data.</div>
+            </a>
             {% else %}
             <div class="svc-card disabled">
                 <div class="svc-head">

--- a/templates/tracker_preview.html
+++ b/templates/tracker_preview.html
@@ -5,35 +5,163 @@
     <div class="container py-4">
         <h1>Tracker Preview</h1>
         <p class="text-muted">
-            Live delay/Doppler plot from blah2's detections, tracked via
+            Interactive delay/Doppler plot from blah2's detections, tracked via
             <a href="https://github.com/offworldlabs/retina-tracker" target="_blank" rel="noopener">retina-tracker</a>.
-            Updates every few seconds while this page is open; capture stops
-            automatically when you leave.
+            Zoom, pan, and hover for details. Background capture runs for the
+            life of the node regardless of this page; only the live refresh
+            stops when you leave.
         </p>
-        <div id="plotStatus" class="text-muted mb-2">Waiting for first render&hellip;</div>
-        <img id="plot" alt="Tracker preview" style="max-width: 100%; border: 1px solid #ddd;">
+        <div class="d-flex align-items-center gap-2 mb-2">
+            <div id="plotStatus" class="text-muted">Waiting for first data&hellip;</div>
+            <div class="flex-grow-1"></div>
+            <button type="button" id="clearBufferBtn" class="ds-btn danger-ghost sm"
+                    title="Clears only what's displayed here — tracking keeps running, so an active aircraft will reappear on its own.">
+                Clear buffer
+            </button>
+        </div>
+        <div id="plot" style="width:100%; height:640px;"></div>
     </div>
 {% endblock %}
 
 {% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@3.7.0/plotly.min.js"></script>
 <script>
 (function() {
-    var img = document.getElementById('plot');
+    var plotDiv = document.getElementById('plot');
     var status = document.getElementById('plotStatus');
-    var source = new EventSource('/tracker-preview/events');
+    var clearBtn = document.getElementById('clearBufferBtn');
+    var csrf = document.querySelector('meta[name="csrf-token"]').content;
 
-    source.onmessage = function(evt) {
+    // Categorical palette + sequential SNR ramp from the design-system
+    // color reference — track identity is never carried by color alone
+    // (legend name + hover both always spell out the track id too), and
+    // SNR is a magnitude with no "opposite sides of zero" meaning, hence
+    // a sequential ramp rather than a diverging one.
+    var PALETTE = ['#2a78d6', '#008300', '#e87ba4', '#eda100', '#1baf7a', '#eb6834', '#4a3aa7', '#e34948'];
+    var SNR_COLORSCALE = [
+        [0.00, '#cde2fb'], [0.20, '#9ec5f4'], [0.40, '#6da7ec'],
+        [0.60, '#3987e5'], [0.80, '#1c5cab'], [1.00, '#0d366b']
+    ];
+
+    // Assigned once per track id on first sighting, never recomputed by
+    // position — otherwise every surviving track would repaint whenever an
+    // older one aged out of the window.
+    var trackColors = {};
+    var nextColorSlot = 0;
+    function colorFor(trackId) {
+        if (!(trackId in trackColors)) {
+            trackColors[trackId] = PALETTE[nextColorSlot % PALETTE.length];
+            nextColorSlot++;
+        }
+        return trackColors[trackId];
+    }
+
+    function renderPlot(snapshot) {
         status.textContent = '';
-        img.src = '/tracker-preview/image.png?t=' + Date.now();
-    };
+        var traces = [];
 
+        Object.keys(snapshot.tracks).forEach(function(trackId) {
+            var pts = snapshot.tracks[trackId];
+            if (!pts.length) return;
+            traces.push({
+                type: 'scattergl',
+                mode: 'lines+markers',
+                name: 'Track ' + trackId,
+                x: pts.map(function(p) { return p.delay; }),
+                y: pts.map(function(p) { return p.doppler; }),
+                line: { color: 'rgba(0,0,0,0.25)', width: 1 },
+                marker: { color: colorFor(trackId), size: 8, line: { color: '#ffffff', width: 1.5 } },
+                customdata: pts.map(function(p) {
+                    return [trackId, p.snr, new Date(p.t).toLocaleTimeString()];
+                }),
+                hovertemplate:
+                    'Track %{customdata[0]}<br>' +
+                    'Delay: %{x:.2f}<br>Doppler: %{y:.2f} Hz<br>' +
+                    'SNR: %{customdata[1]:.1f} dB<br>%{customdata[2]}<extra></extra>',
+            });
+        });
+
+        if (snapshot.raw.length) {
+            traces.push({
+                type: 'scattergl',
+                mode: 'markers',
+                name: 'Detections',
+                x: snapshot.raw.map(function(p) { return p.delay; }),
+                y: snapshot.raw.map(function(p) { return p.doppler; }),
+                marker: {
+                    color: snapshot.raw.map(function(p) { return p.snr; }),
+                    colorscale: SNR_COLORSCALE,
+                    size: 4,
+                    opacity: 0.4,
+                    // Fixed geometry so this never collides with the legend,
+                    // which lives below the plot precisely to keep this
+                    // strip on the right clear for the colorbar alone.
+                    colorbar: { title: { text: 'SNR (dB)' }, x: 1.02, xpad: 0, len: 1, thickness: 14 },
+                },
+                customdata: snapshot.raw.map(function(p) {
+                    return [p.snr, new Date(p.t).toLocaleTimeString()];
+                }),
+                hovertemplate: 'Delay: %{x:.2f}<br>Doppler: %{y:.2f} Hz<br>SNR: %{customdata[0]:.1f} dB<br>%{customdata[1]}<extra></extra>',
+            });
+        }
+
+        // react (not newPlot) for every update, including the first — it
+        // preserves the viewer's zoom/pan across refreshes, which is the
+        // whole point of making this interactive.
+        Plotly.react(plotDiv, traces, {
+            xaxis: { title: { text: 'Delay' } },
+            yaxis: { title: { text: 'Doppler (Hz)' } },
+            // Legend lives below the plot, not floating over it or sharing
+            // the right-hand strip with the colorbar — the two were
+            // competing for the same default position and stepping on each
+            // other. automargin lets Plotly grow the bottom margin to fit
+            // however many tracks are actually live, rather than us
+            // guessing a fixed height that could clip or wrap awkwardly
+            // once enough tracks are confirmed at once.
+            margin: { t: 20, r: 70, b: 60 },
+            showlegend: true,
+            legend: {
+                orientation: 'h',
+                x: 0.5,
+                xanchor: 'center',
+                y: -0.18,
+                yanchor: 'top',
+                font: { size: 10 },
+                automargin: true,
+            },
+        });
+    }
+
+    function refresh() {
+        fetch('/tracker-preview/data.json', { cache: 'no-store' })
+            .then(function(r) { return r.json(); })
+            .then(renderPlot)
+            .catch(function(e) { status.textContent = 'Refresh failed: ' + e.message; });
+    }
+
+    var source = new EventSource('/tracker-preview/events');
+    source.onmessage = refresh;
     source.onerror = function() {
         status.textContent = 'Connection lost — reload the page to restart the capture.';
     };
-
     window.addEventListener('beforeunload', function() {
         source.close();
     });
+
+    clearBtn.addEventListener('click', function() {
+        clearBtn.disabled = true;
+        status.textContent = 'Clearing…';
+        fetch('/tracker-preview/clear', { method: 'POST', headers: { 'X-CSRFToken': csrf } })
+            .then(function(r) { return r.json(); })
+            .then(function(d) { status.textContent = d.success ? '' : (d.error || 'Failed to clear'); })
+            .catch(function(e) { status.textContent = 'Error: ' + e.message; })
+            .finally(function() { clearBtn.disabled = false; });
+    });
+
+    // Show whatever snapshot already exists immediately, rather than
+    // waiting on the first SSE tick — useful when reattaching to a node
+    // that's had other viewers (or this page) open recently.
+    refresh();
 })();
 </script>
 {% endblock %}

--- a/templates/tracker_preview.html
+++ b/templates/tracker_preview.html
@@ -107,8 +107,15 @@
 
         // react (not newPlot) for every update, including the first — it
         // preserves the viewer's zoom/pan across refreshes, which is the
-        // whole point of making this interactive.
+        // whole point of making this interactive. react() alone isn't
+        // actually enough for that, though: without a stable uirevision,
+        // Plotly treats each call as a fresh layout and resets the view on
+        // every refresh regardless. Any constant string works here — what
+        // matters is that it's the *same* value call to call, which is what
+        // tells Plotly "this is a data update to an existing view, not a new
+        // plot" and makes it preserve zoom/pan/legend toggles across it.
         Plotly.react(plotDiv, traces, {
+            uirevision: 'tracker-preview',
             xaxis: { title: { text: 'Delay' } },
             yaxis: { title: { text: 'Doppler (Hz)' } },
             // Legend lives below the plot, not floating over it or sharing

--- a/templates/tracker_preview.html
+++ b/templates/tracker_preview.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block title %}Tracker Preview - OWL-OS{% endblock %}
+
+{% block content %}
+    <div class="container py-4">
+        <h1>Tracker Preview</h1>
+        <p class="text-muted">
+            Live delay/Doppler plot from blah2's detections, tracked via
+            <a href="https://github.com/offworldlabs/retina-tracker" target="_blank" rel="noopener">retina-tracker</a>.
+            Updates every few seconds while this page is open; capture stops
+            automatically when you leave.
+        </p>
+        <div id="plotStatus" class="text-muted mb-2">Waiting for first render&hellip;</div>
+        <img id="plot" alt="Tracker preview" style="max-width: 100%; border: 1px solid #ddd;">
+    </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function() {
+    var img = document.getElementById('plot');
+    var status = document.getElementById('plotStatus');
+    var source = new EventSource('/tracker-preview/events');
+
+    source.onmessage = function(evt) {
+        status.textContent = '';
+        img.src = '/tracker-preview/image.png?t=' + Date.now();
+    };
+
+    source.onerror = function() {
+        status.textContent = 'Connection lost — reload the page to restart the capture.';
+    };
+
+    window.addEventListener('beforeunload', function() {
+        source.close();
+    });
+})();
+</script>
+{% endblock %}

--- a/templates/tracker_preview.html
+++ b/templates/tracker_preview.html
@@ -5,8 +5,7 @@
     <div class="container py-4">
         <h1>Tracker Preview</h1>
         <p class="text-muted">
-            Interactive delay/Doppler plot from blah2's detections, tracked via
-            <a href="https://github.com/offworldlabs/retina-tracker" target="_blank" rel="noopener">retina-tracker</a>.
+            Interactive delay/Doppler plot from blah2's detections.
             Zoom, pan, and hover for details. Background capture runs for the
             life of the node regardless of this page; only the live refresh
             stops when you leave.

--- a/tests/test_tracker_capture.py
+++ b/tests/test_tracker_capture.py
@@ -1,13 +1,13 @@
-"""Tests for TrackerCaptureService's always-on capture / lazy-render lifecycle.
+"""Tests for TrackerCaptureService's always-on capture / lazy-refresh lifecycle.
 
-Stubs matplotlib's savefig/close and retina-tracker's Tracker/get_config so
-these tests exercise only our own threading/history/render-gating logic,
-not retina-tracker's Kalman filtering or matplotlib's actual rendering —
-matching tests/test_calibrate.py's approach of not re-testing a
+Stubs retina-tracker's Tracker/get_config so these tests exercise only our
+own threading/history/refresh-gating logic, not retina-tracker's Kalman
+filtering — matching tests/test_calibrate.py's approach of not re-testing a
 dependency's own internals.
 """
 
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -64,19 +64,19 @@ def make_frame(ts, delay=1.0, doppler=2.0, snr=3.0):
     return {"timestamp": ts, "delay": [delay], "doppler": [doppler], "snr": [snr]}
 
 
-def stub_render(monkeypatch, service, side_effect=None):
-    """Replace TrackerCaptureService._render so tests don't need real
-    matplotlib rendering — just record that it ran."""
+def stub_refresh(monkeypatch, service, side_effect=None):
+    """Replace TrackerCaptureService._refresh_data so tests don't need to
+    build a real snapshot — just record that it ran."""
     calls = []
 
-    def fake_render(self, history, tracks_only=False):
+    def fake_refresh(self, history):
         calls.append(history)
         if side_effect:
             side_effect()
         with self._lock:
-            self._latest_image = b"fake-png"
+            self._latest_data = {"stub": True}
 
-    monkeypatch.setattr(tracker_capture.TrackerCaptureService, "_render", fake_render)
+    monkeypatch.setattr(tracker_capture.TrackerCaptureService, "_refresh_data", fake_refresh)
     return calls
 
 
@@ -124,6 +124,46 @@ def test_history_buffer_prune_drops_old_points_and_empty_tracks():
     assert "NEW" in hist.tracks
 
 
+def test_history_buffer_clear_resets_all_collections():
+    hist = tracker_capture.HistoryBuffer()
+    hist.add_raw(1000, 1.0, 2.0, 3.0)
+    hist.write_event("T1", 1000, 1, [{"timestamp": 1000, "delay": 1.0, "doppler": 2.0, "snr": 3.0}])
+
+    hist.clear()
+
+    assert hist.raw_points == []
+    assert hist.tracks == {}
+    assert hist._last_track_timestamp == {}
+
+
+def test_history_buffer_clear_lets_write_event_repopulate_fresh():
+    # If _last_track_timestamp weren't cleared too, this would be treated
+    # as an already-seen timestamp and silently dropped.
+    hist = tracker_capture.HistoryBuffer()
+    hist.write_event("T1", 1000, 1, [{"timestamp": 1000, "delay": 1.0, "doppler": 2.0, "snr": 3.0}])
+    hist.clear()
+
+    hist.write_event("T1", 1000, 1, [{"timestamp": 1000, "delay": 1.0, "doppler": 2.0, "snr": 3.0}])
+
+    assert hist.tracks["T1"] == [(1000, 1.0, 2.0, 3.0)]
+
+
+def test_history_buffer_to_dict_empty():
+    hist = tracker_capture.HistoryBuffer()
+    assert hist.to_dict() == {"raw": [], "tracks": {}}
+
+
+def test_history_buffer_to_dict_shape():
+    hist = tracker_capture.HistoryBuffer()
+    hist.add_raw(1000, 1.0, 2.0, 3.0)
+    hist.write_event("T1", 1000, 1, [{"timestamp": 1000, "delay": 1.5, "doppler": 2.5, "snr": 4.0}])
+
+    assert hist.to_dict() == {
+        "raw": [{"t": 1000, "delay": 1.0, "doppler": 2.0, "snr": 3.0}],
+        "tracks": {"T1": [{"t": 1000, "delay": 1.5, "doppler": 2.5, "snr": 4.0}]},
+    }
+
+
 # ── Always-on capture lifecycle ─────────────────────────────────────────────
 
 def test_start_runs_immediately_with_zero_viewers():
@@ -134,7 +174,7 @@ def test_start_runs_immediately_with_zero_viewers():
 
 
 def test_detach_does_not_stop_capture(monkeypatch):
-    stub_render(monkeypatch, None)
+    stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([])
     service = tracker_capture.TrackerCaptureService(client)
     service.start()
@@ -143,22 +183,22 @@ def test_detach_does_not_stop_capture(monkeypatch):
     q = service.attach()
     service.detach(q)
     time.sleep(0.1)
-    # Unlike Phase 2, capture never stops on detach — only rendering does.
+    # Unlike Phase 2, capture never stops on detach — only the data refresh does.
     assert service.is_running()
 
 
-def test_no_render_without_viewers(monkeypatch):
-    calls = stub_render(monkeypatch, None)
+def test_no_refresh_without_viewers(monkeypatch):
+    calls = stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([make_frame(1000), make_frame(2000), make_frame(3000)])
     service = tracker_capture.TrackerCaptureService(client)
     service.start()
 
-    time.sleep(0.3)  # plenty of render-interval ticks with data and zero viewers
+    time.sleep(0.3)  # plenty of refresh-interval ticks with data and zero viewers
     assert calls == []
 
 
-def test_render_only_after_attach(monkeypatch):
-    calls = stub_render(monkeypatch, None)
+def test_refresh_only_after_attach(monkeypatch):
+    calls = stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([make_frame(1000)])
     service = tracker_capture.TrackerCaptureService(client)
     service.start()
@@ -167,15 +207,15 @@ def test_render_only_after_attach(monkeypatch):
 
     q = service.attach()
     assert _wait_until(lambda: len(calls) >= 1)
-    assert service.latest_image() == b"fake-png"
+    assert service.latest_data() == {"stub": True}
     service.detach(q)
 
 
-def test_attach_requests_immediate_render_without_waiting_full_interval(monkeypatch):
+def test_attach_requests_immediate_refresh_without_waiting_full_interval(monkeypatch):
     # RENDER_INTERVAL_S is patched small already, so use an artificially large
     # one here to prove attach() bypasses the wait rather than just being fast.
     monkeypatch.setattr(tracker_capture, "RENDER_INTERVAL_S", 10.0)
-    calls = stub_render(monkeypatch, None)
+    calls = stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([make_frame(1000)])
     service = tracker_capture.TrackerCaptureService(client)
     service.start()
@@ -187,7 +227,7 @@ def test_attach_requests_immediate_render_without_waiting_full_interval(monkeypa
 
 
 def test_prune_runs_independent_of_viewers(monkeypatch):
-    stub_render(monkeypatch, None)
+    stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([make_frame(1000)])
     service = tracker_capture.TrackerCaptureService(client)
     service.history.window_s = 0  # anything with a timestamp is immediately "old"
@@ -198,7 +238,7 @@ def test_prune_runs_independent_of_viewers(monkeypatch):
     assert _wait_until(lambda: len(service.history.raw_points) == 0, timeout=1.0)
 
 
-def test_render_failure_does_not_kill_capture_loop(monkeypatch):
+def test_refresh_failure_does_not_kill_capture_loop(monkeypatch):
     calls = {"n": 0}
 
     def flaky():
@@ -206,7 +246,7 @@ def test_render_failure_does_not_kill_capture_loop(monkeypatch):
         if calls["n"] == 1:
             raise ValueError("boom")
 
-    stub_render(monkeypatch, None, side_effect=flaky)
+    stub_refresh(monkeypatch, None, side_effect=flaky)
     client = FakeBlah2Client([make_frame(1000), make_frame(2000)])
     service = tracker_capture.TrackerCaptureService(client)
     service.start()
@@ -215,3 +255,109 @@ def test_render_failure_does_not_kill_capture_loop(monkeypatch):
     assert _wait_until(lambda: calls["n"] >= 2, timeout=2.0)
     assert service.is_running()
     service.detach(q)
+
+
+# ── request_clear() ─────────────────────────────────────────────────────────
+
+# HistoryBuffer.prune() compares point timestamps against real wall-clock
+# time (see _run()'s `self.history.prune(int(time.time() * 1000))`), so
+# fixed tiny epoch values like make_frame's default `ts=1000` look 50+
+# years stale the instant PRUNE_INTERVAL_S (patched to 0.05s) fires — these
+# clear() tests run long enough to cross that boundary, so they need
+# realistic timestamps or prune() would silently empty raw_points on its
+# own, masking whether request_clear() actually did anything.
+def _now_ms():
+    return int(time.time() * 1000)
+
+
+def test_request_clear_wipes_history_from_capture_thread():
+    # Deliberately not stubbing _refresh_data here — the clear branch's own
+    # snapshot reset lives in _run() itself, not in _refresh_data().
+    now = _now_ms()
+    client = FakeBlah2Client([make_frame(now), make_frame(now + 10)])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+    assert _wait_until(lambda: len(service.history.raw_points) >= 2, timeout=1.0)
+
+    service.request_clear()
+
+    assert _wait_until(lambda: service.history.raw_points == [], timeout=1.0)
+    assert service.history.tracks == {}
+    assert service.latest_data() == {"raw": [], "tracks": {}}
+
+
+def test_request_clear_runs_without_viewers():
+    # No viewer ever attached — proves the clear branch is unconditional,
+    # same as prune() already is, not gated on has_viewers.
+    client = FakeBlah2Client([make_frame(_now_ms())])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+    assert _wait_until(lambda: len(service.history.raw_points) >= 1, timeout=1.0)
+
+    service.request_clear()
+
+    assert _wait_until(lambda: service.history.raw_points == [], timeout=1.0)
+
+
+def test_frame_after_clear_populates_fresh_buffer():
+    now = _now_ms()
+    client = FakeBlah2Client([make_frame(now), make_frame(now + 10)])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+    assert _wait_until(lambda: len(service.history.raw_points) >= 2, timeout=1.0)
+
+    service.request_clear()
+    assert _wait_until(lambda: service.history.raw_points == [], timeout=1.0)
+
+    new_ts = _now_ms()
+    client._responses.append(make_frame(new_ts, delay=9.0))
+    assert _wait_until(lambda: len(service.history.raw_points) == 1, timeout=1.0)
+    assert service.history.raw_points == [(new_ts, 9.0, 2.0, 3.0)]
+
+
+def test_clear_requested_during_active_capture_does_not_corrupt_state():
+    now = _now_ms()
+    frames = [make_frame(now + i * 10) for i in range(20)]
+    client = FakeBlah2Client(frames)
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        service.request_clear()
+        time.sleep(0.005)
+
+    assert _wait_until(lambda: not client._responses, timeout=2.0)
+    time.sleep(0.05)  # let the loop settle after the last frame
+
+    assert service.is_running()
+    assert all(isinstance(p, tuple) and len(p) == 4 for p in service.history.raw_points)
+
+
+# ── Routes ───────────────────────────────────────────────────────────────
+
+def test_data_json_returns_empty_snapshot_before_any_capture(app_client):
+    resp = app_client.get('/tracker-preview/data.json')
+    assert resp.status_code == 200
+    assert resp.get_json() == {"raw": [], "tracks": {}}
+
+
+def test_data_json_returns_current_snapshot(app_client):
+    import app as app_module
+
+    app_module.tracker_capture.history.add_raw(1000, 1.0, 2.0, 3.0)
+    app_module.tracker_capture._latest_data = app_module.tracker_capture.history.to_dict()
+
+    resp = app_client.get('/tracker-preview/data.json')
+    assert resp.get_json()["raw"] == [{"t": 1000, "delay": 1.0, "doppler": 2.0, "snr": 3.0}]
+
+
+def test_clear_route_calls_request_clear(app_client):
+    import app as app_module
+
+    with patch.object(app_module.tracker_capture, 'request_clear') as mock_clear:
+        resp = app_client.post('/tracker-preview/clear')
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"success": True}
+    mock_clear.assert_called_once()

--- a/tests/test_tracker_capture.py
+++ b/tests/test_tracker_capture.py
@@ -1,0 +1,217 @@
+"""Tests for TrackerCaptureService's always-on capture / lazy-render lifecycle.
+
+Stubs matplotlib's savefig/close and retina-tracker's Tracker/get_config so
+these tests exercise only our own threading/history/render-gating logic,
+not retina-tracker's Kalman filtering or matplotlib's actual rendering —
+matching tests/test_calibrate.py's approach of not re-testing a
+dependency's own internals.
+"""
+
+import time
+
+import pytest
+
+import tracker_capture
+
+
+class FakeBlah2Client:
+    """Scripted stand-in for Blah2Client.get_detection()."""
+
+    def __init__(self, responses=None):
+        self._responses = list(responses or [])
+
+    def get_detection(self):
+        if not self._responses:
+            return None
+        return self._responses.pop(0)
+
+
+class FakeTracker:
+    """Records process_frame calls instead of doing real Kalman tracking."""
+
+    def __init__(self, config=None, event_writer=None):
+        self.calls = []
+        self.event_writer = event_writer
+
+    def process_frame(self, detections, timestamp):
+        self.calls.append((detections, timestamp))
+
+
+def _wait_until(predicate, timeout=2.0, interval=0.02):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+@pytest.fixture(autouse=True)
+def fast_intervals(monkeypatch):
+    """Tiny intervals so tests don't take real-world seconds/minutes."""
+    monkeypatch.setattr(tracker_capture, "POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(tracker_capture, "RENDER_INTERVAL_S", 0.03)
+    monkeypatch.setattr(tracker_capture, "PRUNE_INTERVAL_S", 0.05)
+
+
+@pytest.fixture(autouse=True)
+def stub_tracker(monkeypatch):
+    monkeypatch.setattr(tracker_capture, "Tracker", FakeTracker)
+    monkeypatch.setattr(tracker_capture, "get_config", lambda: {})
+
+
+def make_frame(ts, delay=1.0, doppler=2.0, snr=3.0):
+    return {"timestamp": ts, "delay": [delay], "doppler": [doppler], "snr": [snr]}
+
+
+def stub_render(monkeypatch, service, side_effect=None):
+    """Replace TrackerCaptureService._render so tests don't need real
+    matplotlib rendering — just record that it ran."""
+    calls = []
+
+    def fake_render(self, history, tracks_only=False):
+        calls.append(history)
+        if side_effect:
+            side_effect()
+        with self._lock:
+            self._latest_image = b"fake-png"
+
+    monkeypatch.setattr(tracker_capture.TrackerCaptureService, "_render", fake_render)
+    return calls
+
+
+# ── HistoryBuffer ──────────────────────────────────────────────────────────
+
+def test_frame_to_detections_basic():
+    frame = {"timestamp": 1000, "delay": [1.0, 2.0], "doppler": [10.0, -20.0], "snr": [5.0, 6.0]}
+    detections = tracker_capture.frame_to_detections(frame)
+    assert detections == [
+        {"delay": 1.0, "doppler": 10.0, "snr": 5.0},
+        {"delay": 2.0, "doppler": -20.0, "snr": 6.0},
+    ]
+
+
+def test_history_buffer_write_event_accumulates_without_duplicates():
+    hist = tracker_capture.HistoryBuffer()
+    # Overlapping windows, as retina-tracker's own rolling get_recent_detections
+    # would supply on successive calls for the same track.
+    hist.write_event("T1", 2000, 2, [
+        {"timestamp": 1000, "delay": 1.0, "doppler": 2.0, "snr": 3.0},
+        {"timestamp": 2000, "delay": 1.1, "doppler": 2.1, "snr": 3.1},
+    ])
+    hist.write_event("T1", 3000, 2, [
+        {"timestamp": 2000, "delay": 1.1, "doppler": 2.1, "snr": 3.1},
+        {"timestamp": 3000, "delay": 1.2, "doppler": 2.2, "snr": 3.2},
+    ])
+    assert hist.tracks["T1"] == [
+        (1000, 1.0, 2.0, 3.0),
+        (2000, 1.1, 2.1, 3.1),
+        (3000, 1.2, 2.2, 3.2),
+    ]
+
+
+def test_history_buffer_prune_drops_old_points_and_empty_tracks():
+    hist = tracker_capture.HistoryBuffer(window_s=10)
+    hist.add_raw(1000, 1.0, 2.0, 3.0)
+    hist.add_raw(50000, 1.0, 2.0, 3.0)
+    hist.write_event("OLD", 1000, 1, [{"timestamp": 1000, "delay": 1.0, "doppler": 2.0, "snr": 3.0}])
+    hist.write_event("NEW", 50000, 1, [{"timestamp": 50000, "delay": 1.0, "doppler": 2.0, "snr": 3.0}])
+
+    hist.prune(now_ms=51000)  # window_s=10 -> cutoff = 41000
+
+    assert [p[0] for p in hist.raw_points] == [50000]
+    assert "OLD" not in hist.tracks
+    assert "NEW" in hist.tracks
+
+
+# ── Always-on capture lifecycle ─────────────────────────────────────────────
+
+def test_start_runs_immediately_with_zero_viewers():
+    client = FakeBlah2Client([])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+    assert _wait_until(service.is_running)
+
+
+def test_detach_does_not_stop_capture(monkeypatch):
+    stub_render(monkeypatch, None)
+    client = FakeBlah2Client([])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+    assert _wait_until(service.is_running)
+
+    q = service.attach()
+    service.detach(q)
+    time.sleep(0.1)
+    # Unlike Phase 2, capture never stops on detach — only rendering does.
+    assert service.is_running()
+
+
+def test_no_render_without_viewers(monkeypatch):
+    calls = stub_render(monkeypatch, None)
+    client = FakeBlah2Client([make_frame(1000), make_frame(2000), make_frame(3000)])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+
+    time.sleep(0.3)  # plenty of render-interval ticks with data and zero viewers
+    assert calls == []
+
+
+def test_render_only_after_attach(monkeypatch):
+    calls = stub_render(monkeypatch, None)
+    client = FakeBlah2Client([make_frame(1000)])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+    time.sleep(0.1)
+    assert calls == []  # no viewer yet
+
+    q = service.attach()
+    assert _wait_until(lambda: len(calls) >= 1)
+    assert service.latest_image() == b"fake-png"
+    service.detach(q)
+
+
+def test_attach_requests_immediate_render_without_waiting_full_interval(monkeypatch):
+    # RENDER_INTERVAL_S is patched small already, so use an artificially large
+    # one here to prove attach() bypasses the wait rather than just being fast.
+    monkeypatch.setattr(tracker_capture, "RENDER_INTERVAL_S", 10.0)
+    calls = stub_render(monkeypatch, None)
+    client = FakeBlah2Client([make_frame(1000)])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+    time.sleep(0.05)  # let the frame land in history before attaching
+
+    q = service.attach()
+    assert _wait_until(lambda: len(calls) >= 1, timeout=1.0)
+    service.detach(q)
+
+
+def test_prune_runs_independent_of_viewers(monkeypatch):
+    stub_render(monkeypatch, None)
+    client = FakeBlah2Client([make_frame(1000)])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.history.window_s = 0  # anything with a timestamp is immediately "old"
+    service.start()
+
+    assert _wait_until(lambda: len(service.history.raw_points) == 1, timeout=1.0)
+    # No viewer ever attached, but pruning must still run on its own cadence.
+    assert _wait_until(lambda: len(service.history.raw_points) == 0, timeout=1.0)
+
+
+def test_render_failure_does_not_kill_capture_loop(monkeypatch):
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("boom")
+
+    stub_render(monkeypatch, None, side_effect=flaky)
+    client = FakeBlah2Client([make_frame(1000), make_frame(2000)])
+    service = tracker_capture.TrackerCaptureService(client)
+    service.start()
+
+    q = service.attach()
+    assert _wait_until(lambda: calls["n"] >= 2, timeout=2.0)
+    assert service.is_running()
+    service.detach(q)

--- a/tests/test_tracker_capture.py
+++ b/tests/test_tracker_capture.py
@@ -2,10 +2,11 @@
 
 Stubs retina-tracker's Tracker/get_config so these tests exercise only our
 own threading/history/refresh-gating logic, not retina-tracker's Kalman
-filtering — matching tests/test_calibrate.py's approach of not re-testing a
-dependency's own internals.
+filtering or the JS/Plotly frontend — a dependency's own internals aren't
+re-tested here.
 """
 
+import queue
 import time
 from unittest.mock import patch
 
@@ -361,3 +362,38 @@ def test_clear_route_calls_request_clear(app_client):
     assert resp.status_code == 200
     assert resp.get_json() == {"success": True}
     mock_clear.assert_called_once()
+
+
+def test_index_page_renders(app_client):
+    resp = app_client.get('/tracker-preview')
+    assert resp.status_code == 200
+    assert b'Tracker Preview' in resp.data
+    assert b'clearBufferBtn' in resp.data
+
+
+def test_events_route_attaches_yields_message_and_detaches_on_close(app_client):
+    """The SSE connection's lifetime IS the attach()/detach() lifecycle —
+    this is the contract the whole viewer-gated capture design depends on,
+    so it's worth testing at the actual route level, not just against
+    TrackerCaptureService directly."""
+    import app as app_module
+
+    q = queue.Queue()
+    q.put(7)  # pre-queued so the generator's first q.get() returns immediately
+
+    with patch.object(app_module.tracker_capture, 'attach', return_value=q) as mock_attach, \
+         patch.object(app_module.tracker_capture, 'detach') as mock_detach:
+        resp = app_client.get('/tracker-preview/events')
+        assert resp.status_code == 200
+        assert resp.content_type.startswith('text/event-stream')
+
+        # Pull exactly one chunk — the generator pauses at its `yield` and
+        # won't attempt a second (blocking) q.get() until asked for more,
+        # so this can't hang even though the loop itself is infinite.
+        first_chunk = next(resp.response)
+        assert b'"seq": 7' in first_chunk
+
+        resp.close()  # WSGI close() contract -> generator's finally -> detach()
+
+    mock_attach.assert_called_once()
+    mock_detach.assert_called_once_with(q)

--- a/tests/test_tracker_capture.py
+++ b/tests/test_tracker_capture.py
@@ -1,9 +1,9 @@
 """Tests for TrackerCaptureService's always-on capture / lazy-refresh lifecycle.
 
-Stubs retina-tracker's Tracker/get_config so these tests exercise only our
-own threading/history/refresh-gating logic, not retina-tracker's Kalman
-filtering or the JS/Plotly frontend — a dependency's own internals aren't
-re-tested here.
+Uses a FakeRetinaTrackerClient stand-in for the sidecar so these tests
+exercise only our own threading/history/refresh-gating logic, not
+retina-tracker's Kalman filtering (which runs out-of-process now) or the
+JS/Plotly frontend — a dependency's own internals aren't re-tested here.
 """
 
 import queue
@@ -27,15 +27,29 @@ class FakeBlah2Client:
         return self._responses.pop(0)
 
 
-class FakeTracker:
-    """Records process_frame calls instead of doing real Kalman tracking."""
+class FakeRetinaTrackerClient:
+    """Stand-in for RetinaTrackerClient: records send_frame calls, and
+    lets tests simulate the tailer thread's on_event callback synchronously
+    via simulate_event() instead of touching a real socket/file."""
 
-    def __init__(self, config=None, event_writer=None):
-        self.calls = []
-        self.event_writer = event_writer
+    def __init__(self):
+        self.sent_frames = []
+        self._on_event = None
 
-    def process_frame(self, detections, timestamp):
-        self.calls.append((detections, timestamp))
+    def send_frame(self, frame):
+        self.sent_frames.append(frame)
+
+    def start(self, on_event):
+        self._on_event = on_event
+
+    def simulate_event(self, event):
+        assert self._on_event is not None, "start() not called yet"
+        self._on_event(event)
+
+
+def make_service(client=None, tracker_client=None):
+    return tracker_capture.TrackerCaptureService(
+        client or FakeBlah2Client([]), tracker_client or FakeRetinaTrackerClient())
 
 
 def _wait_until(predicate, timeout=2.0, interval=0.02):
@@ -53,12 +67,6 @@ def fast_intervals(monkeypatch):
     monkeypatch.setattr(tracker_capture, "POLL_INTERVAL_S", 0.01)
     monkeypatch.setattr(tracker_capture, "RENDER_INTERVAL_S", 0.03)
     monkeypatch.setattr(tracker_capture, "PRUNE_INTERVAL_S", 0.05)
-
-
-@pytest.fixture(autouse=True)
-def stub_tracker(monkeypatch):
-    monkeypatch.setattr(tracker_capture, "Tracker", FakeTracker)
-    monkeypatch.setattr(tracker_capture, "get_config", lambda: {})
 
 
 def make_frame(ts, delay=1.0, doppler=2.0, snr=3.0):
@@ -165,11 +173,52 @@ def test_history_buffer_to_dict_shape():
     }
 
 
+# ── Sidecar integration ─────────────────────────────────────────────────────
+
+def test_run_pushes_raw_frame_to_tracker_client(monkeypatch):
+    stub_refresh(monkeypatch, None)
+    tracker_client = FakeRetinaTrackerClient()
+    client = FakeBlah2Client([make_frame(1000, delay=1.5, doppler=2.5, snr=4.0)])
+    service = make_service(client, tracker_client)
+    service.start()
+
+    assert _wait_until(lambda: len(tracker_client.sent_frames) == 1)
+    # The raw frame is pushed, not the per-detection dicts frame_to_detections()
+    # builds for add_raw() — retina-tracker's wire format wants the parallel
+    # arrays, not per-detection dicts.
+    assert tracker_client.sent_frames[0] == {
+        "timestamp": 1000, "delay": [1.5], "doppler": [2.5], "snr": [4.0],
+    }
+
+
+def test_on_track_event_writes_into_history_buffer():
+    tracker_client = FakeRetinaTrackerClient()
+    service = make_service(tracker_client=tracker_client)
+    service.start()
+
+    tracker_client.simulate_event({
+        "track_id": "T1",
+        "timestamp": 1000,
+        "length": 1,
+        "detections": [{"timestamp": 1000, "delay": 1.5, "doppler": 2.5, "snr": 4.0}],
+    })
+
+    assert service.history.tracks["T1"] == [(1000, 1.5, 2.5, 4.0)]
+
+
+def test_start_wires_tracker_client_tailer_to_on_track_event():
+    tracker_client = FakeRetinaTrackerClient()
+    service = make_service(tracker_client=tracker_client)
+    service.start()
+
+    assert tracker_client._on_event == service.on_track_event
+
+
 # ── Always-on capture lifecycle ─────────────────────────────────────────────
 
 def test_start_runs_immediately_with_zero_viewers():
     client = FakeBlah2Client([])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
     assert _wait_until(service.is_running)
 
@@ -177,7 +226,7 @@ def test_start_runs_immediately_with_zero_viewers():
 def test_detach_does_not_stop_capture(monkeypatch):
     stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
     assert _wait_until(service.is_running)
 
@@ -191,7 +240,7 @@ def test_detach_does_not_stop_capture(monkeypatch):
 def test_no_refresh_without_viewers(monkeypatch):
     calls = stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([make_frame(1000), make_frame(2000), make_frame(3000)])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
 
     time.sleep(0.3)  # plenty of refresh-interval ticks with data and zero viewers
@@ -201,7 +250,7 @@ def test_no_refresh_without_viewers(monkeypatch):
 def test_refresh_only_after_attach(monkeypatch):
     calls = stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([make_frame(1000)])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
     time.sleep(0.1)
     assert calls == []  # no viewer yet
@@ -218,7 +267,7 @@ def test_attach_requests_immediate_refresh_without_waiting_full_interval(monkeyp
     monkeypatch.setattr(tracker_capture, "RENDER_INTERVAL_S", 10.0)
     calls = stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([make_frame(1000)])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
     time.sleep(0.05)  # let the frame land in history before attaching
 
@@ -230,7 +279,7 @@ def test_attach_requests_immediate_refresh_without_waiting_full_interval(monkeyp
 def test_prune_runs_independent_of_viewers(monkeypatch):
     stub_refresh(monkeypatch, None)
     client = FakeBlah2Client([make_frame(1000)])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.history.window_s = 0  # anything with a timestamp is immediately "old"
     service.start()
 
@@ -249,7 +298,7 @@ def test_refresh_failure_does_not_kill_capture_loop(monkeypatch):
 
     stub_refresh(monkeypatch, None, side_effect=flaky)
     client = FakeBlah2Client([make_frame(1000), make_frame(2000)])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
 
     q = service.attach()
@@ -276,7 +325,7 @@ def test_request_clear_wipes_history_from_capture_thread():
     # snapshot reset lives in _run() itself, not in _refresh_data().
     now = _now_ms()
     client = FakeBlah2Client([make_frame(now), make_frame(now + 10)])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
     assert _wait_until(lambda: len(service.history.raw_points) >= 2, timeout=1.0)
 
@@ -291,7 +340,7 @@ def test_request_clear_runs_without_viewers():
     # No viewer ever attached — proves the clear branch is unconditional,
     # same as prune() already is, not gated on has_viewers.
     client = FakeBlah2Client([make_frame(_now_ms())])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
     assert _wait_until(lambda: len(service.history.raw_points) >= 1, timeout=1.0)
 
@@ -303,7 +352,7 @@ def test_request_clear_runs_without_viewers():
 def test_frame_after_clear_populates_fresh_buffer():
     now = _now_ms()
     client = FakeBlah2Client([make_frame(now), make_frame(now + 10)])
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
     assert _wait_until(lambda: len(service.history.raw_points) >= 2, timeout=1.0)
 
@@ -320,7 +369,7 @@ def test_clear_requested_during_active_capture_does_not_corrupt_state():
     now = _now_ms()
     frames = [make_frame(now + i * 10) for i in range(20)]
     client = FakeBlah2Client(frames)
-    service = tracker_capture.TrackerCaptureService(client)
+    service = make_service(client)
     service.start()
 
     deadline = time.monotonic() + 1.0


### PR DESCRIPTION
## Summary
This branch was previously merged as #44 ("20260712 tracker preview") and then reverted off `main` (the merge commit was removed) so retina-tracker could be moved out-of-process into a sidecar container before re-landing. It now contains:

- The original tracker-preview feature: a live delay-Doppler track plot (Plotly) for verifying real-data tracking, fed by an always-on capture service.
- **New**: retina-tracker moved out of an in-process pip dependency into a standalone Docker sidecar (offworldlabs/retina-tracker#14, offworldlabs/retina-node#20). `tracker_capture.py` now pushes detection frames to the sidecar over TCP and tails its JSONL output file for track events, instead of importing and driving a local `Tracker` object directly.
- `HistoryBuffer` gained a lock (previously documented as capture-thread-only; now also written to from the sidecar client's tailer thread).

Auto-Calibrate's separate retina-tracker usage (`calibrator.py`, on `20260708-auto-calibrate`) is explicitly out of scope here and untouched.

## Why
Client wants to verify real-data tracking with a color-coded delay-Doppler plot. Moving retina-tracker to a sidecar decouples it from retina-gui's Python runtime/deploy story (no more pip-installing a tracking algorithm into a Flask app's system Python).

## Test plan
- [x] `pytest` — 26 tests in `test_tracker_capture.py`, including new coverage for the sidecar client wiring
- [x] Full end-to-end live verification on jonathan-node-2 (real blah2 traffic → sidecar → confirmed tracks → UI), including targeted failure-mode tests: sidecar down at startup, container restart/output-truncation recovery, burst of 2000 frames, and a live radar→spectrum→radar mode switch — all passed
- [ ] `retina_tracker_client.py` itself has no unit tests yet (only live-verified) — flagging as a known gap, not a blocker in my view given the live coverage, but noting it for reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)