### PR TITLE
20260803 - Recreate retina-tracker on the radar switch, unstale the apply tests

### DIFF
--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -209,7 +209,7 @@ def set_mode():
 
             result = subprocess.run(
                 ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate',
-                 'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
+                 'blah2', 'blah2_api', 'blah2_web', 'blah2_host', 'retina-tracker'],
                 cwd=RETINA_NODE_PATH,
                 capture_output=True, text=True, timeout=120
             )
@@ -279,7 +279,7 @@ def enforce_radar_mode(retina_node_path: str) -> None:
                        capture_output=True, timeout=30)
         subprocess.run(
             ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate',
-             'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
+             'blah2', 'blah2_api', 'blah2_web', 'blah2_host', 'retina-tracker'],
             cwd=retina_node_path, capture_output=True, timeout=120
         )
     except Exception:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -538,17 +538,23 @@ class TestApplyConfigRoute:
         data = json.loads(response.data)
         assert data['success'] is True
 
-        # Should have called docker compose twice
-        assert mock_run.call_count == 2
+        # config-merger, stop retina-spectrum, rm retina-spectrum,
+        # restart sdrplay.service, then recreate the stack
+        assert mock_run.call_count == 5
 
-        # Check first call (config-merger)
-        first_call = mock_run.call_args_list[0]
-        assert 'config-merger' in first_call[0][0]
+        assert 'config-merger' in mock_run.call_args_list[0][0][0]
 
-        # Check second call (up -d --force-recreate)
-        second_call = mock_run.call_args_list[1]
-        assert 'up' in second_call[0][0]
-        assert '--force-recreate' in second_call[0][0]
+        stop_args = mock_run.call_args_list[1][0][0]
+        assert 'stop' in stop_args and 'retina-spectrum' in stop_args
+
+        rm_args = mock_run.call_args_list[2][0][0]
+        assert 'rm' in rm_args and 'retina-spectrum' in rm_args
+
+        assert mock_run.call_args_list[3][0][0] == ['systemctl', 'restart', 'sdrplay.service']
+
+        up_args = mock_run.call_args_list[4][0][0]
+        assert 'up' in up_args
+        assert '--force-recreate' in up_args
 
     @patch('subprocess.run')
     def test_apply_config_merger_fails(self, mock_run, app_client):
@@ -568,8 +574,12 @@ class TestApplyConfigRoute:
     @patch('subprocess.run')
     def test_apply_restart_fails(self, mock_run, app_client):
         """Apply should return error if restart fails."""
-        # First call succeeds, second fails
+        # config-merger, stop/rm retina-spectrum and the sdrplay restart all
+        # succeed; only the final stack recreate fails.
         mock_run.side_effect = [
+            MagicMock(returncode=0, stdout='', stderr=''),
+            MagicMock(returncode=0, stdout='', stderr=''),
+            MagicMock(returncode=0, stdout='', stderr=''),
             MagicMock(returncode=0, stdout='', stderr=''),
             MagicMock(returncode=1, stdout='', stderr='restart error')
         ]

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -147,18 +147,31 @@ class TestSetMode:
 
         assert response.status_code == 200
         assert json.loads(response.data)['success'] is True
-        assert mock_run.call_count == 2
+        # stop retina-spectrum, rm retina-spectrum, restart sdrplay, up the radar stack
+        assert mock_run.call_count == 4
 
         stop_spectrum_args = mock_run.call_args_list[0][0][0]
         assert stop_spectrum_args[:4] == ['docker', 'compose', '-p', 'retina-node']
         assert 'stop' in stop_spectrum_args
         assert 'retina-spectrum' in stop_spectrum_args
 
