### PR TITLE
20260803 - Self-heal containers left half-created by an interrupted restart

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -94,6 +94,7 @@ device_state.release_calibration_lock()
 # retina-spectrum is only allowed while the wizard location step or config toggle is active.
 if config_mgr.is_retina_node_installed():
     from restart_lock import restart_lock, OPPORTUNISTIC_TIMEOUT_SECONDS
+    from stack_reconcile import find_stale_containers, reconcile
     try:
         # Opportunistic, and deliberately so: this runs before Flask serves
         # anything, so a long wait here delays the whole GUI coming up. If
@@ -104,6 +105,25 @@ if config_mgr.is_retina_node_installed():
                            cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
             subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
                            cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
+
+            # Repair a recreate this process was killed in the middle of.
+            # systemd kills retina-gui's whole control group, so a crash, a
+            # restart or a redeploy during an apply takes the `docker
+            # compose` child with it — potentially after it renamed a
+            # container but before it removed the old one. Nothing else
+            # clears that, and it survives reboots: every apply from here on
+            # would fail on the name conflict. Cheap when there is nothing
+            # to do (one `docker ps`), so it runs unconditionally.
+            stale = find_stale_containers()
+            if stale:
+                app.logger.warning(
+                    f"Found {len(stale)} container(s) left half-created by an "
+                    f"interrupted restart: {', '.join(stale)}. Repairing.")
+                removed, error = reconcile(RETINA_NODE_PATH)
+                if error:
+                    app.logger.error(f"Startup repair failed: {error}")
+                else:
+                    app.logger.warning(f"Startup repair removed: {', '.join(removed)}")
     except Exception:
         pass
 

--- a/src/apply_service.py
+++ b/src/apply_service.py
@@ -44,6 +44,7 @@ PHASE_LABELS = {
     'restarting_sdr': 'Restarting the SDR service',
     'settling': 'Waiting for the SDR to settle',
     'recreating': 'Restarting radar services',
+    'repairing': 'Cleaning up after an interrupted restart',
 }
 
 

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -15,6 +15,16 @@ _mode_cache = 'radar'  # default mode if file read fails (e.g. dev environment w
 # claims it again.
 SDRPLAY_RESTART_SETTLE_SECONDS = 30
 
+# Budget for the stack recreate. Measured at 13.5s on a node under load
+# (4-core Pi at load 4.3), so this is ~20x headroom rather than a guess:
+# the old 120s was generous too, and what actually blew it was two compose
+# runs contending, not the work itself. Now that the restart lock makes that
+# contention impossible, the remaining reasons to exceed even this are a
+# genuinely stuck device or daemon — cases where killing the CLI mid-recreate
+# does real damage (see stack_reconcile), so it is worth waiting longer
+# before resorting to that.
+RECREATE_TIMEOUT_SECONDS = 300
+
 
 def get_current_mode():
     """Read persisted mode. Returns 'radar', 'spectrum', or 'sdrconnect'."""
@@ -129,15 +139,52 @@ def _run_config_merger_and_restart_locked(retina_node_path, on_phase):
     _settle(SDRPLAY_RESTART_SETTLE_SECONDS, on_phase)
 
     on_phase('recreating', None)
-    result = subprocess.run(
-        ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate'],
-        cwd=retina_node_path,
-        capture_output=True, text=True, timeout=120
-    )
+    try:
+        result = subprocess.run(
+            ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate'],
+            cwd=retina_node_path,
+            capture_output=True, text=True, timeout=RECREATE_TIMEOUT_SECONDS
+        )
+    except subprocess.TimeoutExpired:
+        # The CLI has just been SIGKILLed, quite possibly between renaming a
+        # container and removing the old one. Repair before returning, or
+        # every later apply fails on the name conflict it leaves behind.
+        return _repair(retina_node_path, on_phase,
+                       'Restarting the radar services timed out.')
+
     if result.returncode != 0:
-        return f'restart failed: {result.stderr or result.stdout}'
+        output = result.stderr or result.stdout
+        if _is_name_conflict(output):
+            return _repair(retina_node_path, on_phase,
+                           'Restarting the radar services hit a container name conflict.')
+        return f'restart failed: {output}'
 
     return None
