### PR TITLE
Add live per-tuner peak dBFS meter to Capture config

### DIFF
--- a/src/blah2_client.py
+++ b/src/blah2_client.py
@@ -26,3 +26,8 @@ class Blah2Client:
     def get_detection(self):
         """Latest per-CPI CFAR detections: {timestamp, delay[], doppler[], snr[]}."""
         return self._get_json("/api/detection")
+
+    def get_rf_status(self):
+        """Per-tuner RF overload state + peak dBFS: {overloadA, overloadB,
+        peakDbfsA, peakDbfsB, timestamp}."""
+        return self._get_json("/capture/rf-status")

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -53,6 +53,13 @@ def config_page():
                            ssh_keys=ssh_keys.get_keys())
 
 
+@bp.route("/config/rf-status")
+def rf_status():
+    """Live per-tuner RF overload + peak dBFS, proxied from blah2's API."""
+    from app import blah2_client
+    return jsonify(blah2_client.get_rf_status() or {})
+
+
 @bp.route("/ssh-keys", methods=["POST"])
 def add_key():
     from app import ssh_keys

--- a/static/common.css
+++ b/static/common.css
@@ -771,6 +771,28 @@ h1, h2, h3, h4, h5, h6 {
 .cfg-input-row .ds-input { flex: 1; }
 .cfg-input-row .unit { color: var(--ink-3); font-size: 12.5px; font-family: var(--font-mono); white-space: nowrap; }
 
+/* Per-tuner peak dBFS meter (rack-ladder style) */
+.peak-meter { display: flex; flex-direction: column; gap: 10px; padding: 2px 0 14px; }
+.peak-meter .ladder-row { display: flex; align-items: center; gap: 14px; }
+.peak-meter .ladder-name { width: 92px; flex: none; font-size: 13px; font-weight: 500; color: var(--ink); }
+.peak-meter .ladder-name .sub { display: block; font-size: 11px; font-weight: 400; color: var(--ink-3); margin-top: 1px; }
+.peak-meter .ladder-track { display: flex; flex-direction: row; gap: 3px; flex: 1; height: 20px; }
+.peak-meter .seg {
+    flex: 1; border-radius: 2px; background: var(--line-2);
+    transition: background-color 120ms linear, opacity 120ms linear;
+}
+.peak-meter .ladder-value {
+    font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+    font-size: 13.5px; font-weight: 500; color: var(--ink); width: 82px; text-align: right; flex: none;
+}
+.peak-meter .ladder-value .unit { color: var(--ink-3); font-size: 10.5px; font-weight: 400; margin-left: 2px; }
+.peak-meter .ladder-value.alarm { color: var(--danger); font-weight: 600; }
+.peak-meter .ladder-scale-row { display: flex; align-items: center; gap: 14px; }
+.peak-meter .ladder-name-spacer { width: 92px; flex: none; }
+.peak-meter .ladder-value-spacer { width: 82px; flex: none; }
+.peak-meter .ladder-ticks { display: flex; flex: 1; justify-content: space-between; }
+.peak-meter .ladder-ticks .t { font-family: var(--font-mono); font-size: 9px; color: var(--ink-3); }
+
 /* Readonly display */
 .cfg-readonly {
     display: flex; align-items: center; gap: 8px;

--- a/templates/config.html
+++ b/templates/config.html
@@ -275,6 +275,27 @@
                 <span class="desc">SDR sampling and gain. Touch with care — affects data quality.</span>
             </div>
             <div class="cfg-body" {% if not retina_installed %}style="opacity:.5;pointer-events:none;"{% endif %}>
+                <div class="cfg-row" style="padding:6px 0 2px;">
+                    <div class="label-col"><label>Signal peak</label><span class="help">Live peak level relative to clipping. 0 dBFS = saturated.</span></div>
+                </div>
+                <div class="peak-meter">
+                    <div class="ladder-row">
+                        <div class="ladder-name">Reference<span class="sub">Tuner A</span></div>
+                        <div class="ladder-track" id="peakTrackA"></div>
+                        <div class="ladder-value" id="peakValA">—</div>
+                    </div>
+                    <div class="ladder-row">
+                        <div class="ladder-name">Surveillance<span class="sub">Tuner B</span></div>
+                        <div class="ladder-track" id="peakTrackB"></div>
+                        <div class="ladder-value" id="peakValB">—</div>
+                    </div>
+                    <div class="ladder-scale-row">
+                        <div class="ladder-name-spacer"></div>
+                        <div class="ladder-ticks" id="peakTicks"></div>
+                        <div class="ladder-value-spacer"></div>
+                    </div>
+                </div>
+                <div class="divider"></div>
                 {% for field in capture_fields %}
                     {{ render_field(field, 'capture') }}
                 {% endfor %}
@@ -1232,6 +1253,158 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
             if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
         });
     });
