### PR TITLE
20260803 - Refuse config changes mid-install, and queue the last two apply routes

### DIFF
--- a/src/routes/calibrate.py
+++ b/src/routes/calibrate.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, jsonify, request
-import subprocess
 
 import requests as http_requests
 
@@ -169,10 +168,13 @@ def cancel():
 
 @bp.route("/apply", methods=["POST"])
 def apply():
-    """Persist a successful calibration result: write user.yml and do the
-    one-time config-merger + service restart (mirrors /towers/select)."""
-    from app import calibrator, config_mgr, device_state, RETINA_NODE_PATH
-    from routes.mode import run_config_merger_and_restart
+    """Persist a successful calibration result: write user.yml, then queue the
+    config-merger + service restart (mirrors /towers/select).
+
+    can_start_calibration() below already covers a Mender install in progress,
+    which is why this route needs no separate update guard.
+    """
+    from app import apply_service, calibrator, config_mgr, device_state
 
     run_status = calibrator.get_status()
     result = run_status.get("result")
@@ -199,16 +201,8 @@ def apply():
     user_config['capture'] = capture
     config_mgr.save_user_config(user_config)
 
-    try:
-        error = run_config_merger_and_restart(RETINA_NODE_PATH)
-        if error:
-            return jsonify({"success": True, "applied": False, "error": error})
-    except subprocess.TimeoutExpired:
-        return jsonify({"success": True, "applied": False, "error": "Command timed out"})
-    except FileNotFoundError:
-        return jsonify({"success": False, "applied": False,
-                        "error": "docker not found. Is it installed?"})
-    except Exception as e:
-        return jsonify({"success": True, "applied": False, "error": str(e)})
-
-    return jsonify({"success": True, "applied": True})
+    # The user.yml write above stays synchronous — it must be on disk before
+    # this returns. Only the slow merge+restart goes to the shared queue,
+    # which always merges whatever is in user.yml when it runs, so it picks up
+    # the write above. Poll /config/apply/status for progress.
+    return jsonify({"success": True, "status": apply_service.request()}), 202

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -194,13 +194,26 @@ def apply_config():
     In spectrum mode only config-merger runs — blah2 is intentionally stopped
     and must not be restarted until the user switches back to radar mode.
     """
-    from app import apply_service, config_mgr, DEV_MODE
+    from app import apply_service, config_mgr, device_state, DEV_MODE
 
     if DEV_MODE:
         return jsonify({"success": True, "status": apply_service.request()})
 
     if not config_mgr.is_retina_node_installed():
         return jsonify({"success": False, "error": "retina-node not installed"}), 400
+
+    # Refuse during a Mender install rather than queue behind it. The install
+    # replaces the compose manifests this apply's config-merger runs against,
+    # and mender-update's own docker commands are outside the restart lock —
+    # so an apply here can genuinely run concurrently with them. It would also
+    # report success having skipped the restart entirely, since the install
+    # sets mode.txt to 'spectrum'. An install can end in a rollback or reboot,
+    # so holding the apply across it and then applying to a stack that may
+    # have been replaced underneath is worse than asking the user to retry.
+    in_progress, reason = device_state.is_any_update_in_progress()
+    if in_progress:
+        return jsonify({"success": False,
+                        "error": f"{reason}. Apply your changes once it finishes."}), 409
 
     return jsonify({"success": True, "status": apply_service.request()}), 202
 

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -211,6 +211,14 @@ def set_mode():
         return jsonify({'success': False,
                         'error': 'Auto-calibration is running. Cancel it before switching modes'}), 409
 
+    # Same reasoning as /config/apply: a Mender install is replacing the very
+    # containers and manifests every branch below manipulates, and
+    # mender-update's own docker commands are outside the restart lock.
+    in_progress, reason = device_state.is_any_update_in_progress()
+    if in_progress:
+        return jsonify({'success': False,
+                        'error': f'{reason}. Switch modes once it finishes.'}), 409
+
     node_installed = config_mgr.is_retina_node_installed()
     current_mode = get_current_mode()
 

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, jsonify, request, Response, stream_with_context
-import subprocess
 
 import requests as http_requests
 from pydantic import ValidationError
@@ -172,13 +171,14 @@ def spectrum_events():
 
 @bp.route("/select", methods=["POST"])
 def select():
-    """Save RX + TX location to user.yml, run config-merger, and restart services.
+    """Save RX + TX location to user.yml, then queue a config apply.
 
-    In spectrum mode only config-merger runs — blah2 is intentionally stopped
-    and must not be restarted until the user switches back to radar mode.
+    The apply runs on the shared background queue (see apply_service.py) —
+    poll /config/apply/status for progress. In spectrum mode it only runs
+    config-merger: blah2 is intentionally stopped and must not be restarted
+    until the user switches back to radar mode.
     """