+
+
+def _is_name_conflict(output):
+    """Compose failing because a half-recreated container still holds a name."""
+    lowered = (output or '').lower()
+    return 'already in use' in lowered or 'error when allocating new name' in lowered
+
+
+def _repair(retina_node_path, on_phase, reason):
+    """Clear half-recreated containers and restore the stack.
+
+    Runs with the restart lock still held (every caller of this is inside
+    _run_config_merger_and_restart_locked), which is what makes it safe to
+    remove containers here.
+    """
+    from stack_reconcile import reconcile
+
+    on_phase('repairing', None)
+    removed, error = reconcile(retina_node_path)
+    if error:
+        return f'{reason} Automatic repair also failed: {error}'
+    if removed:
+        return (f'{reason} Cleaned up {len(removed)} half-created '
+                f'container(s) and restarted — check the radar is running.')
+    return f'{reason} No half-created containers were left behind.'
 
 
 @bp.route('/api/mode', methods=['GET'])

--- a/src/stack_reconcile.py
+++ b/src/stack_reconcile.py
@@ -1,0 +1,107 @@
+"""Repair a retina-node compose project left half-recreated.
+
+Compose recreates a container by renaming the existing one to
+`<id-prefix>_<name>`, creating the replacement under the real name, then
+removing the old one. Interrupt it between the rename and the remove and the
+project is left with a container squatting a name compose is about to need:
+
+    Error response from daemon: Error when allocating new name: Conflict.
+    The container name "/tar1090" is already in use by container
+    "56f30a56ce9b..."
+
+Nothing clears that on its own, so **every subsequent apply fails the same
+way**, and the state survives a reboot. It is the difference between one bad
+restart and a node that can never accept a config change again.
+
+Two things interrupt a recreate mid-flight:
+
+  - subprocess.run's timeout, which SIGKILLs the compose CLI while the
+    daemon carries on with the operation;
+  - systemd restarting retina-gui.service, which kills the whole control
+    group — compose runs as a child of the Flask process, so a crash, a
+    `systemctl restart`, or a redeploy during an apply all do this.
+
+The second is why reconcile also runs at startup and not only after a failed
+compose call: by the time the GUI is back up, the process that could have
+cleaned up is gone.
+
+Scoped by compose's own project label rather than by name pattern. A bare
+`^[0-9a-f]{12}_` regex over `docker ps -a` would also match containers from
+other projects on the same host, and this removes what it finds.
+"""
+
+import re
+import subprocess
+
+PROJECT = "retina-node"
+PROJECT_LABEL = "com.docker.compose.project"
+
+# Compose's rename prefix: 12 hex chars of the container id, then the
+# original name.
+STALE_NAME_RE = re.compile(r"^[0-9a-f]{12}_")
+
+
+def find_stale_containers(project=PROJECT, timeout=30):
+    """Containers in `project` still carrying compose's rename prefix.
+
+    Returns a list of names; empty on any error, since this is only ever
+    used to decide whether to attempt a repair.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "-a",
+             "--filter", f"label={PROJECT_LABEL}={project}",
+             "--format", "{{.Names}}"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except Exception:
+        return []
+    if result.returncode != 0:
+        return []
+    return [name for name in result.stdout.split()
+            if STALE_NAME_RE.match(name)]
+
+
+def reconcile(retina_node_path, project=PROJECT, bring_up=True):
+    """Remove half-recreated containers and, optionally, restore the stack.
+
+    Callers must already hold the restart lock — this runs `docker rm -f`
+    and `docker compose up`, which is exactly the kind of work that must not
+    interleave with another caller's.
+
+    bring_up=False skips the `up`, for callers that must not start the radar
+    stack (spectrum/sdrconnect mode, where blah2 is deliberately stopped).
+
+    Returns (removed: list[str], error: str|None). Never raises.
+    """
+    stale = find_stale_containers(project)
+    if not stale:
+        return [], None
+
+    try:
+        result = subprocess.run(
+            ["docker", "rm", "-f", *stale],
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode != 0:
+            return [], f"could not remove {', '.join(stale)}: {result.stderr or result.stdout}"
+    except Exception as e:
+        return [], f"could not remove {', '.join(stale)}: {e}"
+
+    if not bring_up:
+        return stale, None
+
+    # Plain `up -d`, deliberately not --force-recreate: this is a repair, so
+    # it should create whatever the removals left missing and leave every
+    # healthy container alone.
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "-p", project, "up", "-d", "--remove-orphans"],
+            cwd=retina_node_path, capture_output=True, text=True, timeout=300,
+        )
+        if result.returncode != 0:
+            return stale, f"repair restart failed: {result.stderr or result.stdout}"
+    except Exception as e:
+        return stale, f"repair restart failed: {e}"
+
+    return stale, None

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -279,6 +279,104 @@ class TestHomepageModeRendering:
         assert b'49152' not in response.data
 
 
+CONFLICT_OUTPUT = (
+    'Error response from daemon: Error when allocating new name: Conflict. '
+    'The container name "/tar1090" is already in use by container "56f30a56ce9b".'
+)
+
+
+class TestRepairAfterInterruptedRecreate:
+    """A recreate killed between compose's rename and its remove leaves a
+    container squatting the name compose next needs. Nothing else clears it,
+    so without this repair every later apply fails identically, forever."""
+
+    def _run_apply(self, temp_dir, run_side_effect):
+        import routes.mode as mode_module
+        with patch('subprocess.run', side_effect=run_side_effect):
+            return mode_module.run_config_merger_and_restart(temp_dir)
+
+    def test_recreate_timeout_triggers_a_repair(self, app_client, temp_dir):
+        seen = []
+
+        def side_effect(args, **kwargs):
+            seen.append(args)
+            if '--force-recreate' in args:
+                raise subprocess.TimeoutExpired(cmd='docker', timeout=300)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return MagicMock(returncode=0, stdout='56f30a56ce9b_tar1090\n', stderr='')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+
+        assert error is not None and 'timed out' in error.lower()
+        assert 'cleaned up 1' in error.lower(), f"no repair reported: {error}"
+        assert any(a[:3] == ['docker', 'rm', '-f'] for a in seen), "never removed the stale container"
+
+    def test_name_conflict_triggers_a_repair(self, app_client, temp_dir):
+        seen = []
+
+        def side_effect(args, **kwargs):
+            seen.append(args)
+            if '--force-recreate' in args:
+                return MagicMock(returncode=1, stdout='', stderr=CONFLICT_OUTPUT)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return MagicMock(returncode=0, stdout='56f30a56ce9b_tar1090\n', stderr='')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+
+        assert error is not None
+        assert 'cleaned up 1' in error.lower(), f"no repair reported: {error}"
+        assert any(a[:3] == ['docker', 'rm', '-f'] for a in seen)
+
+    def test_unrelated_failure_does_not_trigger_a_repair(self, app_client, temp_dir):
+        """Repair removes containers — it must not fire on every failure."""
+        seen = []
+
+        def side_effect(args, **kwargs):
+            seen.append(args)
+            if '--force-recreate' in args:
+                return MagicMock(returncode=1, stdout='', stderr='no such image: blah2:v9')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+
+        assert 'no such image' in error
+        assert not any(a[:3] == ['docker', 'rm', '-f'] for a in seen), \
+            "removed containers for an unrelated failure"
+
+    def test_repair_with_nothing_stale_says_so(self, app_client, temp_dir):
+        def side_effect(args, **kwargs):
+            if '--force-recreate' in args:
+                raise subprocess.TimeoutExpired(cmd='docker', timeout=300)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return MagicMock(returncode=0, stdout='blah2\ntar1090\n', stderr='')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+        assert 'no half-created containers' in error.lower()
+
+    def test_repair_failure_is_surfaced_not_swallowed(self, app_client, temp_dir):
+        def side_effect(args, **kwargs):
+            if '--force-recreate' in args:
+                raise subprocess.TimeoutExpired(cmd='docker', timeout=300)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return MagicMock(returncode=0, stdout='56f30a56ce9b_tar1090\n', stderr='')
+            if args[:3] == ['docker', 'rm', '-f']:
+                return MagicMock(returncode=1, stdout='', stderr='resource busy')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+        assert 'automatic repair also failed' in error.lower()
+
+    def test_conflict_detection_matches_the_real_daemon_message(self):
+        import routes.mode as mode_module
+        assert mode_module._is_name_conflict(CONFLICT_OUTPUT)
+        assert not mode_module._is_name_conflict('no such image: blah2:v9')
+        assert not mode_module._is_name_conflict('')
+        assert not mode_module._is_name_conflict(None)
+
+
 class TestRestartLockCoverage:
     """Every path that recreates or removes containers must hold the restart
     lock — a `docker compose down` landing inside another caller's