+})();
+
+// Live per-tuner peak dBFS meter in the Capture section — rack-ladder style,
+// PPM-like ballistics (instant attack, timed decay) smooth the raw ~1s reports
+// from /config/rf-status into a settled reading instead of a jumpy one.
+(function() {
+    var trackA = document.getElementById('peakTrackA');
+    var trackB = document.getElementById('peakTrackB');
+    var valA = document.getElementById('peakValA');
+    var valB = document.getElementById('peakValB');
+    var ticksEl = document.getElementById('peakTicks');
+    if (!trackA || !trackB) return;
+
+    var FLOOR = -60, CEIL = 0, SEGMENTS = 24, DECAY_PER_SEC = 14;
+    var TICKS = [-60, -48, -36, -24, -12, -6, 0];
+
+    [trackA, trackB].forEach(function(track) {
+        for (var i = 0; i < SEGMENTS; i++) {
+            var seg = document.createElement('div');
+            seg.className = 'seg';
+            track.appendChild(seg);
+        }
+    });
+    TICKS.forEach(function(t) {
+        var lbl = document.createElement('div');
+        lbl.className = 't';
+        lbl.textContent = t;
+        ticksEl.appendChild(lbl);
+    });
+
+    function pct(dbfs) { return Math.min(100, Math.max(0, (dbfs - FLOOR) / (CEIL - FLOOR) * 100)); }
+    function segColor(i, n) {
+        var frac = i / n;
+        if (frac > 0.85) return 'var(--danger)';
+        if (frac > 0.6) return 'var(--warn)';
+        return 'var(--ok)';
+    }
+    function paintLadder(track, dbfs) {
+        var segs = track.children;
+        var n = segs.length;
+        var lit = Math.round((pct(dbfs) / 100) * n);
+        for (var i = 0; i < n; i++) {
+            segs[i].style.background = (i < lit) ? segColor(i, n) : '';
+        }
+    }
+    function paintLadderAlarm(track) {
+        var segs = track.children;
+        for (var i = 0; i < segs.length; i++) segs[i].style.background = 'var(--danger)';
+    }
+    function makeBallistics(start) {
+        // PPM-style ballistics: instant attack (snap up to a new, louder
+        // report), timed decay (ease down toward a quieter report instead of
+        // snapping). `raw` always reflects the latest report — it is NOT a
+        // running max — so `current` has something below it to decay toward.
+        var state = { current: start, raw: start, hasData: false };
+        return {
+            feed: function(newRaw) {
+                state.hasData = true;
+                state.raw = newRaw;
+                if (newRaw > state.current) state.current = newRaw;
+            },
+            clear: function() { state.hasData = false; },
+            tick: function(dtSec) {
+                if (state.current > state.raw) {
+                    state.current = Math.max(state.raw, state.current - DECAY_PER_SEC * dtSec);
+                }
+                return state;
+            }
+        };
+    }
+
+    var ballA = makeBallistics(FLOOR), ballB = makeBallistics(FLOOR);
+    var last = performance.now();
+
+    // Missing rf-status data isn't itself a hardware alarm — blah2 is
+    // intentionally stopped in spectrum/SDRconnect mode, and a single dropped
+    // poll or container restart is normal. Only escalate to "no signal" when
+    // radar mode says blah2 *should* be running and data has stayed missing
+    // for a sustained period (e.g. an overload-induced device crash).
+    var ALARM_GAP_MS = 4000;
+    var currentMode = null;   // unknown until checked; only re-checked while data is missing
+    var missingSinceMs = null;
+
+    // blah2 clamps peak to a minimum of 1 sample before taking log10 (to
+    // avoid log(0)), so "device never actually delivered a sample" reads as
+    // exactly 20*log10(1/32767) ≈ -90.3 dBFS — not "very quiet", which a real
+    // connected front end's own thermal noise would never actually reach.
+    // Treat a reading at/near that floor the same as missing data.
+    var NO_CAPTURE_THRESHOLD = -89;
+    function isFloorReading(dbfs) { return dbfs <= NO_CAPTURE_THRESHOLD; }
+
+    function isAlarming() {
+        return currentMode === 'radar' && missingSinceMs != null
+            && (performance.now() - missingSinceMs) >= ALARM_GAP_MS;
+    }
+
+    function frame(now) {
+        var dt = Math.min(0.25, (now - last) / 1000);
+        last = now;
+        var a = ballA.tick(dt), b = ballB.tick(dt);
+        if (isAlarming()) {
+            paintLadderAlarm(trackA); paintLadderAlarm(trackB);
+            valA.textContent = 'no signal'; valA.className = 'ladder-value alarm';
+            valB.textContent = 'no signal'; valB.className = 'ladder-value alarm';
+        } else {
+            valA.className = 'ladder-value'; valB.className = 'ladder-value';
+            if (a.hasData) {
+                paintLadder(trackA, a.current);
+                valA.innerHTML = a.current.toFixed(1) + '<span class="unit">dBFS</span>';
+            } else {
+                paintLadder(trackA, FLOOR - 1);
+                valA.textContent = '—';
+            }
+            if (b.hasData) {
+                paintLadder(trackB, b.current);
+                valB.innerHTML = b.current.toFixed(1) + '<span class="unit">dBFS</span>';
+            } else {
+                paintLadder(trackB, FLOOR - 1);
+                valB.textContent = '—';
+            }
+        }
+        requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+
+    function pollCapturePeak() {
+        fetch('/config/rf-status')
+            .then(function(r) { return r.json(); })
+            .then(function(s) {
+                var noCapture = s.peakDbfsA == null || s.peakDbfsB == null
+                    || isFloorReading(s.peakDbfsA) || isFloorReading(s.peakDbfsB);
+                if (noCapture) {
+                    if (missingSinceMs == null) missingSinceMs = performance.now();
+                    ballA.clear(); ballB.clear();
+                    // Refresh mode only while it actually matters (data missing) —
+                    // no extra request during normal healthy operation.
+                    return fetch('/api/mode')
+                        .then(function(r) { return r.json(); })
+                        .then(function(m) { currentMode = m.mode; })
+                        .catch(function() {});
+                }
+                missingSinceMs = null;
+                ballA.feed(s.peakDbfsA);
+                ballB.feed(s.peakDbfsB);
+            })
+            .catch(function() {
+                if (missingSinceMs == null) missingSinceMs = performance.now();
+                ballA.clear(); ballB.clear();
+            })
+            .then(function() { setTimeout(pollCapturePeak, 1000); });
+    }
+    pollCapturePeak();
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Adds a live per-tuner peak signal meter to the Capture section of `/config` — a 24-segment horizontal LED-style bar per tuner (Reference/Surveillance), fixed green/amber/red zones, real numeric dBFS value alongside
- Client-side ballistics (instant attack, timed decay) smooth the raw ~1s reports from the backend into a settled reading instead of a jumpy one
- Escalates to a "no signal" alarm only when the node's mode indicates capture should be running *and* valid data has been absent for a sustained period (~4s) — deliberately does not fire during spectrum/SDRconnect mode or brief blips, and also treats blah2's own zero-sample floor reading as "no signal" rather than a misleadingly specific number
- Depends on the companion PR in blah2-arm to actually populate the values; degrades gracefully to "—" without it

## Test plan
- [x] Core dBFS/ballistics math and the "no signal" alarm-gating logic verified against representative scenarios in an isolated test harness before ever touching a real device
- [x] Template renders correctly via the app's own test client; confirmed no interaction with existing page functionality (mode-switching JS, scroll-spy, CSRF handling, form submission, the setup-wizard guard) — see review notes in the PR discussion if needed
- [x] Deployed to two real nodes; confirmed live values update correctly and correlate with the hardware's own overload signal (near-clipping readings coincide with overload=true, healthy readings coincide with overload=false)
- [x] Confirmed the "no signal" alarm fires correctly on a real hardware fault encountered during testing (a temporary device-detection failure), where the naive "is the value present" check would have shown a misleading specific number instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)