-    from app import config_mgr, get_node_id, RETINA_NODE_PATH
-    from routes.mode import run_config_merger_and_restart
+    from app import apply_service, config_mgr, device_state, get_node_id
 
     data = request.get_json()
     if not data:
@@ -221,18 +221,19 @@ def select():
 
     config_mgr.save_user_config(new_user_config)
 
-    if config_mgr.is_retina_node_installed():
-        try:
-            error = run_config_merger_and_restart(RETINA_NODE_PATH)
-            if error:
-                return jsonify({"success": True, "applied": False, "error": error})
-            return jsonify({"success": True, "applied": True})
+    if not config_mgr.is_retina_node_installed():
+        return jsonify({"success": True, "applied": False})
 
-        except subprocess.TimeoutExpired:
-            return jsonify({"success": True, "applied": False, "error": "Command timed out"})
-        except FileNotFoundError:
-            return jsonify({"success": False, "applied": False, "error": "docker not found — is it installed?"})
-        except Exception as e:
-            return jsonify({"success": True, "applied": False, "error": str(e)})
+    in_progress, reason = device_state.is_any_update_in_progress()
+    if in_progress:
+        return jsonify({"success": False,
+                        "error": f"{reason}. Choose a tower once it finishes."}), 409
 
-    return jsonify({"success": True, "applied": False})
+    # The config write above is a local file write and stays synchronous — it
+    # must be visible to anything that reads user.yml the moment this returns.
+    # Only the slow part (config-merger plus a stack restart, ~45s) is handed
+    # to the shared queue, which is what stops this request blocking a browser
+    # for minutes when it lands behind another restart. Poll
+    # /config/apply/status for progress; the queue always merges whatever is
+    # in user.yml when it runs, so it necessarily picks up the write above.
+    return jsonify({"success": True, "status": apply_service.request()}), 202

--- a/static/setup.js
+++ b/static/setup.js
@@ -1061,6 +1061,31 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     frequency_mhz: selectedTower.frequency_mhz
                 };
 
+                function pollApply() {
+                    fetch('/config/apply/status')
+                    .then(function(r) { return r.json(); })
+                    .then(function(s) {
+                        if (s.state === 'running') {
+                            var label = s.phase_label || 'Applying configuration';
+                            if (s.phase === 'settling' && s.settle_remaining) {
+                                label += ' (' + s.settle_remaining + 's)';
+                            }
+                            statusEl.innerHTML = '<span class="text-muted">' + label + '…</span>';
+                            setTimeout(pollApply, 1000);
+                        } else if (s.state === 'failed') {
+                            statusEl.innerHTML = '<span class="text-warning">Configuration saved but services failed to restart: ' + (s.error || 'Unknown error') + '</span>';
+                            saveBtn.disabled = false;
+                            saveBtn.textContent = 'Retry';
+                            skipBtn.style.display = '';
+                            skipBtn.textContent = 'Continue anyway →';
+                        } else {
+                            statusEl.innerHTML = '<span class="text-success">Configuration saved and services restarted.</span>';
+                            setTimeout(advance, 1500);
+                        }
+                    })
+                    .catch(function() { setTimeout(pollApply, 2000); });  // transient: keep watching
+                }
+
                 postJSON('/towers/select', payload)
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
@@ -1071,9 +1096,11 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                         skipBtn.style.display = '';
                         return;
                     }
