### PR TITLE
20260803 - Serialize stack restarts and run config apply off the request

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -109,11 +109,13 @@ except Exception:
     pass
 
 
+from apply_service import ApplyService
 from blah2_client import Blah2Client
 from calibrator import Calibrator
 from retina_tracker_client import RetinaTrackerClient
 from tracker_capture import TrackerCaptureService
 
+apply_service = ApplyService(RETINA_NODE_PATH, dev_mode=DEV_MODE)
 blah2_client = Blah2Client(BLAH2_API_URL)
 retina_tracker_client = RetinaTrackerClient(
     RETINA_TRACKER_HOST, RETINA_TRACKER_PORT, RETINA_TRACKER_EVENTS_PATH)

--- a/src/app.py
+++ b/src/app.py
@@ -93,11 +93,17 @@ device_state.release_calibration_lock()
 # Enforce radar at the Docker level: stop and remove retina-spectrum if it is running.
 # retina-spectrum is only allowed while the wizard location step or config toggle is active.
 if config_mgr.is_retina_node_installed():
+    from restart_lock import restart_lock, OPPORTUNISTIC_TIMEOUT_SECONDS
     try:
-        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
-                       cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
-        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
-                       cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
+        # Opportunistic, and deliberately so: this runs before Flask serves
+        # anything, so a long wait here delays the whole GUI coming up. If
+        # something else holds the lock it is mid-restart and will stop
+        # retina-spectrum itself, so skipping costs nothing.
+        with restart_lock(DATA_DIR, timeout=OPPORTUNISTIC_TIMEOUT_SECONDS):
+            subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                           cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
+            subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                           cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
     except Exception:
         pass
 

--- a/src/apply_service.py
+++ b/src/apply_service.py
@@ -1,0 +1,171 @@
+"""Runs config apply (config-merger + stack restart) off the request thread.
+
+Why this exists, rather than /config/apply calling
+run_config_merger_and_restart directly as it used to:
+
+A whole apply measures ~45s on real hardware, two thirds of which is the
+SDRplay settle window — a fixed sleep with nothing to show for it. Run
+synchronously inside the POST, that is 45 seconds of a spinner that cannot
+distinguish "working" from "hung", and the only feedback the user ever gets
+is a single success/failure at the end. Users reasonably concluded it had
+stalled and clicked Apply again, which started a *second* `docker compose`
+against the same project: that is what produced the container-name
+conflicts ("The container name /tar1090 is already in use"), and the
+resulting contention is what pushed the compose step past its own 120s
+timeout and produced "Command timed out" — which re-enabled the button and
+invited yet another click.
+
+So the fix is two-part and both halves live here:
+
+  - The work runs on a background thread and the route returns immediately.
+    No HTTP timeout, proxy timeout, or closed tab can interrupt a restart
+    half-way through any more.
+  - A repeat request while one is already running does NOT start a second
+    run. It sets a re-run flag, and the worker starts one more pass when the
+    current one finishes. Since config-merger reads user.yml at the moment
+    it runs (it is never handed a snapshot), that single extra pass picks up
+    every config change saved in the meantime — which is exactly the "hold
+    the config and apply it at the right time" behaviour, without the user
+    having to time anything.
+
+Serialisation against *other* callers (mode switches, the cron watchdog,
+tower select) is not this class's job — that is the restart lock inside
+run_config_merger_and_restart. This class only ensures the config-apply
+path never queues work against itself.
+"""
+
+import threading
+from datetime import datetime, timezone
+
+PHASE_LABELS = {
+    'waiting_for_lock': 'Waiting for another restart to finish',
+    'merging': 'Merging configuration',
+    'stopping_spectrum': 'Releasing the SDR',
+    'restarting_sdr': 'Restarting the SDR service',
+    'settling': 'Waiting for the SDR to settle',
+    'recreating': 'Restarting radar services',
+}
+
+
+def _utcnow():
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ApplyService:
+    """One-at-a-time config apply with progress and request coalescing."""
+
+    def __init__(self, retina_node_path, dev_mode=False, restart_fn=None):
+        self._retina_node_path = retina_node_path
+        self._dev_mode = dev_mode
+        # Injected collaborator, same idiom as Calibrator's clients: tests
+        # pass a fake instead of monkeypatching routes.mode, which conftest's
+        # importlib.reload(app) would swap out from under them anyway.
+        # None means "resolve the real one lazily" — routes.mode imports app,
+        # and app constructs this class, so it cannot be imported at module
+        # load time without a cycle.
+        self._restart_fn = restart_fn
+        self._lock = threading.Lock()
+        self._thread = None
+        self._rerun_requested = False
+        self._status = self._idle_status()
+
+    @staticmethod
+    def _idle_status():
+        return {
+            'state': 'idle',       # idle | running | done | failed
+            'phase': None,
+            'phase_label': None,
+            'settle_remaining': None,
+            'error': None,
+            'queued': False,
+            'started_at': None,
+            'finished_at': None,
+        }
+
+    def get_status(self):
+        with self._lock:
+            return dict(self._status)
+
+    def is_running(self):
+        with self._lock:
+            return self._status['state'] == 'running'
+
+    def request(self):
+        """Start an apply, or coalesce into the one already running.
+
+        Returns the current status dict. Never raises, never blocks on the
+        actual work.
+        """
+        if self._dev_mode:
+            with self._lock:
+                self._status = self._idle_status()
+                self._status.update(state='done', finished_at=_utcnow())
+                return dict(self._status)
+
+        with self._lock:
+            if self._status['state'] == 'running':
+                # Coalesce: one more pass after the current one, which will
+                # pick up whatever is in user.yml by then.
+                self._rerun_requested = True
+                self._status['queued'] = True
+                return dict(self._status)
+
+            self._status = self._idle_status()
+            self._status.update(state='running', started_at=_utcnow())
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+            return dict(self._status)
+
+    def _set_phase(self, phase, detail=None):
+        with self._lock:
+            self._status['phase'] = phase
+            self._status['phase_label'] = PHASE_LABELS.get(phase)
+            self._status['settle_remaining'] = detail if phase == 'settling' else None
+
+    def _resolve_restart_fn(self):
+        if self._restart_fn is not None:
+            return self._restart_fn
+        from routes.mode import run_config_merger_and_restart
+        return run_config_merger_and_restart
+
+    def _run(self):
+        import subprocess
+        from restart_lock import BACKGROUND_TIMEOUT_SECONDS
+
+        restart = self._resolve_restart_fn()
+
+        while True:
+            error = None
+            try:
+                # Not attached to a request, so it can afford to queue behind
+                # a long operation (a mode switch, the watchdog) rather than
+                # give up and make the user click again.
+                error = restart(
+                    self._retina_node_path, on_phase=self._set_phase,
+                    lock_timeout=BACKGROUND_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                error = 'Command timed out'
+            except FileNotFoundError:
+                error = 'docker not found. Is it installed?'
+            except Exception as e:
+                error = str(e)
+
+            with self._lock:
+                # A request that arrived while this pass was running gets one
+                # more pass — but only one, however many arrived, since they
+                # would all merge the same user.yml.
+                if self._rerun_requested and error is None:
+                    self._rerun_requested = False
+                    self._status['queued'] = False
+                    continue
+                self._rerun_requested = False
+                self._status.update(
+                    state='failed' if error else 'done',
+                    phase=None,
+                    phase_label=None,
+                    settle_remaining=None,
+                    error=error,
+                    queued=False,
+                    finished_at=_utcnow(),
+                )
+                return

--- a/src/restart_lock.py
+++ b/src/restart_lock.py
@@ -1,0 +1,126 @@
+"""Cross-process mutex for anything that drives the retina-node Docker stack.
+
+Every path that runs `docker compose` against project `retina-node` must
+hold this lock for the whole operation. Without it these callers can and do
+collide — a `docker compose down` from the cron watchdog landing inside a
+GUI apply's `up -d --force-recreate` leaves containers renamed to
+`<hash>_<name>` and the daemon rejecting the real name as "already in use",
+which then breaks every subsequent apply until someone cleans up by hand.
+
+An fcntl.flock on a file, rather than the timestamp-file locks in
+device_state.py, for two reasons that both matter here:
+
+  - The kernel releases it when the holding process dies, so there is no
+    staleness heuristic that can be wrong. device_state's locks need
+    timeouts (INSTALL_LOCK_TIMEOUT and friends) precisely because a crashed
+    holder would otherwise wedge them forever; a restart is short and
+    frequent enough that guessing at a staleness window would be worse than
+    the problem it solves.
+  - flock(1) makes the same lock available to shell callers, so the cron
+    watchdog (blah2-arm/script/blah2_rspduo_restart.bash) can eventually
+    replace its point-in-time `pgrep -f "docker compose"` guard — which
+    cannot see the settle window in run_config_merger_and_restart, where no
+    compose process exists for ~30s but the operation is very much still in
+    flight — with `flock -n <file> -c ...` against this exact file.
+
+Deliberately NOT re-entrant: exactly one place in a call chain should take
+it (run_config_merger_and_restart for the config paths, set_mode for the
+mode transitions). flock is per-file-descriptor, so a nested acquire from
+the same process opens a second fd and blocks against itself forever.
+"""
+
+import errno
+import fcntl
+import os
+from contextlib import contextmanager
+
+LOCK_FILENAME = "restart.lock"
+
+# Synchronous HTTP callers (mode switch, tower select, calibrate apply) wait
+# this long for an in-flight restart before giving up and telling the user.
+# A whole restart measures ~45s on real hardware, most of it the settle
+# window, so this covers one queued operation plus headroom without leaving
+# a request hanging indefinitely.
+DEFAULT_TIMEOUT_SECONDS = 90
+
+# The async apply worker is not attached to a request, so it can afford to
+# wait out a long-running operation ahead of it rather than fail.
+BACKGROUND_TIMEOUT_SECONDS = 600
+
+POLL_SECONDS = 0.25
+
+
+class RestartBusy(Exception):
+    """Raised when the lock could not be acquired within the timeout."""
+
+
+def lock_path(data_dir):
+    return os.path.join(data_dir, LOCK_FILENAME)
+
+
+@contextmanager
+def restart_lock(data_dir, timeout=DEFAULT_TIMEOUT_SECONDS):
+    """Hold the stack-restart lock for the duration of the block.
+
+    Raises RestartBusy if it can't be acquired within `timeout` seconds.
+    Polls rather than using a blocking flock so the wait is bounded without
+    needing signals/alarms, which would not be safe on a Flask worker thread.
+    """
+    import time
+
+    path = lock_path(data_dir)
+    try:
+        os.makedirs(data_dir, exist_ok=True)
+    except OSError:
+        pass
+
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o644)
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as e:
+                if e.errno not in (errno.EACCES, errno.EAGAIN):
+                    raise
+                if time.monotonic() >= deadline:
+                    raise RestartBusy(
+                        "Another restart is already in progress. "
+                        "Wait for it to finish, then try again.")
+                time.sleep(POLL_SECONDS)
+
+        # Recorded for humans reading the file during an incident; the lock
+        # itself is held by the kernel, not by this content.
+        try:
+            os.ftruncate(fd, 0)
+            os.write(fd, f"pid={os.getpid()}\n".encode())
+        except OSError:
+            pass
+
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)
+
+
+def is_locked(data_dir):
+    """True if some process currently holds the lock. Advisory only — the
+    answer can be stale the instant it is returned, so this is for status
+    display, never for deciding whether it is safe to proceed.
+    """
+    path = lock_path(data_dir)
+    if not os.path.exists(path):
+        return False
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return False
+    except OSError:
+        return True
+    finally:
+        os.close(fd)

