### PR TITLE
20260721 - Expose retina-tracker's min_snr as a per-node /config setting

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -157,6 +157,7 @@ class ConfigManager:
         location = {}
         truth = {}
         tar1090 = {}
+        retina_tracker = {}
 
         for key, value in form_data.items():
             if value == '':
@@ -182,6 +183,8 @@ class ConfigManager:
                 truth[key[6:]] = parsed  # Remove 'truth.' prefix
             elif key.startswith('tar1090.'):
                 tar1090[key[8:]] = parsed  # Remove 'tar1090.' prefix
+            elif key.startswith('retina_tracker.'):
+                retina_tracker[key[15:]] = parsed  # Remove 'retina_tracker.' prefix
 
         # Handle unchecked checkboxes (they don't get submitted)
         # Only add checkbox defaults if there's other capture data (not just checkboxes)
@@ -197,7 +200,7 @@ class ConfigManager:
         if tar1090 and 'adsblol_fallback' not in tar1090:
             tar1090['adsblol_fallback'] = False
 
-        return capture, location, truth, tar1090
+        return capture, location, truth, tar1090, retina_tracker
 
     def compute_user_overrides(self, submitted_nested, merged_config, existing_user_config, section_key):
         """Compare submitted values against merged config, return only values that differ.

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -163,6 +163,19 @@ class AdsbTruthConfig(BaseModel):
 
 
 # ============================================================================
+# retina-tracker Settings
+# ============================================================================
+
+class RetinaTrackerConfig(BaseModel):
+    """retina-tracker sidecar settings (flat for form display).
+
+    Unrelated to blah2's own built-in tracker (process.tracker in
+    capture config) - this tunes github.com/offworldlabs/retina-tracker.
+    """
+    min_snr: float = Field(gt=0, title="Minimum SNR", description="dB. Detections below this are discarded before tracking even begins - too high and the tracker will never confirm a track. Tune to this node's real noise floor.")
+
+
+# ============================================================================
 # tar1090 Settings
 # ============================================================================
 

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -4,7 +4,7 @@ import subprocess
 from pydantic import ValidationError
 from config_schema import (
     AdsbTruthConfig, Tar1090Config,
-    CaptureFormConfig, LocationFormConfig,
+    CaptureFormConfig, LocationFormConfig, RetinaTrackerConfig,
 )
 from form_utils import schema_to_form_fields
 
@@ -39,12 +39,16 @@ def config_page():
     tar1090_values = config_mgr.parse_tar1090_adsb_source(config)
     tar1090_fields = schema_to_form_fields(Tar1090Config, tar1090_values)
 
+    retina_tracker_values = (config.get('retina_tracker', {}) or {})
+    retina_tracker_fields = schema_to_form_fields(RetinaTrackerConfig, retina_tracker_values)
+
     return render_template("config.html",
                            retina_installed=retina_installed,
                            capture_fields=capture_fields,
                            location_fields=location_fields,
                            truth_fields=truth_fields,
                            tar1090_fields=tar1090_fields,
+                           retina_tracker_fields=retina_tracker_fields,
                            towers_cache=device_state.get_towers_cache(),
                            ssh_keys=ssh_keys.get_keys())
 
@@ -76,7 +80,7 @@ def save_config():
     from app import config_mgr
     from config_manager import ConfigManager
 
-    capture_flat, location_flat, truth_data, tar1090_data = ConfigManager.parse_flat_form_data(request.form.to_dict())
+    capture_flat, location_flat, truth_data, tar1090_data, retina_tracker_data = ConfigManager.parse_flat_form_data(request.form.to_dict())
 
     all_errors = {}
 
@@ -104,6 +108,12 @@ def save_config():
         except ValidationError as e:
             all_errors.update(ConfigManager.format_validation_errors(e, 'tar1090'))
 
+    if retina_tracker_data:
+        try:
+            RetinaTrackerConfig(**retina_tracker_data)
+        except ValidationError as e:
+            all_errors.update(ConfigManager.format_validation_errors(e, 'retina_tracker'))
+
     if all_errors:
         from app import ssh_keys, DEV_MODE, device_state
         return render_template("config.html",
@@ -112,6 +122,7 @@ def save_config():
                                location_fields=schema_to_form_fields(LocationFormConfig, location_flat),
                                truth_fields=schema_to_form_fields(AdsbTruthConfig, truth_data),
                                tar1090_fields=schema_to_form_fields(Tar1090Config, tar1090_data),
+                               retina_tracker_fields=schema_to_form_fields(RetinaTrackerConfig, retina_tracker_data),
                                towers_cache=device_state.get_towers_cache(),
                                config_errors=all_errors,
                                ssh_keys=ssh_keys.get_keys())
@@ -133,7 +144,7 @@ def save_config():
 
     new_user_config = {}
     for key in existing_user:
-        if key not in ('capture', 'location', 'truth', 'tar1090'):
+        if key not in ('capture', 'location', 'truth', 'tar1090', 'retina_tracker'):
             new_user_config[key] = existing_user[key]
 
     if capture_flat:
@@ -156,6 +167,11 @@ def save_config():
         tar1090_overrides = config_mgr.compute_user_overrides(tar1090_nested, merged_config, existing_user, 'tar1090')
         if tar1090_overrides:
             new_user_config['tar1090'] = tar1090_overrides
+
+    if retina_tracker_data:
+        retina_tracker_overrides = config_mgr.compute_user_overrides(retina_tracker_data, merged_config, existing_user, 'retina_tracker')
+        if retina_tracker_overrides:
+            new_user_config['retina_tracker'] = retina_tracker_overrides
 
     config_mgr.save_user_config(new_user_config)
     return redirect(url_for("config.config_page") + "?saved=1")

--- a/templates/config.html
+++ b/templates/config.html
@@ -92,6 +92,7 @@
         <a href="#capture">Capture</a>
         <a href="#truth">ADS-B truth</a>
         <a href="#tar1090">tar1090</a>
+        <a href="#retina-tracker">Retina Tracker</a>
         <h3>Administration</h3>
         <a href="#ssh">SSH access</a>
         <a href="#cloud">Cloud services</a>
@@ -332,6 +333,19 @@
                     {% endif %}
                 </div>
                 {% endif %}
+            </div>
+        </section>
+
+        {# ── Retina Tracker ── #}
+        <section id="retina-tracker" class="cfg-section">
+            <div class="cfg-section-head">
+                <h2>Retina Tracker</h2>
+                <span class="desc">Tuning for the retina-tracker sidecar's track confirmation.</span>
+            </div>
+            <div class="cfg-body" {% if not retina_installed %}style="opacity:.5;pointer-events:none;"{% endif %}>
+                {% for field in retina_tracker_fields %}
+                    {{ render_field(field, 'retina_tracker') }}
+                {% endfor %}
             </div>
         </section>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,9 @@ def sample_merged_config():
             'adsb_source': '192.168.8.183,30005,beast_in',
             'adsblol_fallback': True,
             'adsblol_radius': 40
+        },
+        'retina_tracker': {
+            'min_snr': 7.0
         }
     }
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -486,6 +486,37 @@ class TestTruthSave:
         assert b'is-invalid' in response.data
 
 
+class TestRetinaTrackerSave:
+    """Test saving retina_tracker config.
+
+    Note: retina_tracker fields use 'retina_tracker.' prefix directly
+    (e.g., 'retina_tracker.min_snr') since RetinaTrackerConfig is a flat
+    schema, same as AdsbTruthConfig.
+
+    With layered config, only values that differ from merged config are saved.
+    """
+
+    def test_save_valid_retina_tracker_config(self, app_client, user_config_file):
+        """Valid retina_tracker config should save changed values."""
+        response = app_client.post('/config/save', data={
+            'retina_tracker.min_snr': '4.5',  # Different from merged (was 7.0)
+        }, follow_redirects=False)
+
+        assert response.status_code == 302
+
+        with open(user_config_file) as f:
+            saved = yaml.safe_load(f)
+        assert saved['retina_tracker']['min_snr'] == 4.5
+
+    def test_invalid_min_snr(self, app_client):
+        """min_snr <= 0 should show error."""
+        response = app_client.post('/config/save', data={
+            'retina_tracker.min_snr': '0',  # Invalid: must be > 0
+        })
+        assert response.status_code == 200
+        assert b'is-invalid' in response.data
+
+
 class TestApplyConfigRoute:
     """Test the /config/apply POST route."""
 
@@ -624,7 +655,7 @@ class TestParseFlatFormData:
         """Flat capture fields should be parsed correctly."""
         from config_manager import ConfigManager
 
-        capture, location, truth, tar1090 = ConfigManager.parse_flat_form_data({
+        capture, location, truth, tar1090, retina_tracker = ConfigManager.parse_flat_form_data({
             'capture.fs': '2000000',
             'capture.fc': '503000000',
             'capture.device_type': 'RspDuo',
@@ -642,7 +673,7 @@ class TestParseFlatFormData:
         """Flat location fields should be parsed correctly."""
         from config_manager import ConfigManager
 
-        capture, location, truth, tar1090 = ConfigManager.parse_flat_form_data({
+        capture, location, truth, tar1090, retina_tracker = ConfigManager.parse_flat_form_data({
             'location.rx_latitude': '37.7644',
             'location.rx_longitude': '-122.3954',
             'location.rx_altitude': '23',
@@ -658,7 +689,7 @@ class TestParseFlatFormData:
         """String integers should be converted to int."""
         from config_manager import ConfigManager
 
-        capture, _, _, _ = ConfigManager.parse_flat_form_data({
+        capture, _, _, _, _ = ConfigManager.parse_flat_form_data({
             'capture.fs': '12345'
         })
         assert capture['fs'] == 12345
@@ -668,7 +699,7 @@ class TestParseFlatFormData:
         """String floats should be converted to float."""
         from config_manager import ConfigManager
 
-        _, location, _, _ = ConfigManager.parse_flat_form_data({
+        _, location, _, _, _ = ConfigManager.parse_flat_form_data({
             'location.rx_latitude': '37.7644'
         })
         assert location['rx_latitude'] == 37.7644
@@ -678,7 +709,7 @@ class TestParseFlatFormData:
         """Negative values should be parsed correctly."""
         from config_manager import ConfigManager
 
-        capture, location, _, _ = ConfigManager.parse_flat_form_data({
+        capture, location, _, _, _ = ConfigManager.parse_flat_form_data({
             'capture.device_agcSetPoint': '-50',
             'location.rx_longitude': '-122.3954'
         })
@@ -689,7 +720,7 @@ class TestParseFlatFormData:
         """Boolean true values should be converted."""
         from config_manager import ConfigManager
 
-        capture, _, _, _ = ConfigManager.parse_flat_form_data({
+        capture, _, _, _, _ = ConfigManager.parse_flat_form_data({
             'capture.device_dabNotch': 'on'
         })
         assert capture['device_dabNotch'] is True
@@ -698,7 +729,7 @@ class TestParseFlatFormData:
         """Empty strings should be skipped."""
         from config_manager import ConfigManager
 
-        capture, _, _, _ = ConfigManager.parse_flat_form_data({
+        capture, _, _, _, _ = ConfigManager.parse_flat_form_data({
             'capture.fs': '123',
             'capture.fc': ''
         })
@@ -709,7 +740,7 @@ class TestParseFlatFormData:
         """Non-numeric strings should stay as strings."""
         from config_manager import ConfigManager
 
-        capture, _, _, _ = ConfigManager.parse_flat_form_data({
+        capture, _, _, _, _ = ConfigManager.parse_flat_form_data({
             'capture.device_type': 'RspDuo'
         })
         assert capture['device_type'] == 'RspDuo'

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 from config_schema import (
     CaptureFormConfig, LocationFormConfig, AdsbTruthConfig, Tar1090Config,
+    RetinaTrackerConfig,
     load_yaml_file, save_yaml_file, values_differ
 )
 
@@ -220,6 +221,22 @@ class TestAdsbTruthConfig:
                 enabled=True, tar1090='x', adsb2dd='x',
                 delay_tolerance=-1, doppler_tolerance=5.0
             )
+
+
+class TestRetinaTrackerConfig:
+    """Test retina_tracker config validation."""
+
+    def test_valid_config(self):
+        """Valid config should pass."""
+        config = RetinaTrackerConfig(min_snr=4.5)
+        assert config.min_snr == 4.5
+
+    def test_min_snr_must_be_positive(self):
+        """min_snr must be > 0."""
+        with pytest.raises(ValidationError):
+            RetinaTrackerConfig(min_snr=0)
+        with pytest.raises(ValidationError):
+            RetinaTrackerConfig(min_snr=-1)
 
 
 class TestTar1090Config:


### PR DESCRIPTION
## Summary
- `min_snr` is retina-tracker's detection-confirmation threshold, applied as a hard pre-filter before any tracking logic runs. It was previously hardcoded (default `7.0`) with no way to tune it per-node — on a node whose real detections run lower, the tracker could silently never confirm a single track no matter how good the search geometry is.
- Adds `RetinaTrackerConfig` (flat schema, same pattern as `AdsbTruthConfig`) and a new "Retina Tracker" section on `/config`, wired through the existing layered default/user/merged config system so only actual overrides get written to `user.yml`.

Depends on the companion [retina-node PR](https://github.com/offworldlabs/retina-node/pull/22), which generates the `retina-tracker.yaml` file this value ultimately reaches.

## Test plan
- [x] 4 new tests: schema validation (valid + `min_snr <= 0` rejected), save round-trip through the real `/config/save` route, invalid-value error rendering. Full suite: 323 passed, same 11 pre-existing failures as clean `main` (confirmed identical baseline), zero regressions.
- [x] Verified live on a desk node: `/config` renders the new section and current merged value; submitted a real save through the route and confirmed `user.yml` picked up the override; confirmed via `/config/apply` (the actual production apply flow) that the sidecar container picks up the new value on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)