-                    if (data.applied) {
-                        statusEl.innerHTML = '<span class="text-success">Configuration saved and services restarted.</span>';
-                        setTimeout(advance, 1500);
+                    if (data.status) {
+                        // The restart runs on the server's shared queue now.
+                        // Still wait for it to finish before advancing —
+                        // later wizard steps expect the radar to be back up.
+                        pollApply();
                     } else if (data.error) {
                         statusEl.innerHTML = '<span class="text-warning">Configuration saved but services failed to restart: ' + data.error + '</span>';
                         saveBtn.disabled = false;

--- a/templates/config.html
+++ b/templates/config.html
@@ -1533,23 +1533,41 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         })
         .then(function(r) { return r.json(); })
         .then(function(d) {
-            if (d.success && d.applied) {
+            if (!d.success) { calApplyFailed(d.error || 'Apply failed'); return; }
+            // The tuning is already written to user.yml; the merge and restart
+            // run on the server's shared queue (see apply_service.py).
+            pollCalApply();
+        })
+        .catch(function() { calApplyFailed('Apply request failed'); });
+    });
+
+    function calApplyFailed(message) {
+        applyBtn.disabled = false;
+        applyBtn.textContent = 'Persist to config';
+        errorEl.style.display = '';
+        errorEl.textContent = message;
+    }
+
+    function pollCalApply() {
+        fetch('/config/apply/status')
+        .then(function(r) { return r.json(); })
+        .then(function(s) {
+            if (s.state === 'running') {
+                var label = s.phase_label || 'Applying';
+                if (s.phase === 'settling' && s.settle_remaining) {
+                    label += ' (' + s.settle_remaining + 's)';
+                }
+                applyBtn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.8em;height:.8em;border-width:1.5px;"></span> ' + label + '…';
+                setTimeout(pollCalApply, 1000);
+            } else if (s.state === 'failed') {
+                calApplyFailed(s.error || 'Apply failed');
+            } else {
                 applyBtn.style.display = 'none';
                 resultEl.innerHTML += '<br><strong>Saved and applied.</strong> Services are restarting with the new tuning.';
-            } else {
-                applyBtn.disabled = false;
-                applyBtn.textContent = 'Persist to config';
-                errorEl.style.display = '';
-                errorEl.textContent = d.error || 'Apply failed';
             }
         })
-        .catch(function() {
-            applyBtn.disabled = false;
-            applyBtn.textContent = 'Persist to config';
-            errorEl.style.display = '';
-            errorEl.textContent = 'Apply request failed';
-        });
-    });
+        .catch(function() { setTimeout(pollCalApply, 2000); });  // transient: keep watching
+    }
 
     modalEl.addEventListener('hidden.bs.modal', function() {
         if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -576,6 +576,66 @@ class TestApplyConfigRoute:
         assert data['settle_remaining'] == 12
 
 
+class TestApplyDuringMenderInstall:
+    """A Mender install replaces the compose manifests an apply's
+    config-merger runs against, and mender-update's own docker commands sit
+    outside the restart lock — so an apply can genuinely run concurrently
+    with them. It would also report success having skipped the restart
+    entirely, since the install sets mode.txt to 'spectrum'."""
+
+    def _installing(self, app_module):
+        return patch.object(app_module.device_state, 'is_any_update_in_progress',
+                            return_value=(True, 'Installing retina-node-v0.5.0'))
+
+    def test_config_apply_refused(self, app_client):
+        import app as app_module
+        with self._installing(app_module), \
+             patch.object(app_module, 'apply_service') as svc:
+            response = app_client.post('/config/apply')
+
+        assert response.status_code == 409
+        body = json.loads(response.data)
+        assert body['success'] is False
+        assert 'Installing retina-node-v0.5.0' in body['error']
+        svc.request.assert_not_called()
+
+    def test_tower_select_refused(self, app_client):
+        import app as app_module
+        payload = {"rx_latitude": -33.8688, "rx_longitude": 151.2093,
+                   "rx_altitude": 45.0, "tx_latitude": -33.82,
+                   "tx_longitude": 151.185, "tx_altitude": 100.0,
+                   "tx_callsign": "ATN6"}
+        with self._installing(app_module), \
+             patch.object(app_module, 'apply_service') as svc:
+            response = app_client.post('/towers/select', data=json.dumps(payload),
+                                       content_type='application/json')
+
+        assert response.status_code == 409
+        assert 'Installing' in json.loads(response.data)['error']
+        svc.request.assert_not_called()
+
+    def test_mode_switch_refused(self, app_client):
+        import app as app_module
+        with self._installing(app_module), patch('subprocess.run') as mock_run:
+            response = app_client.post('/api/mode', data=json.dumps({'mode': 'spectrum'}),
+                                       content_type='application/json')
+
+        assert response.status_code == 409
+        assert 'Installing' in json.loads(response.data)['error']
+        assert mock_run.call_count == 0, "touched docker during an install"
+
+    def test_allowed_again_once_the_install_finishes(self, app_client):
+        import app as app_module
+        with patch.object(app_module.device_state, 'is_any_update_in_progress',
+                          return_value=(False, None)), \
+             patch.object(app_module, 'apply_service') as svc:
+            svc.request.return_value = {'state': 'running'}
+            response = app_client.post('/config/apply')
+
+        assert response.status_code == 202
+        svc.request.assert_called_once_with()
+
+
 class TestSSHKeysRoutes:
     """Test SSH key management routes."""
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1111,7 +1111,6 @@ class TestRoutes:
 
     def test_apply_writes_user_config(self, app_client, config_files):
         import app as app_module
-        import routes.mode as mode_module
         done = {
             "state": "done",
             "started_at": "2026-07-08T00:00:00+00:00",
@@ -1120,12 +1119,16 @@ class TestRoutes:
                        "track_id": "0A3F"},
         }
         with patch.object(app_module.calibrator, 'get_status', return_value=done), \
-             patch.object(mode_module, 'run_config_merger_and_restart',
-                          return_value=None):
+             patch.object(app_module.apply_service, 'request',
+                          return_value={"state": "running"}) as queued:
             resp = app_client.post('/calibrate/apply')
-        assert resp.status_code == 200
+        # The tuning is written synchronously; the merge+restart is queued, so
+        # this returns immediately rather than blocking the browser for ~45s.
+        assert resp.status_code == 202
         body = resp.get_json()
-        assert body["success"] is True and body["applied"] is True
+        assert body["success"] is True
+        assert body["status"]["state"] == "running"
+        queued.assert_called_once_with()
 
         user_path, _ = config_files
         with open(user_path) as f:

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -282,11 +282,14 @@ class TestTowerSelect:
             data=json.dumps(payload),
             content_type='application/json',
         )