--- a/src/restart_lock.py
+++ b/src/restart_lock.py
@@ -47,6 +47,14 @@ DEFAULT_TIMEOUT_SECONDS = 90
 # wait out a long-running operation ahead of it rather than fail.
 BACKGROUND_TIMEOUT_SECONDS = 600
 
+# Fire-and-forget callers — GUI startup, and the wizard's navigate-away
+# beacon — where nobody is waiting on the result and whoever holds the lock
+# is already performing a restart that subsumes what this caller wanted
+# (both only stop/remove retina-spectrum, which every restart path does
+# defensively anyway). They give up quickly rather than queue: blocking GUI
+# startup behind a two-minute restart would be strictly worse than skipping.
+OPPORTUNISTIC_TIMEOUT_SECONDS = 10
+
 POLL_SECONDS = 0.25
 
 
@@ -59,15 +67,23 @@ def lock_path(data_dir):
 
 
 @contextmanager
-def restart_lock(data_dir, timeout=DEFAULT_TIMEOUT_SECONDS):
+def restart_lock(data_dir, timeout=None):
     """Hold the stack-restart lock for the duration of the block.
 
-    Raises RestartBusy if it can't be acquired within `timeout` seconds.
+    Raises RestartBusy if it can't be acquired within `timeout` seconds,
+    defaulting to DEFAULT_TIMEOUT_SECONDS. Resolved here rather than as a
+    default argument so the module constant stays adjustable at runtime — a
+    default argument binds once at import and silently ignores any later
+    change, which makes the wait untunable and every contention test pay the
+    full production timeout.
+
     Polls rather than using a blocking flock so the wait is bounded without
     needing signals/alarms, which would not be safe on a Flask worker thread.
     """
     import time
 
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT_SECONDS
     path = lock_path(data_dir)
     try:
         os.makedirs(data_dir, exist_ok=True)

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, render_template, request, redirect, url_for, jsonify
-import subprocess
 
 from pydantic import ValidationError
 from config_schema import (
@@ -186,27 +185,28 @@ def save_config():
 
 @bp.route("/config/apply", methods=["POST"])
 def apply_config():
-    """Run config-merger and restart services.
+    """Start a config apply and return immediately.
+
+    The work (config-merger, then in radar mode a stack restart) runs on a
+    background thread — see apply_service.py for why it is not done inline
+    on this request. Poll /config/apply/status for progress.
 
     In spectrum mode only config-merger runs — blah2 is intentionally stopped
     and must not be restarted until the user switches back to radar mode.
     """
-    from app import config_mgr, RETINA_NODE_PATH, DEV_MODE
-    from routes.mode import run_config_merger_and_restart
+    from app import apply_service, config_mgr, DEV_MODE
 
     if DEV_MODE:
-        return jsonify({"success": True})
+        return jsonify({"success": True, "status": apply_service.request()})
 
     if not config_mgr.is_retina_node_installed():
         return jsonify({"success": False, "error": "retina-node not installed"}), 400
 
-    try:
-        error = run_config_merger_and_restart(RETINA_NODE_PATH)
-        if error:
-            return jsonify({"success": False, "error": error}), 500
-        return jsonify({"success": True})
+    return jsonify({"success": True, "status": apply_service.request()}), 202
 
-    except subprocess.TimeoutExpired:
-        return jsonify({"success": False, "error": "Command timed out"}), 500
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)}), 500
+
+@bp.route("/config/apply/status", methods=["GET"])
+def apply_config_status():
+    """Progress of the current or most recent config apply."""
+    from app import apply_service
+    return jsonify(apply_service.get_status())

--- a/src/routes/mender_routes.py
+++ b/src/routes/mender_routes.py
@@ -187,11 +187,21 @@ def install():
             except Exception:
                 pass
             if already_installed:
+                # The lock is taken around this `down` only, not the whole
+                # install: an install runs for minutes and _recover() below
+                # calls enforce_radar_mode, which takes the lock itself —
+                # holding it across all of that would deadlock against
+                # ourselves, since flock is not re-entrant (see restart_lock).
+                # Long timeout because abandoning the down and installing on
+                # top of running containers is worse than waiting.
+                from app import DATA_DIR
+                from restart_lock import restart_lock, BACKGROUND_TIMEOUT_SECONDS
                 try:
-                    subprocess.run(
-                        ["docker", "compose", "-p", "retina-node", "down"],
-                        capture_output=True, timeout=60
-                    )
+                    with restart_lock(DATA_DIR, timeout=BACKGROUND_TIMEOUT_SECONDS):
+                        subprocess.run(
+                            ["docker", "compose", "-p", "retina-node", "down"],
+                            capture_output=True, timeout=60
+                        )
                 except Exception as e:
                     app.logger.warning(f"Pre-install docker down failed (continuing): {e}")
             success, error = mender.install_from_url(download_url)

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -332,7 +332,26 @@ def enforce_radar_mode(retina_node_path: str) -> None:
     Called on wizard completion so the node is always left in a clean radar
     state regardless of what happened during the wizard flow. Non-fatal: errors
     are swallowed so callers don't need to handle them.
+
+    Takes the restart lock like every other recreate path — this one matters
+    more than its "wizard completion" description suggests, because the
+    Mender install path also calls it from a background thread to recover a
+    failed install (see mender_routes), where nothing else would be
+    coordinating it with a concurrent apply. Failing to get the lock is
+    swallowed along with everything else here: whoever holds it is already
+    performing a restart, which leaves the stack up regardless.
     """
+    from app import DATA_DIR
+    from restart_lock import restart_lock
+
+    try:
+        with restart_lock(DATA_DIR):
+            _enforce_radar_mode_locked(retina_node_path)
+    except Exception:
+        pass
+
+
+def _enforce_radar_mode_locked(retina_node_path: str) -> None:
     try:
         subprocess.run(
             ['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
@@ -363,14 +382,20 @@ def release_spectrum():
     wizard location step mid-flow. Returns 204 — callers do not inspect the
     response body.
     """
-    from app import RETINA_NODE_PATH, config_mgr
+    from app import DATA_DIR, RETINA_NODE_PATH, config_mgr
+    from restart_lock import restart_lock, OPPORTUNISTIC_TIMEOUT_SECONDS
+
     if not config_mgr.is_retina_node_installed():
         return '', 204
     try:
-        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
-                       cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
-        subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
-                       cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
+        # Opportunistic: a beacon nobody waits on, and every restart path
+        # already stops retina-spectrum defensively, so giving up when the
+        # lock is busy loses nothing.
+        with restart_lock(DATA_DIR, timeout=OPPORTUNISTIC_TIMEOUT_SECONDS):
+            subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                           cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
+            subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                           cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
         _write_mode('radar')
     except Exception:
         pass

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -39,12 +39,61 @@ def _write_mode(mode):
         pass  # dev: no /data — in-memory cache is the fallback
 
 
-def run_config_merger_and_restart(retina_node_path: str) -> str | None:
+def _settle(seconds, on_phase):
+    """Sleep out the SDRplay settle window, reporting the remaining time.
+
+    Chunked rather than one flat sleep purely so callers can show a
+    countdown: this window is two thirds of a whole apply's wall time, and
+    a progress display that sits silent through it is indistinguishable
+    from a hang — which is what drove users to click Apply a second time
+    and collide two `docker compose` runs in the first place.
+    """
+    deadline = time.monotonic() + seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        on_phase('settling', int(remaining) + 1)
+        time.sleep(min(1.0, remaining))
+
+
+def run_config_merger_and_restart(retina_node_path: str, on_phase=None,
+                                  lock_timeout=None) -> str | None:
     """Run config-merger then, in radar mode, restart services.
 
+    Holds the stack-restart lock (see restart_lock.py) for the whole
+    operation, settle window included, so the cron watchdog and every other
+    caller queue behind it instead of interleaving `docker compose` runs
+    against the same project.
+
+    lock_timeout: how long to wait for that lock. Defaults to the short,
+    request-shaped wait, because /towers/select and /calibrate/apply still
+    call this inline on a Flask request thread and must not hang a browser
+    for minutes. ApplyService, which runs off-request, passes the long one.
+
+    on_phase: optional callback(phase, detail) for progress reporting.
     Returns an error string on failure, None on success.
     Lets TimeoutExpired and FileNotFoundError propagate — callers handle them.
     """
+    from app import DATA_DIR
+    from restart_lock import restart_lock, RestartBusy, DEFAULT_TIMEOUT_SECONDS
+
+    on_phase = on_phase or (lambda phase, detail=None: None)
+    if lock_timeout is None:
+        lock_timeout = DEFAULT_TIMEOUT_SECONDS
+
+    on_phase('waiting_for_lock', None)
+    try:
+        with restart_lock(DATA_DIR, timeout=lock_timeout):
+            return _run_config_merger_and_restart_locked(
+                retina_node_path, on_phase)
+    except RestartBusy as e:
+        return str(e)
+
+
+def _run_config_merger_and_restart_locked(retina_node_path, on_phase):
+    """The body of run_config_merger_and_restart, with the lock held."""
+    on_phase('merging', None)
     result = subprocess.run(
         ['docker', 'compose', '-p', 'retina-node', 'run', '--rm', 'config-merger'],
         cwd=retina_node_path,
@@ -58,6 +107,7 @@ def run_config_merger_and_restart(retina_node_path: str) -> str | None:
 
     # Defensive: ensure retina-spectrum is stopped before bringing the radar stack up.
     # Non-fatal — retina-spectrum may already be stopped.
+    on_phase('stopping_spectrum', None)
     try:
         subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
                        cwd=retina_node_path, capture_output=True, timeout=60)
@@ -69,14 +119,16 @@ def run_config_merger_and_restart(retina_node_path: str) -> str | None:
     # Force a clean sdrplay_apiService restart so the USB device is properly
     # re-initialised before blah2 claims it.  Mirrors what the watchdog does.
     # Non-fatal: no-op on dev machines without sdrplay.service.
+    on_phase('restarting_sdr', None)
     subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
                    capture_output=True, timeout=30)
 
     # See SDRPLAY_RESTART_SETTLE_SECONDS — without this, recreating the
     # containers immediately after the restart request returns has
     # repeatedly wedged the SDRplay device on real hardware.
-    time.sleep(SDRPLAY_RESTART_SETTLE_SECONDS)
+    _settle(SDRPLAY_RESTART_SETTLE_SECONDS, on_phase)
 
+    on_phase('recreating', None)
     result = subprocess.run(
         ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate'],
         cwd=retina_node_path,
@@ -121,110 +173,127 @@ def set_mode():
             _write_mode(mode)
             return jsonify({'success': True, 'mode': mode})
 
-        if mode == 'spectrum':
-            # Write mode first so the watchdog guard fires immediately and cannot
-            # see blah2 stopped mid-transition and trigger a spurious stack restart.
-            _write_mode(mode)
-
-            if current_mode == 'sdrconnect':
-                subprocess.run(['systemctl', 'stop', 'sdrconnect.service'],
-                               capture_output=True, timeout=30)
-            else:
-                result = subprocess.run(
-                    ['docker', 'compose', '-p', 'retina-node', 'stop',
-                     'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
-                    cwd=RETINA_NODE_PATH,
-                    capture_output=True, text=True, timeout=60
-                )
-                if result.returncode != 0:
-                    return jsonify({'success': False,
-                                    'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
-
-            result = subprocess.run(
-                ['docker', 'compose', '-p', 'retina-node', '--profile', 'spectrum', 'up', '-d', 'retina-spectrum'],
-                cwd=RETINA_NODE_PATH,
-                capture_output=True, text=True, timeout=120
-            )
-            if result.returncode != 0:
-                return jsonify({'success': False,
-                                'error': f'Failed to start retina-spectrum: {result.stderr or result.stdout}'}), 500
-
-        elif mode == 'sdrconnect':
-            # Write mode first, same reasoning as the spectrum transition above.
-            _write_mode(mode)
-
-            if current_mode == 'spectrum':
-                subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
-                               cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
-                subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
-                               cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
-            else:
-                result = subprocess.run(
-                    ['docker', 'compose', '-p', 'retina-node', 'stop',
-                     'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
-                    cwd=RETINA_NODE_PATH,
-                    capture_output=True, text=True, timeout=60
-                )
-                if result.returncode != 0:
-                    return jsonify({'success': False,
-                                    'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
-
-            # Force a clean sdrplay_apiService restart so the USB device is
-            # properly re-initialised before SDRconnect claims it.  Non-fatal.
-            subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
-                           capture_output=True, timeout=30)
-
-            result = subprocess.run(['systemctl', 'start', 'sdrconnect.service'],
-                                    capture_output=True, text=True, timeout=30)
-            if result.returncode != 0:
-                return jsonify({'success': False,
-                                'error': f'Failed to start sdrconnect.service: {result.stderr or result.stdout}'}), 500
-
-        else:  # radar
-            if current_mode == 'sdrconnect':
-                subprocess.run(['systemctl', 'stop', 'sdrconnect.service'],
-                               capture_output=True, timeout=30)
-            else:
-                result = subprocess.run(
-                    ['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
-                    cwd=RETINA_NODE_PATH,
-                    capture_output=True, text=True, timeout=60
-                )
-                if result.returncode != 0:
-                    return jsonify({'success': False,
-                                    'error': f'Failed to stop retina-spectrum: {result.stderr or result.stdout}'}), 500
-
-                # Remove the stopped container so it cannot be auto-restarted and
-                # so the SDR device is cleanly released before blah2 starts.
-                subprocess.run(
-                    ['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
-                    cwd=RETINA_NODE_PATH,
-                    capture_output=True, text=True, timeout=30
-                )
-
-            # Force a clean sdrplay_apiService restart so the USB device is
-            # properly re-initialised before blah2 claims it.  Non-fatal.
-            subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
-                           capture_output=True, timeout=30)
-
-            result = subprocess.run(
-                ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate',
-                 'blah2', 'blah2_api', 'blah2_web', 'blah2_host', 'retina-tracker'],
-                cwd=RETINA_NODE_PATH,
-                capture_output=True, text=True, timeout=120
-            )
-            if result.returncode != 0:
-                return jsonify({'success': False,
-                                'error': f'Failed to start blah2: {result.stderr or result.stdout}'}), 500
-
-            _write_mode(mode)
-
-        return jsonify({'success': True, 'mode': mode})
+        from app import DATA_DIR
+        from restart_lock import restart_lock, RestartBusy
+        try:
+            with restart_lock(DATA_DIR):
+                return _set_mode_locked(mode, current_mode, RETINA_NODE_PATH)
+        except RestartBusy as e:
+            return jsonify({'success': False, 'error': str(e)}), 409
 
     except subprocess.TimeoutExpired:
         return jsonify({'success': False, 'error': 'Command timed out'}), 500
     except Exception as e:
         return jsonify({'success': False, 'error': str(e)}), 500
+
+
+def _set_mode_locked(mode, current_mode, retina_node_path):
+    """The Docker/systemd half of set_mode, with the restart lock held.
+
+    Split out of set_mode purely so the lock scope is the whole transition
+    and not just one command: every branch here stops or starts containers
+    that another caller (a config apply, the cron watchdog) may be
+    recreating at the same instant.
+    """
+    if mode == 'spectrum':
+        # Write mode first so the watchdog guard fires immediately and cannot
+        # see blah2 stopped mid-transition and trigger a spurious stack restart.
+        _write_mode(mode)
+
+        if current_mode == 'sdrconnect':
+            subprocess.run(['systemctl', 'stop', 'sdrconnect.service'],
+                           capture_output=True, timeout=30)
+        else:
+            result = subprocess.run(
+                ['docker', 'compose', '-p', 'retina-node', 'stop',
+                 'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
+                cwd=retina_node_path,
+                capture_output=True, text=True, timeout=60
+            )
+            if result.returncode != 0:
+                return jsonify({'success': False,
+                                'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
+
+        result = subprocess.run(
+            ['docker', 'compose', '-p', 'retina-node', '--profile', 'spectrum', 'up', '-d', 'retina-spectrum'],
+            cwd=retina_node_path,
+            capture_output=True, text=True, timeout=120
+        )
+        if result.returncode != 0:
+            return jsonify({'success': False,
+                            'error': f'Failed to start retina-spectrum: {result.stderr or result.stdout}'}), 500
+
+    elif mode == 'sdrconnect':
+        # Write mode first, same reasoning as the spectrum transition above.
+        _write_mode(mode)
+
+        if current_mode == 'spectrum':
+            subprocess.run(['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                           cwd=retina_node_path, capture_output=True, timeout=60)
+            subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                           cwd=retina_node_path, capture_output=True, timeout=30)
+        else:
+            result = subprocess.run(
+                ['docker', 'compose', '-p', 'retina-node', 'stop',
+                 'blah2', 'blah2_api', 'blah2_web', 'blah2_host'],
+                cwd=retina_node_path,
+                capture_output=True, text=True, timeout=60
+            )
+            if result.returncode != 0:
+                return jsonify({'success': False,
+                                'error': f'Failed to stop blah2: {result.stderr or result.stdout}'}), 500
+
+        # Force a clean sdrplay_apiService restart so the USB device is
+        # properly re-initialised before SDRconnect claims it.  Non-fatal.
+        subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
+                       capture_output=True, timeout=30)
+
+        result = subprocess.run(['systemctl', 'start', 'sdrconnect.service'],
+                                capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            return jsonify({'success': False,
+                            'error': f'Failed to start sdrconnect.service: {result.stderr or result.stdout}'}), 500
+
+    else:  # radar
+        if current_mode == 'sdrconnect':
+            subprocess.run(['systemctl', 'stop', 'sdrconnect.service'],
+                           capture_output=True, timeout=30)
+        else:
+            result = subprocess.run(
+                ['docker', 'compose', '-p', 'retina-node', 'stop', 'retina-spectrum'],
+                cwd=retina_node_path,
+                capture_output=True, text=True, timeout=60
+            )
+            if result.returncode != 0:
+                return jsonify({'success': False,
+                                'error': f'Failed to stop retina-spectrum: {result.stderr or result.stdout}'}), 500
+
+            # Remove the stopped container so it cannot be auto-restarted and
+            # so the SDR device is cleanly released before blah2 starts.
+            subprocess.run(
+                ['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
+                cwd=retina_node_path,
+                capture_output=True, text=True, timeout=30
+            )
+
+        # Force a clean sdrplay_apiService restart so the USB device is
+        # properly re-initialised before blah2 claims it.  Non-fatal.
+        subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
+                       capture_output=True, timeout=30)
+
+        result = subprocess.run(
+            ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate',
+             'blah2', 'blah2_api', 'blah2_web', 'blah2_host', 'retina-tracker'],
+            cwd=retina_node_path,
+            capture_output=True, text=True, timeout=120
+        )
+        if result.returncode != 0:
+            return jsonify({'success': False,
+                            'error': f'Failed to start blah2: {result.stderr or result.stdout}'}), 500
+
+        _write_mode(mode)
+
+    return jsonify({'success': True, 'mode': mode})
 
 
 @bp.route('/api/spectrum/ready', methods=['GET'])

--- a/templates/config.html
+++ b/templates/config.html
@@ -1129,34 +1129,59 @@
     scan();
 })();
 
-// Auto-apply after successful save redirect
+// Auto-apply after successful save redirect.
+// The apply runs on the server's own thread — this only kicks it off and
+// then reports progress, so a slow apply (~45s, mostly the SDR settle
+// window) can't be mistaken for a hang and re-clicked into a second,
+// colliding docker compose run.
 if (window.location.search.includes('saved=1')) {
     history.replaceState({}, '', window.location.pathname);
     const btn = document.getElementById('applyBtn');
     const status = document.getElementById('applyStatus');
     if (btn) {
+        const spinner = '<span class="spinner-border spinner-border-sm" style="width:.8em;height:.8em;border-width:1.5px;"></span> ';
         btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.8em;height:.8em;border-width:1.5px;"></span> Applying…';
+        btn.innerHTML = spinner + 'Applying…';
+
+        const fail = msg => {
+            status.style.color = 'var(--danger)';
+            status.textContent = msg;
+            btn.disabled = false;
+            btn.textContent = 'Apply changes';
+        };
+
+        const poll = () => {
+            fetch('/config/apply/status')
+                .then(r => r.json())
+                .then(s => {
+                    if (s.state === 'running') {
+                        let label = s.phase_label || 'Applying…';
+                        if (s.phase === 'settling' && s.settle_remaining) {
+                            label += ' (' + s.settle_remaining + 's)';
+                        }
+                        if (s.queued) label += ' — your latest changes are queued';
+                        btn.innerHTML = spinner + label;
+                        status.style.color = '';
+                        status.textContent = '';
+                        setTimeout(poll, 1000);
+                    } else if (s.state === 'failed') {
+                        fail(s.error || 'Failed to apply');
+                    } else {
+                        status.style.color = 'var(--ok)';
+                        status.textContent = 'Applied successfully!';
+                        setTimeout(() => { window.location.href = '/config'; }, 800);
+                    }
+                })
+                .catch(() => setTimeout(poll, 2000));  // transient: keep watching
+        };
+
         fetch('/config/apply', { method: 'POST', headers: {'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content} })
             .then(r => r.json())
             .then(data => {
-                if (data.success) {
-                    status.style.color = 'var(--ok)';
-                    status.textContent = 'Applied successfully!';
-                    setTimeout(() => { window.location.href = '/config'; }, 800);
-                } else {
-                    status.style.color = 'var(--danger)';
-                    status.textContent = data.error || 'Failed to apply';
-                    btn.disabled = false;
-                    btn.textContent = 'Apply changes';
-                }
+                if (data.success === false) { fail(data.error || 'Failed to apply'); return; }
+                poll();
             })
-            .catch(e => {
-                status.style.color = 'var(--danger)';
-                status.textContent = 'Error: ' + e.message;
-                btn.disabled = false;
-                btn.textContent = 'Apply changes';
-            });
+            .catch(e => fail('Error: ' + e.message));
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -315,24 +315,54 @@ document.querySelectorAll('.svc-card[data-port]').forEach(function(el) {
 {% endif %}
 {% if retina_node_version %}
 <script>
+// Kicks off a server-side restart and then polls for progress — see
+// apply_service.py. The button stays disabled until the run reaches a
+// terminal state, so it can't be clicked into a second, colliding
+// docker compose run against the same project.
 document.getElementById('applyRestartBtn').addEventListener('click', function() {
     const btn = this;
     const status = document.getElementById('applyRestartStatus');
     if (btn.disabled) return;
+    const spinner = '<span class="spinner-border spinner-border-sm" style="width:.8em;height:.8em;border-width:1.5px;"></span> ';
+    const idleLabel = '<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 0-15-6.7L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 15 6.7L21 16"/><path d="M21 21v-5h-5"/></svg> Restart services';
     btn.disabled = true;
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.8em;height:.8em;border-width:1.5px;"></span> Restarting…';
+    btn.innerHTML = spinner + 'Restarting…';
     status.textContent = '';
+
+    const finish = (ok, msg) => {
+        status.style.color = ok ? 'var(--ok)' : 'var(--danger)';
+        status.textContent = msg;
+        btn.disabled = false;
+        btn.innerHTML = idleLabel;
+    };
+
+    const poll = () => {
+        fetch('/config/apply/status')
+            .then(r => r.json())
+            .then(s => {
+                if (s.state === 'running') {
+                    let label = s.phase_label || 'Restarting…';
+                    if (s.phase === 'settling' && s.settle_remaining) {
+                        label += ' (' + s.settle_remaining + 's)';
+                    }
+                    btn.innerHTML = spinner + label;
+                    setTimeout(poll, 1000);
+                } else if (s.state === 'failed') {
+                    finish(false, s.error || 'Failed');
+                } else {
+                    finish(true, 'Applied.');
+                }
+            })
+            .catch(() => setTimeout(poll, 2000));  // transient: keep watching
+    };
+
     fetch('/config/apply', { method: 'POST', headers: {'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content} })
         .then(r => r.json())
         .then(data => {
-            if (data.success) { status.style.color = 'var(--ok)';     status.textContent = 'Applied.'; }
-            else              { status.style.color = 'var(--danger)'; status.textContent = data.error || 'Failed'; }
+            if (data.success === false) { finish(false, data.error || 'Failed'); return; }
+            poll();
         })
-        .catch(e => { status.style.color = 'var(--danger)'; status.textContent = 'Error: ' + e.message; })
-        .finally(() => {
-            btn.disabled = false;
-            btn.innerHTML = '<svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 0-15-6.7L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 15 6.7L21 16"/><path d="M21 21v-5h-5"/></svg> Restart services';
-        });
+        .catch(e => finish(false, 'Error: ' + e.message));
 });
 </script>
 {% endif %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -518,7 +518,13 @@ class TestRetinaTrackerSave:
 
 
 class TestApplyConfigRoute:
-    """Test the /config/apply POST route."""
+    """The /config/apply POST + /config/apply/status GET pair.
+
+    Apply is asynchronous now (see apply_service.py): the POST only starts
+    the work and returns, so these cover the route's contract with the
+    service. The service's own behaviour — coalescing, phase reporting,
+    error capture — is covered in test_apply_service.py.
+    """
 
     def test_apply_not_installed(self, app_client_no_retina):
         """Apply should fail when retina-node not installed."""
@@ -528,79 +534,46 @@ class TestApplyConfigRoute:
         assert data['success'] is False
         assert 'not installed' in data['error']
 
-    @patch('subprocess.run')
-    def test_apply_success(self, mock_run, app_client):
-        """Apply should run docker commands on success."""
-        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+    def test_apply_starts_the_service_and_returns_immediately(self, app_client):
+        import app as app_module
+        with patch.object(app_module, 'apply_service') as svc:
+            svc.request.return_value = {'state': 'running', 'phase': 'merging'}
+            response = app_client.post('/config/apply')
 
-        response = app_client.post('/config/apply')
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = json.loads(response.data)
         assert data['success'] is True
+        assert data['status']['state'] == 'running'
+        svc.request.assert_called_once_with()
 
-        # config-merger, stop retina-spectrum, rm retina-spectrum,
-        # restart sdrplay.service, then recreate the stack
-        assert mock_run.call_count == 5
+    def test_repeat_apply_is_delegated_not_duplicated(self, app_client):
+        """The route always forwards to the one shared service, which is what
+        makes a second click coalesce rather than start a second docker
+        compose run. The coalescing itself is covered in test_apply_service.py.
+        """
+        import app as app_module
+        with patch.object(app_module, 'apply_service') as svc:
+            svc.request.return_value = {'state': 'running', 'queued': True}
+            app_client.post('/config/apply')
+            response = app_client.post('/config/apply')
 
-        assert 'config-merger' in mock_run.call_args_list[0][0][0]
+        assert svc.request.call_count == 2
+        assert json.loads(response.data)['status']['queued'] is True
 
-        stop_args = mock_run.call_args_list[1][0][0]
-        assert 'stop' in stop_args and 'retina-spectrum' in stop_args
+    def test_apply_status_reports_the_service_status(self, app_client):
+        import app as app_module
+        with patch.object(app_module, 'apply_service') as svc:
+            svc.get_status.return_value = {
+                'state': 'running', 'phase': 'settling',
+                'phase_label': 'Waiting for the SDR to settle',
+                'settle_remaining': 12,
+            }
+            response = app_client.get('/config/apply/status')
 
-        rm_args = mock_run.call_args_list[2][0][0]
-        assert 'rm' in rm_args and 'retina-spectrum' in rm_args
-
-        assert mock_run.call_args_list[3][0][0] == ['systemctl', 'restart', 'sdrplay.service']
-
-        up_args = mock_run.call_args_list[4][0][0]
-        assert 'up' in up_args
-        assert '--force-recreate' in up_args
-
-    @patch('subprocess.run')
-    def test_apply_config_merger_fails(self, mock_run, app_client):
-        """Apply should return error if config-merger fails."""
-        mock_run.return_value = MagicMock(
-            returncode=1,
-            stdout='',
-            stderr='config-merger error message'
-        )
-
-        response = app_client.post('/config/apply')
-        assert response.status_code == 500
+        assert response.status_code == 200
         data = json.loads(response.data)
-        assert data['success'] is False
-        assert 'config-merger failed' in data['error']
-
-    @patch('subprocess.run')
-    def test_apply_restart_fails(self, mock_run, app_client):
-        """Apply should return error if restart fails."""
-        # config-merger, stop/rm retina-spectrum and the sdrplay restart all
-        # succeed; only the final stack recreate fails.
-        mock_run.side_effect = [
-            MagicMock(returncode=0, stdout='', stderr=''),
-            MagicMock(returncode=0, stdout='', stderr=''),
-            MagicMock(returncode=0, stdout='', stderr=''),
-            MagicMock(returncode=0, stdout='', stderr=''),
-            MagicMock(returncode=1, stdout='', stderr='restart error')
-        ]
-
-        response = app_client.post('/config/apply')
-        assert response.status_code == 500
-        data = json.loads(response.data)
-        assert data['success'] is False
-        assert 'restart failed' in data['error']
-
-    @patch('subprocess.run')
-    def test_apply_timeout(self, mock_run, app_client):
-        """Apply should handle timeout gracefully."""
-        import subprocess
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd='docker', timeout=60)
-
-        response = app_client.post('/config/apply')
-        assert response.status_code == 500
-        data = json.loads(response.data)
-        assert data['success'] is False
-        assert 'timed out' in data['error'].lower()
+        assert data['phase'] == 'settling'
+        assert data['settle_remaining'] == 12
 
 
 class TestSSHKeysRoutes:

--- a/tests/test_apply_service.py
+++ b/tests/test_apply_service.py
@@ -1,0 +1,201 @@
+"""ApplyService: the background config-apply worker.
+
+The behaviours here are the ones that fix the reported bug — a slow apply
+being clicked a second time and turning into two concurrent `docker compose`
+runs against the same project (container-name conflicts, then timeouts).
+"""
+import subprocess
+import threading
+import time
+
+import pytest
+
+from apply_service import ApplyService
+
+
+def wait_until(predicate, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class FakeRestart:
+    """Stands in for run_config_merger_and_restart: blocks until released,
+    records each call, and reports whatever phases the test asks for."""
+
+    def __init__(self, error=None, phases=(), raises=None):
+        self.calls = 0
+        self.error = error
+        self.phases = phases
+        self.raises = raises
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.concurrent = False
+        self._in_flight = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, path, on_phase=None, lock_timeout=None):
+        with self._lock:
+            self._in_flight += 1
+            if self._in_flight > 1:
+                self.concurrent = True
+        try:
+            self.calls += 1
+            self.entered.set()
+            for phase, detail in self.phases:
+                if on_phase:
+                    on_phase(phase, detail)
+            self.release.wait(timeout=5)
+            if self.raises:
+                raise self.raises
+            return self.error
+        finally:
+            with self._lock:
+                self._in_flight -= 1
+
+
+@pytest.fixture
+def service():
+    """Builds an ApplyService wired to a FakeRestart.
+
+    The restart callable is injected rather than monkeypatched onto
+    routes.mode: conftest's app_client fixture calls importlib.reload(app),
+    which rebuilds that module, so a patched attribute there would silently
+    stop being the one this service calls.
+    """
+    def build(fake):
+        return ApplyService('/nonexistent', restart_fn=fake)
+    return build
+
+
+class TestAsyncBehaviour:
+
+    def test_request_returns_without_waiting_for_the_work(self, service):
+        fake = FakeRestart()
+        svc = service(fake)
+
+        status = svc.request()
+
+        assert status['state'] == 'running'
+        assert fake.entered.wait(timeout=5)
+        assert svc.get_status()['state'] == 'running'
+        fake.release.set()
+        assert wait_until(lambda: svc.get_status()['state'] == 'done')
+
+    def test_success_reports_done(self, service):
+        fake = FakeRestart()
+        svc = service(fake)
+        svc.request()
+        fake.entered.wait(timeout=5)
+        fake.release.set()
+
+        assert wait_until(lambda: svc.get_status()['state'] == 'done')
+        status = svc.get_status()
+        assert status['error'] is None
+        assert status['finished_at'] is not None
+
+    def test_failure_is_captured_not_raised(self, service):
+        fake = FakeRestart(error='restart failed: boom')
+        svc = service(fake)
+        svc.request()
+        fake.entered.wait(timeout=5)
+        fake.release.set()
+
+        assert wait_until(lambda: svc.get_status()['state'] == 'failed')
+        assert svc.get_status()['error'] == 'restart failed: boom'
+
+    def test_timeout_exception_is_captured(self, service):
+        fake = FakeRestart(raises=subprocess.TimeoutExpired(cmd='docker', timeout=120))
+        svc = service(fake)
+        svc.request()
+        fake.entered.wait(timeout=5)
+        fake.release.set()
+
+        assert wait_until(lambda: svc.get_status()['state'] == 'failed')
+        assert 'timed out' in svc.get_status()['error'].lower()
+
+
+class TestCoalescing:
+    """The actual bug: a second click must never become a second run."""
+
+    def test_second_request_while_running_does_not_run_concurrently(self, service):
+        fake = FakeRestart()
+        svc = service(fake)
+
+        svc.request()
+        assert fake.entered.wait(timeout=5)
+        second = svc.request()
+
+        assert second['queued'] is True
+        assert fake.calls == 1, "a second concurrent restart was started"
+        fake.release.set()
+        assert wait_until(lambda: svc.get_status()['state'] == 'done')
+        assert fake.concurrent is False
+
+    def test_queued_request_triggers_exactly_one_more_pass(self, service):
+        """However many clicks land during a run, they merge the same
+        user.yml, so one extra pass is enough — and is what picks up config
+        saved while the first pass was already in flight."""
+        fake = FakeRestart()
+        svc = service(fake)
+
+        svc.request()
+        assert fake.entered.wait(timeout=5)
+        svc.request()
+        svc.request()
+        svc.request()
+
+        fake.entered.clear()
+        fake.release.set()
+        assert wait_until(lambda: svc.get_status()['state'] == 'done', timeout=10)
+        assert fake.calls == 2
+
+    def test_failed_run_does_not_retry_the_queued_request(self, service):
+        """A queued re-run after a failure would loop against a node that is
+        already unhealthy; surface the error instead."""
+        fake = FakeRestart(error='config-merger failed: bad yaml')
+        svc = service(fake)
+
+        svc.request()
+        assert fake.entered.wait(timeout=5)
+        svc.request()
+        fake.release.set()
+
+        assert wait_until(lambda: svc.get_status()['state'] == 'failed')
+        assert fake.calls == 1
+        assert svc.get_status()['queued'] is False
+
+
+class TestProgress:
+
+    def test_phases_are_exposed_with_labels(self, service):
+        fake = FakeRestart(phases=[('merging', None), ('settling', 17)])
+        svc = service(fake)
+        svc.request()
+        assert fake.entered.wait(timeout=5)
+
+        assert wait_until(lambda: svc.get_status()['phase'] == 'settling')
+        status = svc.get_status()
+        assert status['phase_label'] == 'Waiting for the SDR to settle'
+        assert status['settle_remaining'] == 17
+
+        fake.release.set()
+        assert wait_until(lambda: svc.get_status()['state'] == 'done')
+        # Terminal status carries no stale phase from the run
+        assert svc.get_status()['phase'] is None
+        assert svc.get_status()['settle_remaining'] is None
+
+
+class TestDevMode:
+
+    def test_dev_mode_short_circuits(self):
+        called = []
+        svc = ApplyService('/nonexistent', dev_mode=True,
+                           restart_fn=lambda *a, **k: called.append(1))
+        status = svc.request()
+
+        assert status['state'] == 'done'
+        assert called == []

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -281,27 +281,61 @@ class TestRestartSettleTime:
     /towers/select, /calibrate/apply, /config/save+apply, wizard
     completion) — testing it here covers all of them at once."""
 
-    @patch('time.sleep')
     @patch('subprocess.run')
     def test_settles_between_sdrplay_restart_and_container_recreate(
-            self, mock_run, mock_sleep, app_client, temp_dir):
+            self, mock_run, app_client, temp_dir, monkeypatch):
         """The settle-time fix's whole point (diagnosed live tonight): the
-        sdrplay.service restart and the container recreate must not race."""
+        sdrplay.service restart and the container recreate must not race.
+
+        The settle is slept in ~1s chunks so callers can show a countdown
+        (see _settle), so this asserts the *total* time slept and that every
+        chunk of it falls between the restart and the recreate — not a
+        single flat sleep call, which is an implementation detail.
+        """
         import routes.mode as mode_module
+        monkeypatch.setattr(mode_module, 'SDRPLAY_RESTART_SETTLE_SECONDS', 30)
+
         order = []
+        clock = {'t': 0.0}
+        monkeypatch.setattr(mode_module.time, 'monotonic', lambda: clock['t'])
+
+        def fake_sleep(seconds):
+            clock['t'] += seconds
+            order.append(('sleep', seconds))
+        monkeypatch.setattr(mode_module.time, 'sleep', fake_sleep)
 
         def record_run(*a, **k):
             order.append(('run', a[0]))
             return MagicMock(returncode=0, stdout='', stderr='')
         mock_run.side_effect = record_run
-        mock_sleep.side_effect = lambda s: order.append(('sleep', s))
 
         error = mode_module.run_config_merger_and_restart(temp_dir)
         assert error is None
 
-        sleep_calls = [i for i, (kind, _) in enumerate(order) if kind == 'sleep']
-        assert len(sleep_calls) == 1
-        i = sleep_calls[0]
-        assert order[i][1] == mode_module.SDRPLAY_RESTART_SETTLE_SECONDS
-        assert 'systemctl' in order[i - 1][1]            # restart happened right before
-        assert '--force-recreate' in order[i + 1][1]     # recreate happens right after
+        sleep_idx = [i for i, (kind, _) in enumerate(order) if kind == 'sleep']
+        assert sleep_idx, "never settled"
+        assert sum(order[i][1] for i in sleep_idx) == 30
+
+        restart_idx = next(i for i, (kind, arg) in enumerate(order)
+                           if kind == 'run' and 'systemctl' in arg)
+        recreate_idx = next(i for i, (kind, arg) in enumerate(order)
+                            if kind == 'run' and '--force-recreate' in arg)
+        assert restart_idx < min(sleep_idx)
+        assert max(sleep_idx) < recreate_idx
+
+    @patch('subprocess.run')
+    def test_reports_each_phase_in_order(self, mock_run, app_client, temp_dir):
+        """The UI's progress display depends on these phases arriving in
+        order — a silent apply is what got clicked twice in the first place."""
+        import routes.mode as mode_module
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+
+        phases = []
+        error = mode_module.run_config_merger_and_restart(
+            temp_dir, on_phase=lambda phase, detail=None: phases.append(phase))
+
+        assert error is None
+        assert phases[0] == 'waiting_for_lock'
+        assert [p for p in phases if p != 'settling'] == [
+            'waiting_for_lock', 'merging', 'stopping_spectrum',
+            'restarting_sdr', 'recreating']

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -2,8 +2,12 @@
 import json
 import os
 import subprocess
+import threading
+import time
 import pytest
 from unittest.mock import patch, MagicMock, call
+
+from restart_lock import is_locked, restart_lock
 
 
 @pytest.fixture(autouse=True)
@@ -273,6 +277,119 @@ class TestHomepageModeRendering:
         response = app_client.get('/')
         assert b'Passive Radar' not in response.data
         assert b'49152' not in response.data
+
+
+class TestRestartLockCoverage:
+    """Every path that recreates or removes containers must hold the restart
+    lock — a `docker compose down` landing inside another caller's
+    `up -d --force-recreate` is what renames containers to <hash>_<name> and
+    leaves the daemon rejecting the real name as already in use."""
+
+    def test_enforce_radar_mode_takes_the_lock(self, app_client, temp_dir, monkeypatch):
+        import routes.mode as mode_module
+        import app as app_module
+        monkeypatch.setattr(app_module, 'DATA_DIR', temp_dir)
+
+        held = []
+        with patch('subprocess.run') as mock_run:
+            mock_run.side_effect = lambda *a, **k: (
+                held.append(is_locked(temp_dir)), MagicMock(returncode=0))[1]
+            mode_module.enforce_radar_mode(temp_dir)
+
+        assert held, "enforce_radar_mode ran no commands"
+        assert all(held), "ran docker commands without holding the lock"
+        assert is_locked(temp_dir) is False, "lock not released"
+
+    def test_enforce_radar_mode_skips_when_lock_is_busy(self, app_client, temp_dir, monkeypatch):
+        """Non-fatal by contract: whoever holds the lock is already
+        restarting, so this must not raise or hang."""
+        import routes.mode as mode_module
+        import app as app_module
+        import restart_lock as rl
+        monkeypatch.setattr(app_module, 'DATA_DIR', temp_dir)
+        monkeypatch.setattr(rl, 'DEFAULT_TIMEOUT_SECONDS', 0.1)
+
+        with restart_lock(temp_dir):
+            with patch('subprocess.run') as mock_run:
+                started = time.monotonic()
+                mode_module.enforce_radar_mode(temp_dir)
+                elapsed = time.monotonic() - started
+        assert mock_run.call_count == 0
+        assert elapsed < 5, f"waited {elapsed:.1f}s — timeout not honoured"
+
+    def test_release_spectrum_takes_the_lock(self, app_client, temp_dir, monkeypatch):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'DATA_DIR', temp_dir)
+
+        held = []
+        with patch('subprocess.run') as mock_run:
+            mock_run.side_effect = lambda *a, **k: (
+                held.append(is_locked(temp_dir)), MagicMock(returncode=0))[1]
+            response = app_client.post('/api/mode/release-spectrum')
+
+        assert response.status_code == 204
+        assert held and all(held)
+        assert is_locked(temp_dir) is False
+
+    def test_release_spectrum_gives_up_quickly_when_busy(self, app_client, temp_dir, monkeypatch):
+        """A sendBeacon nobody waits on must not block the request thread."""
+        import app as app_module
+        import restart_lock as rl
+        monkeypatch.setattr(app_module, 'DATA_DIR', temp_dir)
+        monkeypatch.setattr(rl, 'OPPORTUNISTIC_TIMEOUT_SECONDS', 0.1)
+
+        with restart_lock(temp_dir):
+            with patch('subprocess.run') as mock_run:
+                started = time.monotonic()
+                response = app_client.post('/api/mode/release-spectrum')
+                elapsed = time.monotonic() - started
+
+        assert response.status_code == 204
+        assert mock_run.call_count == 0
+        assert elapsed < 5, f"blocked for {elapsed:.1f}s on a fire-and-forget beacon"
+
+
+class TestNoSelfDeadlock:
+    """flock is not re-entrant, so a nested acquire from the same process
+    blocks against itself forever. These are the two call chains where that
+    is a live risk."""
+
+    def test_enforce_radar_mode_does_not_nest_inside_its_own_lock(
+            self, app_client, temp_dir, monkeypatch):
+        import routes.mode as mode_module
+        import app as app_module
+        monkeypatch.setattr(app_module, 'DATA_DIR', temp_dir)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+            done = threading.Event()
+
+            def run():
+                mode_module.enforce_radar_mode(temp_dir)
+                done.set()
+
+            t = threading.Thread(target=run, daemon=True)
+            t.start()
+            assert done.wait(timeout=20), "enforce_radar_mode deadlocked on its own lock"
+
+    def test_shared_restart_fn_does_not_nest(self, app_client, temp_dir, monkeypatch):
+        import routes.mode as mode_module
+        import app as app_module
+        monkeypatch.setattr(app_module, 'DATA_DIR', temp_dir)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+            done = threading.Event()
+            result = {}
+
+            def run():
+                result['error'] = mode_module.run_config_merger_and_restart(temp_dir)
+                done.set()
+
+            t = threading.Thread(target=run, daemon=True)
+            t.start()
+            assert done.wait(timeout=20), "run_config_merger_and_restart deadlocked"
+            assert result['error'] is None
 
 
 class TestRestartSettleTime:

--- a/tests/test_restart_lock.py
+++ b/tests/test_restart_lock.py
@@ -1,0 +1,120 @@
+"""restart_lock: the cross-process mutex every docker-compose caller takes.
+
+Without it, a `docker compose down` from the cron watchdog can land inside a
+GUI apply's `up -d --force-recreate` and leave containers renamed to
+<hash>_<name> with the daemon rejecting the real name as already in use.
+"""
+import multiprocessing
+import os
+import threading
+import time
+
+import pytest
+
+from restart_lock import (
+    RestartBusy, is_locked, lock_path, restart_lock,
+)
+
+
+class TestMutualExclusion:
+
+    def test_second_acquire_blocks_until_first_releases(self, temp_dir):
+        order = []
+        first_holding = threading.Event()
+        may_release = threading.Event()
+
+        def hold():
+            with restart_lock(temp_dir):
+                order.append('first-in')
+                first_holding.set()
+                may_release.wait(timeout=5)
+                order.append('first-out')
+
+        t = threading.Thread(target=hold)
+        t.start()
+        assert first_holding.wait(timeout=5)
+
+        with pytest.raises(RestartBusy):
+            with restart_lock(temp_dir, timeout=0.2):
+                order.append('second-in-too-early')
+
+        may_release.set()
+        t.join(timeout=5)
+
+        with restart_lock(temp_dir, timeout=2):
+            order.append('second-in')
+
+        assert order == ['first-in', 'first-out', 'second-in']
+
+    def test_excludes_a_separate_process(self, temp_dir):
+        """The watchdog is a different process entirely — a lock that only
+        works within this interpreter would not fix anything."""
+        holding = multiprocessing.Event()
+        release = multiprocessing.Event()
+
+        p = multiprocessing.Process(
+            target=_hold_lock_in_child, args=(temp_dir, holding, release))
+        p.start()
+        try:
+            assert holding.wait(timeout=10)
+            with pytest.raises(RestartBusy):
+                with restart_lock(temp_dir, timeout=0.5):
+                    pass
+        finally:
+            release.set()
+            p.join(timeout=10)
+
+        with restart_lock(temp_dir, timeout=2):
+            pass  # released with the child
+
+
+class TestRelease:
+
+    def test_released_when_the_body_raises(self, temp_dir):
+        with pytest.raises(ValueError):
+            with restart_lock(temp_dir):
+                raise ValueError('boom')
+
+        with restart_lock(temp_dir, timeout=1):
+            pass  # not wedged by the exception
+
+    def test_released_when_the_holder_process_dies(self, temp_dir):
+        """No staleness heuristic to get wrong: the kernel drops an flock
+        when its holder dies, however it dies."""
+        holding = multiprocessing.Event()
+
+        p = multiprocessing.Process(
+            target=_hold_lock_forever_in_child, args=(temp_dir, holding))
+        p.start()
+        assert holding.wait(timeout=10)
+        p.kill()
+        p.join(timeout=10)
+
+        with restart_lock(temp_dir, timeout=5):
+            pass
+
+
+class TestStatus:
+
+    def test_is_locked_tracks_the_lock(self, temp_dir):
+        assert is_locked(temp_dir) is False
+        with restart_lock(temp_dir):
+            assert is_locked(temp_dir) is True
+        assert is_locked(temp_dir) is False
+
+    def test_lock_file_is_created_under_the_data_dir(self, temp_dir):
+        target = os.path.join(temp_dir, 'nested')
+        with restart_lock(target):
+            assert os.path.exists(lock_path(target))
+
+
+def _hold_lock_in_child(data_dir, holding, release):
+    with restart_lock(data_dir, timeout=10):
+        holding.set()
+        release.wait(timeout=30)
+
+
+def _hold_lock_forever_in_child(data_dir, holding):
+    with restart_lock(data_dir, timeout=10):
+        holding.set()
+        time.sleep(60)


### PR DESCRIPTION
Fixes the reported failure: config changes had to be applied several times before they stuck, producing `Command timed out` and `docker compose` container-name conflicts (`The container name "/tar1090" is already in use`).

## The cause was not what it looked like

Measured on a loaded node: a healthy full-stack recreate takes **13.5s against its 120s budget**, and narrowing it to only the config-reading services saves ~0.1s. Stack size was never the problem — an earlier plan to narrow the recreate was measured, found worthless, and dropped.

What is: a whole apply takes **~45s, of which 30s is the fixed SDRplay settle sleep**, and it ran synchronously inside the POST with no progress reported. 45 seconds of a spinner indistinguishable from a hang, so users clicked Apply again. That second click started a second `docker compose` against the same project — which renames containers to `<hash>_<name>` and leaves the daemon rejecting the real name — and the resulting contention pushed the compose step past its own timeout, which re-enabled the button and invited another click.

## Two changes, one per half of that loop

**`restart_lock.py`** — a cross-process mutex every `docker compose` caller now takes. An `flock` rather than the timestamp-file locks in `device_state.py`, for two reasons that both matter: the kernel releases it when the holder dies, so no staleness heuristic can be wrong; and `flock(1)` exposes the same lock to shell callers, so the cron watchdog can later replace its `pgrep -f "docker compose"` guard — which is blind during the ~30s settle window where no compose process exists but the operation is very much still in flight.

**`apply_service.py`** — `/config/apply` starts the work on a background thread and returns 202, with `/config/apply/status` for progress. No HTTP timeout, proxy timeout or closed tab can interrupt a restart half-way through. A repeat request while one is running does not start a second run: it sets a re-run flag and the worker makes one more pass afterwards. `config-merger` reads `user.yml` when it runs rather than taking a snapshot, so that single extra pass picks up every change saved in the meantime — the "hold the config and apply it at the right time" behaviour, without the user timing anything.

Both UI callers now poll and show the live phase, including a countdown through the settle window, and stay disabled until terminal.

The second commit extends the lock to the four callers the first one missed: `enforce_radar_mode` (which the Mender install also calls from a background thread), the wizard's `release-spectrum` beacon, GUI startup, and the Mender pre-install `down`. The last two are opportunistic — nobody waits on them and whoever holds the lock already stops retina-spectrum — so they give up after 10s rather than block GUI boot behind a two-minute restart.

The Mender `down` is locked around that one command only: an install runs for minutes and its recovery path calls `enforce_radar_mode`, which takes the lock itself, so holding it throughout would deadlock against itself — `flock` is not re-entrant. Two tests cover exactly that for both nesting-prone call chains.

## Verified on hardware

Deployed to a node at load 4.3 and exercised live:

```
POST /config/apply -> HTTP 202 (immediate)
 0s  merging          33s  recreating
 2s  restarting_sdr   48s  done
 3s  settling  30s left
```

- lock held across the settle window: **yes**
- `docker compose` process running during that window: **no** — empirical proof of the watchdog's blind spot
- second Apply mid-run: `queued: true`, one extra pass, strictly sequential (96s for two passes), never concurrent
- release-spectrum beacon mid-apply: 204 in 10s, no containers touched
- no orphaned containers afterwards
- Apply exercised in a real browser: countdown renders, behaves

## Tests

`407 passed, 7 failed` — all 7 pre-existing on `main` (mender dev-tag tests, and tower-finder tests that reach the live service).

New: 9 `ApplyService` tests (coalescing, phases, error capture, dev mode), 6 lock tests including exclusion against a **separate process** and release when the holder is `kill -9`'d, plus lock-coverage and self-deadlock tests for the newly-locked callers.

`ApplyService` takes its restart callable as an injected collaborator rather than having tests monkeypatch `routes.mode` — conftest's `importlib.reload(app)` swaps that module out from under a patched attribute, which had four tests passing alone and failing in the full suite.

`restart_lock`'s timeout resolves inside the function instead of as a default argument; bound at import it was silently untunable, and one test file paid the full 90s production wait (5s → 97s → 11s).

## Known gaps, not in this PR

- A compose run killed mid-recreate (timeout, or a GUI restart — systemd kills the control group) still leaves `<hash>_<name>` orphans, and nothing reconciles them, including at boot. That state survives a reboot.
- The cron watchdog does not yet take this lock. It's a `blah2-arm` change; the lock now exists for it.
- `/towers/select` and `/calibrate/apply` are lock-safe but still block the request ~45s with no progress, and up to ~135s when queued. They should move onto `ApplyService` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)