--- a/tests/test_stack_reconcile.py
+++ b/tests/test_stack_reconcile.py
@@ -1,0 +1,146 @@
+"""stack_reconcile: clearing containers left half-created by an interrupted
+`docker compose up --force-recreate`.
+
+Compose renames the old container to <id-prefix>_<name> before creating the
+replacement. Killed in between, it leaves that container squatting the name
+compose next needs — and nothing clears it, so every later apply fails the
+same way, across reboots.
+"""
+from unittest.mock import MagicMock, patch
+
+from stack_reconcile import (
+    PROJECT, find_stale_containers, reconcile,
+)
+
+# Real shape of the failure, from a node that hit it.
+CONFLICT_OUTPUT = (
+    'Error response from daemon: Error when allocating new name: Conflict. '
+    'The container name "/tar1090" is already in use by container '
+    '"56f30a56ce9ba3fa3df56ed9dea871dcdd6490bc40e92fcb87ab198c18d70310".'
+)
+
+
+def ok(stdout=''):
+    return MagicMock(returncode=0, stdout=stdout, stderr='')
+
+
+class TestFindStaleContainers:
+
+    def test_picks_out_renamed_containers_only(self):
+        listing = ok('blah2\n56f30a56ce9b_tar1090\ntar1090\nb37c58b1ec89_retina-tracker\n')
+        with patch('subprocess.run', return_value=listing):
+            assert find_stale_containers() == [
+                '56f30a56ce9b_tar1090', 'b37c58b1ec89_retina-tracker']
+
+    def test_healthy_project_has_none(self):
+        with patch('subprocess.run', return_value=ok('blah2\ntar1090\nadsb2dd\n')):
+            assert find_stale_containers() == []
+
+    def test_scopes_the_query_to_the_compose_project(self):
+        """A bare name regex over `docker ps -a` would also match containers
+        from other projects on this host — and reconcile removes what it
+        finds."""
+        with patch('subprocess.run', return_value=ok('')) as mock_run:
+            find_stale_containers()
+        args = mock_run.call_args[0][0]
+        assert '--filter' in args
+        assert f'label=com.docker.compose.project={PROJECT}' in args
+
+    def test_underscore_names_that_are_not_compose_renames_are_left_alone(self):
+        """Only a 12-hex-char prefix is compose's rename form."""
+        with patch('subprocess.run', return_value=ok('my_service\nnot_hex_prefix_thing\n')):
+            assert find_stale_containers() == []
+
+    def test_docker_failure_reports_nothing_rather_than_raising(self):
+        with patch('subprocess.run', return_value=MagicMock(returncode=1, stdout='', stderr='boom')):
+            assert find_stale_containers() == []
+
+    def test_docker_missing_reports_nothing_rather_than_raising(self):
+        with patch('subprocess.run', side_effect=FileNotFoundError()):
+            assert find_stale_containers() == []
+
+
+class TestReconcile:
+
+    def test_no_stale_containers_is_a_no_op(self):
+        with patch('subprocess.run', return_value=ok('blah2\ntar1090\n')) as mock_run:
+            removed, error = reconcile('/manifests')
+        assert removed == []
+        assert error is None
+        assert mock_run.call_count == 1, "should not have run rm or up"
+
+    def test_removes_stale_then_restores_the_stack(self):
+        calls = []
+
+        def record(args, **kwargs):
+            calls.append(args)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\nblah2\n')
+            return ok()
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests')
+
+        assert removed == ['56f30a56ce9b_tar1090']
+        assert error is None
+        assert calls[1][:3] == ['docker', 'rm', '-f']
+        assert '56f30a56ce9b_tar1090' in calls[1]
+        assert 'up' in calls[2] and '-d' in calls[2]
+        assert '--force-recreate' not in calls[2], \
+            "a repair should restore what is missing, not bounce healthy containers"
+
+    def test_bring_up_false_removes_without_starting_anything(self):
+        """Spectrum/sdrconnect mode deliberately keeps blah2 stopped."""
+        calls = []
+
+        def record(args, **kwargs):
+            calls.append(args)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\n')
+            return ok()
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests', bring_up=False)
+
+        assert removed == ['56f30a56ce9b_tar1090']
+        assert error is None
+        assert not any('up' in c for c in calls)
+
+    def test_failed_removal_is_reported(self):
+        def record(args, **kwargs):
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\n')
+            return MagicMock(returncode=1, stdout='', stderr='device or resource busy')
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests')
+
+        assert removed == []
+        assert 'could not remove' in error
+        assert '56f30a56ce9b_tar1090' in error
+
+    def test_failed_restore_still_reports_what_was_removed(self):
+        def record(args, **kwargs):
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\n')
+            if args[:3] == ['docker', 'rm', '-f']:
+                return ok()
+            return MagicMock(returncode=1, stdout='', stderr='no such image')
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests')
+
+        assert removed == ['56f30a56ce9b_tar1090']
+        assert 'repair restart failed' in error
+
+    def test_never_raises_on_unexpected_failure(self):
+        def record(args, **kwargs):
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\n')
+            raise OSError('docker daemon gone')
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests')
+
+        assert removed == []
+        assert 'could not remove' in error