-        assert resp.status_code == 200
+        # Queued, not applied inline: the config write is synchronous but the
+        # merge+restart goes to the shared queue (see apply_service.py).
+        assert resp.status_code == 202
         data = json.loads(resp.data)
         assert data['success'] is True
 
-        # Verify user.yml was updated
+        # The write must have happened before the response, not been deferred
+        # to the queue — anything reading user.yml next has to see it.
         with open(user_path) as f:
             saved = yaml.safe_load(f)
         assert saved['location']['rx']['latitude'] == -33.8688
@@ -338,7 +341,7 @@ class TestTowerSelect:
             data=json.dumps(payload),
             content_type='application/json',
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 202
 
         with open(user_path) as f:
             saved = yaml.safe_load(f)


### PR DESCRIPTION
**Stacked on #52** (which is stacked on #51) — merge those first. The diff here is one commit.

Closes the last two gaps in the config-application path.

## 1. Nothing stopped a config apply during a Mender install

`/config/apply`, `/towers/select` and `/api/mode` had no update guard — only `/calibrate/apply` did, via `can_start_calibration()`.

An apply started during an install would wait for the restart lock (Mender's pre-install `down` holds it), then run config-merger with its `cwd` inside the manifests directory **Mender is replacing**, then skip the restart entirely because the install sets `mode.txt` to `spectrum` — and **report success**. The user is told it worked while the stack is down mid-install and nothing was restarted.

Worse: `mender-update`'s own docker commands run outside the restart lock, so the merger genuinely can run concurrently with them. What limits the damage today is the `mode.txt` trick — a side effect of silencing the watchdog, not anything designed to make this safe.

All three now refuse with the existing human-readable reason:

> Installing retina-node-v0.5.0. Apply your changes once it finishes.

**Refusing rather than queueing is deliberate.** An install runs for minutes and can end in a rollback or a reboot; holding a config apply across it and then applying to a stack that may have been replaced underneath is worse than asking the user to retry.

## 2. Two routes still blocked the request

`/towers/select` and `/calibrate/apply` were made lock-safe in #51 but stayed synchronous — blocking a browser ~45s, and up to ~135s once they had to wait for the lock first. That's past the **100s Cloudflare tunnel cutoff** for anyone reaching a node remotely: the request would 524 while the work completed fine on the node. The same "did it work or not?" condition that started this whole investigation, on a different route.

Both now write `user.yml` synchronously — it must be on disk before the response, since anything reading it next has to see it — and hand only the slow merge+restart to the shared queue, returning 202.

**This turned out simpler than planned.** No `prepare`-callback plumbing: the queue always merges whatever is in `user.yml` when it runs, so it necessarily picks up the synchronous write. That also removes the stale-snapshot risk I'd been worried about for `/calibrate/apply`.

Their callers (the wizard's tower step, the calibration modal's "Persist to config") now poll `/config/apply/status` and show the same phase display and settle countdown as Apply. The wizard still waits for the restart before advancing, since later steps expect the radar to be back up.

Neither route shells out any more, so both lost their `subprocess` import.

## Verified on hardware

```
POST /towers/select  ->  HTTP 202 in 0s        (previously ~45s blocking)
user.yml on disk before the response returned:  fc 177500000, name ATN6
queue:  0s merging → 1s stopping_spectrum → 2s restarting_sdr
        3s settling → 32s recreating → 45s done
```

The `user.yml` check is the one that matters — it proves the write is synchronous and not deferred into the queue.

## Net effect

Every config-changing action now takes the lock, runs off-request with progress, coalesces repeat requests, self-heals interrupted recreates, and refuses during an install. No config route holds a request open any more, so the Cloudflare 100s ceiling stops being reachable.

## Tests

`429 passed, 7 failed` — all 7 pre-existing on `main`. New: 4 install-guard tests (each asserting the queue/docker is never touched when refused, plus that it's allowed again once the install finishes). Updated `test_select_saves_location`, `test_select_preserves_other_config` and `test_apply_writes_user_config` to the 202 contract, keeping their assertions that `user.yml` is written before the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)