-        start_args = mock_run.call_args_list[1][0][0]
-        assert start_args[:4] == ['docker', 'compose', '-p', 'retina-node']
-        assert 'start' in start_args
-        for svc in ('blah2', 'blah2_api', 'blah2_web', 'blah2_host'):
-            assert svc in start_args
+        rm_spectrum_args = mock_run.call_args_list[1][0][0]
+        assert 'rm' in rm_spectrum_args
+        assert 'retina-spectrum' in rm_spectrum_args
+
+        assert mock_run.call_args_list[2][0][0] == ['systemctl', 'restart', 'sdrplay.service']
+
+        up_args = mock_run.call_args_list[3][0][0]
+        assert up_args[:4] == ['docker', 'compose', '-p', 'retina-node']
+        assert 'up' in up_args
+        assert '--force-recreate' in up_args
+        # blah2_web/blah2_host read no config but were stopped on the way into
+        # spectrum mode, so they must be named here or they stay stopped.
+        # retina-tracker bind-mounts the config dir and reads config.yml at
+        # startup (--blah2-config), so it must be recreated to pick up any
+        # config change made while spectrum mode was active.
+        for svc in ('blah2', 'blah2_api', 'blah2_web', 'blah2_host', 'retina-tracker'):
+            assert svc in up_args
 
     @patch('subprocess.run')
     def test_switch_to_spectrum_writes_mode_file(self, mock_run, app_client, temp_dir):
@@ -215,16 +228,24 @@ class TestSetMode:
         assert 'timed out' in data['error'].lower()
 
     @patch('subprocess.run')
-    def test_mode_file_not_written_on_failure(self, mock_run, app_client, temp_dir):
-        """Mode file must not be updated when docker commands fail."""
+    def test_spectrum_mode_file_written_before_docker_even_on_failure(
+            self, mock_run, app_client, temp_dir):
+        """The spectrum transition writes mode.txt *before* touching Docker,
+        deliberately (see set_mode): the cron watchdog reads that file, and
+        if it were written only after a successful stop it could see blah2
+        down mid-transition and fire a spurious stack restart. A failed
+        transition therefore still leaves mode.txt == 'spectrum'."""
         mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='error')
 
-        app_client.post('/api/mode',
-                        data=json.dumps({'mode': 'spectrum'}),
-                        content_type='application/json')
+        response = app_client.post('/api/mode',
+                                   data=json.dumps({'mode': 'spectrum'}),
+                                   content_type='application/json')
 
-        mode_file = os.path.join(temp_dir, 'mode.txt')
-        assert not os.path.exists(mode_file)
+        assert response.status_code == 500
+        assert json.loads(response.data)['success'] is False
+
+        with open(os.path.join(temp_dir, 'mode.txt')) as f:
+            assert f.read().strip() == 'spectrum'
 
 
 class TestHomepageModeRendering:


### PR DESCRIPTION
## The fix

The radar-mode transition force-recreated `blah2`, `blah2_api`, `blah2_web` and `blah2_host` but **not `retina-tracker`** — which bind-mounts the config dir and reads `config.yml` at startup (`--blah2-config`). A config change made while spectrum mode was active left the tracker running on stale config until something else recreated it. Same omission in `enforce_radar_mode`, which the wizard calls on completion.

`blah2_web`/`blah2_host` stay in the list despite reading no config: the spectrum transition *stops* them, so they must be named here or they stay stopped.

## Test repairs

Three tests covering this path had gone stale and were failing on `main`, leaving it with no real coverage:

- `test_switch_to_radar_calls_correct_docker_commands` asserted 2 subprocess calls and a `start` subcommand; the path has made 4 calls and used `up --force-recreate` since the sdrplay restart was added.
- `test_apply_success` asserted 2 calls; `run_config_merger_and_restart` makes 5.
- `test_apply_restart_fails` supplied only 2 mocked results, so it tripped at the config-merger step and never reached the restart it was meant to be asserting on.

`test_mode_file_not_written_on_failure` asserted behaviour that was deliberately reversed — the spectrum transition now writes `mode.txt` *before* touching Docker so the cron watchdog can't see blah2 down mid-transition and fire a spurious restart. Rewritten to assert and explain that.

## Tests

`386 passed, 7 failed` — all 7 pre-existing on `main` (mender dev-tag tests, and tower-finder tests that reach the live service). This branch takes the failure count from 11 to 7.

## Context

Fell out of an investigation into config-apply timeouts and `docker compose` container-name conflicts. Measured on a loaded node, a full 7-container force-recreate takes ~13.5s against a 120s budget, so this change is about **correctness, not latency** — narrowing the recreate to only the config-reading services saves ~0.1s and was dropped from that plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)