### PR DESCRIPTION
**Stacked on #51** — targets `20260803-serialize-async-apply`, so merge that first. The diff here is one commit.

## The failure this removes

Compose recreates a container by renaming the existing one to `<id-prefix>_<name>`, creating the replacement under the real name, then removing the old. Interrupted in between, it leaves a container squatting the name compose next needs:

```
Error when allocating new name: Conflict. The container name "/tar1090"
is already in use by container "56f30a56ce9b..."
```

Nothing cleared that, so **every subsequent apply failed identically — and the state survives a reboot.** That's the difference between one bad restart and a node that can never accept a config change again. It's also the exact wreckage in the originally reported log, which showed compose operating on containers already in the renamed form.

## Both ways a recreate gets interrupted

- **`subprocess.run` timing out**, SIGKILLing the compose CLI while the daemon carries on. The apply path now catches that (and a name-conflict exit) and repairs before returning, reporting what it cleaned up.
- **systemd restarting `retina-gui.service`**, which kills the whole control group — compose runs as a child of the Flask process, so a crash, a `systemctl restart`, or a redeploy during an apply all take it down mid-recreate. By the time the GUI is back, the process that could have cleaned up is gone, so reconcile also runs at **startup**. Cheap when there's nothing to do (one `docker ps`), so it runs unconditionally.

## Design notes

**Scoped by compose's project label, not by name pattern.** A bare `^[0-9a-f]{12}_` regex over `docker ps -a` would also match containers from other projects on the same host, and this removes what it finds.

**The repair restarts with a plain `up -d`, deliberately not `--force-recreate`** — it should create what the removals left missing and leave healthy containers alone.

**Repair fires only on a timeout or an actual name conflict**, never on any other failure. It removes containers, so it must not be the response to, say, a missing image. Covered by a test.

**Recreate budget 120s → 300s.** Measured at 13.5s on a node under load, so the old value was already generous, and what blew it was two compose runs contending — which the restart lock in #51 now prevents. The remaining ways to exceed it are a stuck device or daemon, exactly where killing the CLI mid-recreate does real damage, so it's worth waiting longer first.

## Verified on hardware

Manufactured the exact wreckage on a live node (`docker rename tar1090 56f30a56ce9b_tar1090`) and restarted the GUI:

```
WARNING in app: Found 1 container(s) left half-created by an interrupted
                restart: 56f30a56ce9b_tar1090. Repairing.
WARNING in app: Startup repair removed: 56f30a56ce9b_tar1090

tar1090        Up 5 seconds (healthy)   <- recreated
blah2          Up 9 minutes             <- untouched
adsb2dd        Up 9 minutes             <- untouched
```

The untouched timestamps confirm the repair restored what was missing without bouncing healthy containers.

The in-apply repair path (timeout / conflict mid-apply) is covered by unit tests but not live-verified — it needs a genuinely stuck daemon to trigger, which I couldn't manufacture safely.

## Tests

`425 passed, 7 failed` — all 7 pre-existing on `main`. New: 12 `stack_reconcile` tests (label scoping, non-compose underscore names left alone, docker missing/failing, partial-failure reporting) and 6 covering the repair triggers, including that an unrelated failure does **not** remove containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)