### PR TITLE
20260803 - Land #52 and #53 on main (stacked merges went to their base branches)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -94,6 +94,7 @@ device_state.release_calibration_lock()
 # retina-spectrum is only allowed while the wizard location step or config toggle is active.
 if config_mgr.is_retina_node_installed():
     from restart_lock import restart_lock, OPPORTUNISTIC_TIMEOUT_SECONDS
+    from stack_reconcile import find_stale_containers, reconcile
     try:
         # Opportunistic, and deliberately so: this runs before Flask serves
         # anything, so a long wait here delays the whole GUI coming up. If
@@ -104,6 +105,25 @@ if config_mgr.is_retina_node_installed():
                            cwd=RETINA_NODE_PATH, capture_output=True, timeout=60)
             subprocess.run(['docker', 'compose', '-p', 'retina-node', 'rm', '-sf', 'retina-spectrum'],
                            cwd=RETINA_NODE_PATH, capture_output=True, timeout=30)
+
+            # Repair a recreate this process was killed in the middle of.
+            # systemd kills retina-gui's whole control group, so a crash, a
+            # restart or a redeploy during an apply takes the `docker
+            # compose` child with it — potentially after it renamed a
+            # container but before it removed the old one. Nothing else
+            # clears that, and it survives reboots: every apply from here on
+            # would fail on the name conflict. Cheap when there is nothing
+            # to do (one `docker ps`), so it runs unconditionally.
+            stale = find_stale_containers()
+            if stale:
+                app.logger.warning(
+                    f"Found {len(stale)} container(s) left half-created by an "
+                    f"interrupted restart: {', '.join(stale)}. Repairing.")
+                removed, error = reconcile(RETINA_NODE_PATH)
+                if error:
+                    app.logger.error(f"Startup repair failed: {error}")
+                else:
+                    app.logger.warning(f"Startup repair removed: {', '.join(removed)}")
     except Exception:
         pass
 

--- a/src/apply_service.py
+++ b/src/apply_service.py
@@ -44,6 +44,7 @@ PHASE_LABELS = {
     'restarting_sdr': 'Restarting the SDR service',
     'settling': 'Waiting for the SDR to settle',
     'recreating': 'Restarting radar services',
+    'repairing': 'Cleaning up after an interrupted restart',
 }
 
 

--- a/src/routes/calibrate.py
+++ b/src/routes/calibrate.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, jsonify, request
-import subprocess
 
 import requests as http_requests
 
@@ -169,10 +168,13 @@ def cancel():
 
 @bp.route("/apply", methods=["POST"])
 def apply():
-    """Persist a successful calibration result: write user.yml and do the
-    one-time config-merger + service restart (mirrors /towers/select)."""
-    from app import calibrator, config_mgr, device_state, RETINA_NODE_PATH
-    from routes.mode import run_config_merger_and_restart
+    """Persist a successful calibration result: write user.yml, then queue the
+    config-merger + service restart (mirrors /towers/select).
+
+    can_start_calibration() below already covers a Mender install in progress,
+    which is why this route needs no separate update guard.
+    """
+    from app import apply_service, calibrator, config_mgr, device_state
 
     run_status = calibrator.get_status()
     result = run_status.get("result")
@@ -199,16 +201,8 @@ def apply():
     user_config['capture'] = capture
     config_mgr.save_user_config(user_config)
 
-    try:
-        error = run_config_merger_and_restart(RETINA_NODE_PATH)
-        if error:
-            return jsonify({"success": True, "applied": False, "error": error})
-    except subprocess.TimeoutExpired:
-        return jsonify({"success": True, "applied": False, "error": "Command timed out"})
-    except FileNotFoundError:
-        return jsonify({"success": False, "applied": False,
-                        "error": "docker not found. Is it installed?"})
-    except Exception as e:
-        return jsonify({"success": True, "applied": False, "error": str(e)})
-
-    return jsonify({"success": True, "applied": True})
+    # The user.yml write above stays synchronous — it must be on disk before
+    # this returns. Only the slow merge+restart goes to the shared queue,
+    # which always merges whatever is in user.yml when it runs, so it picks up
+    # the write above. Poll /config/apply/status for progress.
+    return jsonify({"success": True, "status": apply_service.request()}), 202

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -194,13 +194,26 @@ def apply_config():
     In spectrum mode only config-merger runs — blah2 is intentionally stopped
     and must not be restarted until the user switches back to radar mode.
     """
-    from app import apply_service, config_mgr, DEV_MODE
+    from app import apply_service, config_mgr, device_state, DEV_MODE
 
     if DEV_MODE:
         return jsonify({"success": True, "status": apply_service.request()})
 
     if not config_mgr.is_retina_node_installed():
         return jsonify({"success": False, "error": "retina-node not installed"}), 400
+
+    # Refuse during a Mender install rather than queue behind it. The install
+    # replaces the compose manifests this apply's config-merger runs against,
+    # and mender-update's own docker commands are outside the restart lock —
+    # so an apply here can genuinely run concurrently with them. It would also
+    # report success having skipped the restart entirely, since the install
+    # sets mode.txt to 'spectrum'. An install can end in a rollback or reboot,
+    # so holding the apply across it and then applying to a stack that may
+    # have been replaced underneath is worse than asking the user to retry.
+    in_progress, reason = device_state.is_any_update_in_progress()
+    if in_progress:
+        return jsonify({"success": False,
+                        "error": f"{reason}. Apply your changes once it finishes."}), 409
 
     return jsonify({"success": True, "status": apply_service.request()}), 202
 

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -211,6 +211,14 @@ def set_mode():
         return jsonify({'success': False,
                         'error': 'Auto-calibration is running. Cancel it before switching modes'}), 409
 
+    # Same reasoning as /config/apply: a Mender install is replacing the very
+    # containers and manifests every branch below manipulates, and
+    # mender-update's own docker commands are outside the restart lock.
+    in_progress, reason = device_state.is_any_update_in_progress()
+    if in_progress:
+        return jsonify({'success': False,
+                        'error': f'{reason}. Switch modes once it finishes.'}), 409
+
     node_installed = config_mgr.is_retina_node_installed()
     current_mode = get_current_mode()
 

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -15,6 +15,16 @@ _mode_cache = 'radar'  # default mode if file read fails (e.g. dev environment w
 # claims it again.
 SDRPLAY_RESTART_SETTLE_SECONDS = 30
 
+# Budget for the stack recreate. Measured at 13.5s on a node under load
+# (4-core Pi at load 4.3), so this is ~20x headroom rather than a guess:
+# the old 120s was generous too, and what actually blew it was two compose
+# runs contending, not the work itself. Now that the restart lock makes that
+# contention impossible, the remaining reasons to exceed even this are a
+# genuinely stuck device or daemon — cases where killing the CLI mid-recreate
+# does real damage (see stack_reconcile), so it is worth waiting longer
+# before resorting to that.
+RECREATE_TIMEOUT_SECONDS = 300
+
 
 def get_current_mode():
     """Read persisted mode. Returns 'radar', 'spectrum', or 'sdrconnect'."""
@@ -129,15 +139,52 @@ def _run_config_merger_and_restart_locked(retina_node_path, on_phase):
     _settle(SDRPLAY_RESTART_SETTLE_SECONDS, on_phase)
 
     on_phase('recreating', None)
-    result = subprocess.run(
-        ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate'],
-        cwd=retina_node_path,
-        capture_output=True, text=True, timeout=120
-    )
+    try:
+        result = subprocess.run(
+            ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate'],
+            cwd=retina_node_path,
+            capture_output=True, text=True, timeout=RECREATE_TIMEOUT_SECONDS
+        )
+    except subprocess.TimeoutExpired:
+        # The CLI has just been SIGKILLed, quite possibly between renaming a
+        # container and removing the old one. Repair before returning, or
+        # every later apply fails on the name conflict it leaves behind.
+        return _repair(retina_node_path, on_phase,
+                       'Restarting the radar services timed out.')
+
     if result.returncode != 0:
-        return f'restart failed: {result.stderr or result.stdout}'
+        output = result.stderr or result.stdout
+        if _is_name_conflict(output):
+            return _repair(retina_node_path, on_phase,
+                           'Restarting the radar services hit a container name conflict.')
+        return f'restart failed: {output}'
 
     return None
+
+
+def _is_name_conflict(output):
+    """Compose failing because a half-recreated container still holds a name."""
+    lowered = (output or '').lower()
+    return 'already in use' in lowered or 'error when allocating new name' in lowered
+
+
+def _repair(retina_node_path, on_phase, reason):
+    """Clear half-recreated containers and restore the stack.
+
+    Runs with the restart lock still held (every caller of this is inside
+    _run_config_merger_and_restart_locked), which is what makes it safe to
+    remove containers here.
+    """
+    from stack_reconcile import reconcile
+
+    on_phase('repairing', None)
+    removed, error = reconcile(retina_node_path)
+    if error:
+        return f'{reason} Automatic repair also failed: {error}'
+    if removed:
+        return (f'{reason} Cleaned up {len(removed)} half-created '
+                f'container(s) and restarted — check the radar is running.')
+    return f'{reason} No half-created containers were left behind.'
 
 
 @bp.route('/api/mode', methods=['GET'])

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, jsonify, request, Response, stream_with_context
-import subprocess
 
 import requests as http_requests
 from pydantic import ValidationError
@@ -172,13 +171,14 @@ def spectrum_events():
 
 @bp.route("/select", methods=["POST"])
 def select():
-    """Save RX + TX location to user.yml, run config-merger, and restart services.
+    """Save RX + TX location to user.yml, then queue a config apply.
 
-    In spectrum mode only config-merger runs — blah2 is intentionally stopped
-    and must not be restarted until the user switches back to radar mode.
+    The apply runs on the shared background queue (see apply_service.py) —
+    poll /config/apply/status for progress. In spectrum mode it only runs
+    config-merger: blah2 is intentionally stopped and must not be restarted
+    until the user switches back to radar mode.
     """
-    from app import config_mgr, get_node_id, RETINA_NODE_PATH
-    from routes.mode import run_config_merger_and_restart
+    from app import apply_service, config_mgr, device_state, get_node_id
 
     data = request.get_json()
     if not data:
@@ -221,18 +221,19 @@ def select():
 
     config_mgr.save_user_config(new_user_config)
 
-    if config_mgr.is_retina_node_installed():
-        try:
-            error = run_config_merger_and_restart(RETINA_NODE_PATH)
-            if error:
-                return jsonify({"success": True, "applied": False, "error": error})
-            return jsonify({"success": True, "applied": True})
+    if not config_mgr.is_retina_node_installed():
+        return jsonify({"success": True, "applied": False})
 
-        except subprocess.TimeoutExpired:
-            return jsonify({"success": True, "applied": False, "error": "Command timed out"})
-        except FileNotFoundError:
-            return jsonify({"success": False, "applied": False, "error": "docker not found — is it installed?"})
-        except Exception as e:
-            return jsonify({"success": True, "applied": False, "error": str(e)})
+    in_progress, reason = device_state.is_any_update_in_progress()
+    if in_progress:
+        return jsonify({"success": False,
+                        "error": f"{reason}. Choose a tower once it finishes."}), 409
 
-    return jsonify({"success": True, "applied": False})
+    # The config write above is a local file write and stays synchronous — it
+    # must be visible to anything that reads user.yml the moment this returns.
+    # Only the slow part (config-merger plus a stack restart, ~45s) is handed
+    # to the shared queue, which is what stops this request blocking a browser
+    # for minutes when it lands behind another restart. Poll
+    # /config/apply/status for progress; the queue always merges whatever is
+    # in user.yml when it runs, so it necessarily picks up the write above.
+    return jsonify({"success": True, "status": apply_service.request()}), 202

--- a/src/stack_reconcile.py
+++ b/src/stack_reconcile.py
@@ -1,0 +1,107 @@
+"""Repair a retina-node compose project left half-recreated.
+
+Compose recreates a container by renaming the existing one to
+`<id-prefix>_<name>`, creating the replacement under the real name, then
+removing the old one. Interrupt it between the rename and the remove and the
+project is left with a container squatting a name compose is about to need:
+
+    Error response from daemon: Error when allocating new name: Conflict.
+    The container name "/tar1090" is already in use by container
+    "56f30a56ce9b..."
+
+Nothing clears that on its own, so **every subsequent apply fails the same
+way**, and the state survives a reboot. It is the difference between one bad
+restart and a node that can never accept a config change again.
+
+Two things interrupt a recreate mid-flight:
+
+  - subprocess.run's timeout, which SIGKILLs the compose CLI while the
+    daemon carries on with the operation;
+  - systemd restarting retina-gui.service, which kills the whole control
+    group — compose runs as a child of the Flask process, so a crash, a
+    `systemctl restart`, or a redeploy during an apply all do this.
+
+The second is why reconcile also runs at startup and not only after a failed
+compose call: by the time the GUI is back up, the process that could have
+cleaned up is gone.
+
+Scoped by compose's own project label rather than by name pattern. A bare
+`^[0-9a-f]{12}_` regex over `docker ps -a` would also match containers from
+other projects on the same host, and this removes what it finds.
+"""
+
+import re
+import subprocess
+
+PROJECT = "retina-node"
+PROJECT_LABEL = "com.docker.compose.project"
+
+# Compose's rename prefix: 12 hex chars of the container id, then the
+# original name.
+STALE_NAME_RE = re.compile(r"^[0-9a-f]{12}_")
+
+
+def find_stale_containers(project=PROJECT, timeout=30):
+    """Containers in `project` still carrying compose's rename prefix.
+
+    Returns a list of names; empty on any error, since this is only ever
+    used to decide whether to attempt a repair.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "-a",
+             "--filter", f"label={PROJECT_LABEL}={project}",
+             "--format", "{{.Names}}"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except Exception:
+        return []
+    if result.returncode != 0:
+        return []
+    return [name for name in result.stdout.split()
+            if STALE_NAME_RE.match(name)]
+
+
+def reconcile(retina_node_path, project=PROJECT, bring_up=True):
+    """Remove half-recreated containers and, optionally, restore the stack.
+
+    Callers must already hold the restart lock — this runs `docker rm -f`
+    and `docker compose up`, which is exactly the kind of work that must not
+    interleave with another caller's.
+
+    bring_up=False skips the `up`, for callers that must not start the radar
+    stack (spectrum/sdrconnect mode, where blah2 is deliberately stopped).
+
+    Returns (removed: list[str], error: str|None). Never raises.
+    """
+    stale = find_stale_containers(project)
+    if not stale:
+        return [], None
+
+    try:
+        result = subprocess.run(
+            ["docker", "rm", "-f", *stale],
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode != 0:
+            return [], f"could not remove {', '.join(stale)}: {result.stderr or result.stdout}"
+    except Exception as e:
+        return [], f"could not remove {', '.join(stale)}: {e}"
+
+    if not bring_up:
+        return stale, None
+
+    # Plain `up -d`, deliberately not --force-recreate: this is a repair, so
+    # it should create whatever the removals left missing and leave every
+    # healthy container alone.
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "-p", project, "up", "-d", "--remove-orphans"],
+            cwd=retina_node_path, capture_output=True, text=True, timeout=300,
+        )
+        if result.returncode != 0:
+            return stale, f"repair restart failed: {result.stderr or result.stdout}"
+    except Exception as e:
+        return stale, f"repair restart failed: {e}"
+
+    return stale, None

--- a/static/setup.js
+++ b/static/setup.js
@@ -1061,6 +1061,31 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     frequency_mhz: selectedTower.frequency_mhz
                 };
 
+                function pollApply() {
+                    fetch('/config/apply/status')
+                    .then(function(r) { return r.json(); })
+                    .then(function(s) {
+                        if (s.state === 'running') {
+                            var label = s.phase_label || 'Applying configuration';
+                            if (s.phase === 'settling' && s.settle_remaining) {
+                                label += ' (' + s.settle_remaining + 's)';
+                            }
+                            statusEl.innerHTML = '<span class="text-muted">' + label + '…</span>';
+                            setTimeout(pollApply, 1000);
+                        } else if (s.state === 'failed') {
+                            statusEl.innerHTML = '<span class="text-warning">Configuration saved but services failed to restart: ' + (s.error || 'Unknown error') + '</span>';
+                            saveBtn.disabled = false;
+                            saveBtn.textContent = 'Retry';
+                            skipBtn.style.display = '';
+                            skipBtn.textContent = 'Continue anyway →';
+                        } else {
+                            statusEl.innerHTML = '<span class="text-success">Configuration saved and services restarted.</span>';
+                            setTimeout(advance, 1500);
+                        }
+                    })
+                    .catch(function() { setTimeout(pollApply, 2000); });  // transient: keep watching
+                }
+
                 postJSON('/towers/select', payload)
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
@@ -1071,9 +1096,11 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                         skipBtn.style.display = '';
                         return;
                     }
-                    if (data.applied) {
-                        statusEl.innerHTML = '<span class="text-success">Configuration saved and services restarted.</span>';
-                        setTimeout(advance, 1500);
+                    if (data.status) {
+                        // The restart runs on the server's shared queue now.
+                        // Still wait for it to finish before advancing —
+                        // later wizard steps expect the radar to be back up.
+                        pollApply();
                     } else if (data.error) {
                         statusEl.innerHTML = '<span class="text-warning">Configuration saved but services failed to restart: ' + data.error + '</span>';
                         saveBtn.disabled = false;

--- a/templates/config.html
+++ b/templates/config.html
@@ -1533,23 +1533,41 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         })
         .then(function(r) { return r.json(); })
         .then(function(d) {
-            if (d.success && d.applied) {
+            if (!d.success) { calApplyFailed(d.error || 'Apply failed'); return; }
+            // The tuning is already written to user.yml; the merge and restart
+            // run on the server's shared queue (see apply_service.py).
+            pollCalApply();
+        })
+        .catch(function() { calApplyFailed('Apply request failed'); });
+    });
+
+    function calApplyFailed(message) {
+        applyBtn.disabled = false;
+        applyBtn.textContent = 'Persist to config';
+        errorEl.style.display = '';
+        errorEl.textContent = message;
+    }
+
+    function pollCalApply() {
+        fetch('/config/apply/status')
+        .then(function(r) { return r.json(); })
+        .then(function(s) {
+            if (s.state === 'running') {
+                var label = s.phase_label || 'Applying';
+                if (s.phase === 'settling' && s.settle_remaining) {
+                    label += ' (' + s.settle_remaining + 's)';
+                }
+                applyBtn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.8em;height:.8em;border-width:1.5px;"></span> ' + label + '…';
+                setTimeout(pollCalApply, 1000);
+            } else if (s.state === 'failed') {
+                calApplyFailed(s.error || 'Apply failed');
+            } else {
                 applyBtn.style.display = 'none';
                 resultEl.innerHTML += '<br><strong>Saved and applied.</strong> Services are restarting with the new tuning.';
-            } else {
-                applyBtn.disabled = false;
-                applyBtn.textContent = 'Persist to config';
-                errorEl.style.display = '';
-                errorEl.textContent = d.error || 'Apply failed';
             }
         })
-        .catch(function() {
-            applyBtn.disabled = false;
-            applyBtn.textContent = 'Persist to config';
-            errorEl.style.display = '';
-            errorEl.textContent = 'Apply request failed';
-        });
-    });
+        .catch(function() { setTimeout(pollCalApply, 2000); });  // transient: keep watching
+    }
 
     modalEl.addEventListener('hidden.bs.modal', function() {
         if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -576,6 +576,66 @@ class TestApplyConfigRoute:
         assert data['settle_remaining'] == 12
 
 
+class TestApplyDuringMenderInstall:
+    """A Mender install replaces the compose manifests an apply's
+    config-merger runs against, and mender-update's own docker commands sit
+    outside the restart lock — so an apply can genuinely run concurrently
+    with them. It would also report success having skipped the restart
+    entirely, since the install sets mode.txt to 'spectrum'."""
+
+    def _installing(self, app_module):
+        return patch.object(app_module.device_state, 'is_any_update_in_progress',
+                            return_value=(True, 'Installing retina-node-v0.5.0'))
+
+    def test_config_apply_refused(self, app_client):
+        import app as app_module
+        with self._installing(app_module), \
+             patch.object(app_module, 'apply_service') as svc:
+            response = app_client.post('/config/apply')
+
+        assert response.status_code == 409
+        body = json.loads(response.data)
+        assert body['success'] is False
+        assert 'Installing retina-node-v0.5.0' in body['error']
+        svc.request.assert_not_called()
+
+    def test_tower_select_refused(self, app_client):
+        import app as app_module
+        payload = {"rx_latitude": -33.8688, "rx_longitude": 151.2093,
+                   "rx_altitude": 45.0, "tx_latitude": -33.82,
+                   "tx_longitude": 151.185, "tx_altitude": 100.0,
+                   "tx_callsign": "ATN6"}
+        with self._installing(app_module), \
+             patch.object(app_module, 'apply_service') as svc:
+            response = app_client.post('/towers/select', data=json.dumps(payload),
+                                       content_type='application/json')
+
+        assert response.status_code == 409
+        assert 'Installing' in json.loads(response.data)['error']
+        svc.request.assert_not_called()
+
+    def test_mode_switch_refused(self, app_client):
+        import app as app_module
+        with self._installing(app_module), patch('subprocess.run') as mock_run:
+            response = app_client.post('/api/mode', data=json.dumps({'mode': 'spectrum'}),
+                                       content_type='application/json')
+
+        assert response.status_code == 409
+        assert 'Installing' in json.loads(response.data)['error']
+        assert mock_run.call_count == 0, "touched docker during an install"
+
+    def test_allowed_again_once_the_install_finishes(self, app_client):
+        import app as app_module
+        with patch.object(app_module.device_state, 'is_any_update_in_progress',
+                          return_value=(False, None)), \
+             patch.object(app_module, 'apply_service') as svc:
+            svc.request.return_value = {'state': 'running'}
+            response = app_client.post('/config/apply')
+
+        assert response.status_code == 202
+        svc.request.assert_called_once_with()
+
+
 class TestSSHKeysRoutes:
     """Test SSH key management routes."""
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1111,7 +1111,6 @@ class TestRoutes:
 
     def test_apply_writes_user_config(self, app_client, config_files):
         import app as app_module
-        import routes.mode as mode_module
         done = {
             "state": "done",
             "started_at": "2026-07-08T00:00:00+00:00",
@@ -1120,12 +1119,16 @@ class TestRoutes:
                        "track_id": "0A3F"},
         }
         with patch.object(app_module.calibrator, 'get_status', return_value=done), \
-             patch.object(mode_module, 'run_config_merger_and_restart',
-                          return_value=None):
+             patch.object(app_module.apply_service, 'request',
+                          return_value={"state": "running"}) as queued:
             resp = app_client.post('/calibrate/apply')
-        assert resp.status_code == 200
+        # The tuning is written synchronously; the merge+restart is queued, so
+        # this returns immediately rather than blocking the browser for ~45s.
+        assert resp.status_code == 202
         body = resp.get_json()
-        assert body["success"] is True and body["applied"] is True
+        assert body["success"] is True
+        assert body["status"]["state"] == "running"
+        queued.assert_called_once_with()
 
         user_path, _ = config_files
         with open(user_path) as f:

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -279,6 +279,104 @@ class TestHomepageModeRendering:
         assert b'49152' not in response.data
 
 
+CONFLICT_OUTPUT = (
+    'Error response from daemon: Error when allocating new name: Conflict. '
+    'The container name "/tar1090" is already in use by container "56f30a56ce9b".'
+)
+
+
+class TestRepairAfterInterruptedRecreate:
+    """A recreate killed between compose's rename and its remove leaves a
+    container squatting the name compose next needs. Nothing else clears it,
+    so without this repair every later apply fails identically, forever."""
+
+    def _run_apply(self, temp_dir, run_side_effect):
+        import routes.mode as mode_module
+        with patch('subprocess.run', side_effect=run_side_effect):
+            return mode_module.run_config_merger_and_restart(temp_dir)
+
+    def test_recreate_timeout_triggers_a_repair(self, app_client, temp_dir):
+        seen = []
+
+        def side_effect(args, **kwargs):
+            seen.append(args)
+            if '--force-recreate' in args:
+                raise subprocess.TimeoutExpired(cmd='docker', timeout=300)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return MagicMock(returncode=0, stdout='56f30a56ce9b_tar1090\n', stderr='')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+
+        assert error is not None and 'timed out' in error.lower()
+        assert 'cleaned up 1' in error.lower(), f"no repair reported: {error}"
+        assert any(a[:3] == ['docker', 'rm', '-f'] for a in seen), "never removed the stale container"
+
+    def test_name_conflict_triggers_a_repair(self, app_client, temp_dir):
+        seen = []
+
+        def side_effect(args, **kwargs):
+            seen.append(args)
+            if '--force-recreate' in args:
+                return MagicMock(returncode=1, stdout='', stderr=CONFLICT_OUTPUT)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return MagicMock(returncode=0, stdout='56f30a56ce9b_tar1090\n', stderr='')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+
+        assert error is not None
+        assert 'cleaned up 1' in error.lower(), f"no repair reported: {error}"
+        assert any(a[:3] == ['docker', 'rm', '-f'] for a in seen)
+
+    def test_unrelated_failure_does_not_trigger_a_repair(self, app_client, temp_dir):
+        """Repair removes containers — it must not fire on every failure."""
+        seen = []
+
+        def side_effect(args, **kwargs):
+            seen.append(args)
+            if '--force-recreate' in args:
+                return MagicMock(returncode=1, stdout='', stderr='no such image: blah2:v9')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+
+        assert 'no such image' in error
+        assert not any(a[:3] == ['docker', 'rm', '-f'] for a in seen), \
+            "removed containers for an unrelated failure"
+
+    def test_repair_with_nothing_stale_says_so(self, app_client, temp_dir):
+        def side_effect(args, **kwargs):
+            if '--force-recreate' in args:
+                raise subprocess.TimeoutExpired(cmd='docker', timeout=300)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return MagicMock(returncode=0, stdout='blah2\ntar1090\n', stderr='')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+        assert 'no half-created containers' in error.lower()
+
+    def test_repair_failure_is_surfaced_not_swallowed(self, app_client, temp_dir):
+        def side_effect(args, **kwargs):
+            if '--force-recreate' in args:
+                raise subprocess.TimeoutExpired(cmd='docker', timeout=300)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return MagicMock(returncode=0, stdout='56f30a56ce9b_tar1090\n', stderr='')
+            if args[:3] == ['docker', 'rm', '-f']:
+                return MagicMock(returncode=1, stdout='', stderr='resource busy')
+            return MagicMock(returncode=0, stdout='', stderr='')
+
+        error = self._run_apply(temp_dir, side_effect)
+        assert 'automatic repair also failed' in error.lower()
+
+    def test_conflict_detection_matches_the_real_daemon_message(self):
+        import routes.mode as mode_module
+        assert mode_module._is_name_conflict(CONFLICT_OUTPUT)
+        assert not mode_module._is_name_conflict('no such image: blah2:v9')
+        assert not mode_module._is_name_conflict('')
+        assert not mode_module._is_name_conflict(None)
+
+
 class TestRestartLockCoverage:
     """Every path that recreates or removes containers must hold the restart
     lock — a `docker compose down` landing inside another caller's

--- a/tests/test_stack_reconcile.py
+++ b/tests/test_stack_reconcile.py
@@ -1,0 +1,146 @@
+"""stack_reconcile: clearing containers left half-created by an interrupted
+`docker compose up --force-recreate`.
+
+Compose renames the old container to <id-prefix>_<name> before creating the
+replacement. Killed in between, it leaves that container squatting the name
+compose next needs — and nothing clears it, so every later apply fails the
+same way, across reboots.
+"""
+from unittest.mock import MagicMock, patch
+
+from stack_reconcile import (
+    PROJECT, find_stale_containers, reconcile,
+)
+
+# Real shape of the failure, from a node that hit it.
+CONFLICT_OUTPUT = (
+    'Error response from daemon: Error when allocating new name: Conflict. '
+    'The container name "/tar1090" is already in use by container '
+    '"56f30a56ce9ba3fa3df56ed9dea871dcdd6490bc40e92fcb87ab198c18d70310".'
+)
+
+
+def ok(stdout=''):
+    return MagicMock(returncode=0, stdout=stdout, stderr='')
+
+
+class TestFindStaleContainers:
+
+    def test_picks_out_renamed_containers_only(self):
+        listing = ok('blah2\n56f30a56ce9b_tar1090\ntar1090\nb37c58b1ec89_retina-tracker\n')
+        with patch('subprocess.run', return_value=listing):
+            assert find_stale_containers() == [
+                '56f30a56ce9b_tar1090', 'b37c58b1ec89_retina-tracker']
+
+    def test_healthy_project_has_none(self):
+        with patch('subprocess.run', return_value=ok('blah2\ntar1090\nadsb2dd\n')):
+            assert find_stale_containers() == []
+
+    def test_scopes_the_query_to_the_compose_project(self):
+        """A bare name regex over `docker ps -a` would also match containers
+        from other projects on this host — and reconcile removes what it
+        finds."""
+        with patch('subprocess.run', return_value=ok('')) as mock_run:
+            find_stale_containers()
+        args = mock_run.call_args[0][0]
+        assert '--filter' in args
+        assert f'label=com.docker.compose.project={PROJECT}' in args
+
+    def test_underscore_names_that_are_not_compose_renames_are_left_alone(self):
+        """Only a 12-hex-char prefix is compose's rename form."""
+        with patch('subprocess.run', return_value=ok('my_service\nnot_hex_prefix_thing\n')):
+            assert find_stale_containers() == []
+
+    def test_docker_failure_reports_nothing_rather_than_raising(self):
+        with patch('subprocess.run', return_value=MagicMock(returncode=1, stdout='', stderr='boom')):
+            assert find_stale_containers() == []
+
+    def test_docker_missing_reports_nothing_rather_than_raising(self):
+        with patch('subprocess.run', side_effect=FileNotFoundError()):
+            assert find_stale_containers() == []
+
+
+class TestReconcile:
+
+    def test_no_stale_containers_is_a_no_op(self):
+        with patch('subprocess.run', return_value=ok('blah2\ntar1090\n')) as mock_run:
+            removed, error = reconcile('/manifests')
+        assert removed == []
+        assert error is None
+        assert mock_run.call_count == 1, "should not have run rm or up"
+
+    def test_removes_stale_then_restores_the_stack(self):
+        calls = []
+
+        def record(args, **kwargs):
+            calls.append(args)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\nblah2\n')
+            return ok()
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests')
+
+        assert removed == ['56f30a56ce9b_tar1090']
+        assert error is None
+        assert calls[1][:3] == ['docker', 'rm', '-f']
+        assert '56f30a56ce9b_tar1090' in calls[1]
+        assert 'up' in calls[2] and '-d' in calls[2]
+        assert '--force-recreate' not in calls[2], \
+            "a repair should restore what is missing, not bounce healthy containers"
+
+    def test_bring_up_false_removes_without_starting_anything(self):
+        """Spectrum/sdrconnect mode deliberately keeps blah2 stopped."""
+        calls = []
+
+        def record(args, **kwargs):
+            calls.append(args)
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\n')
+            return ok()
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests', bring_up=False)
+
+        assert removed == ['56f30a56ce9b_tar1090']
+        assert error is None
+        assert not any('up' in c for c in calls)
+
+    def test_failed_removal_is_reported(self):
+        def record(args, **kwargs):
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\n')
+            return MagicMock(returncode=1, stdout='', stderr='device or resource busy')
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests')
+
+        assert removed == []
+        assert 'could not remove' in error
+        assert '56f30a56ce9b_tar1090' in error
+
+    def test_failed_restore_still_reports_what_was_removed(self):
+        def record(args, **kwargs):
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\n')
+            if args[:3] == ['docker', 'rm', '-f']:
+                return ok()
+            return MagicMock(returncode=1, stdout='', stderr='no such image')
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests')
+
+        assert removed == ['56f30a56ce9b_tar1090']
+        assert 'repair restart failed' in error
+
+    def test_never_raises_on_unexpected_failure(self):
+        def record(args, **kwargs):
+            if args[:3] == ['docker', 'ps', '-a']:
+                return ok('56f30a56ce9b_tar1090\n')
+            raise OSError('docker daemon gone')
+
+        with patch('subprocess.run', side_effect=record):
+            removed, error = reconcile('/manifests')
+
+        assert removed == []
+        assert 'could not remove' in error

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -282,11 +282,14 @@ class TestTowerSelect:
             data=json.dumps(payload),
             content_type='application/json',
         )
-        assert resp.status_code == 200
+        # Queued, not applied inline: the config write is synchronous but the
+        # merge+restart goes to the shared queue (see apply_service.py).
+        assert resp.status_code == 202
         data = json.loads(resp.data)
         assert data['success'] is True
 
-        # Verify user.yml was updated
+        # The write must have happened before the response, not been deferred
+        # to the queue — anything reading user.yml next has to see it.
         with open(user_path) as f:
             saved = yaml.safe_load(f)
         assert saved['location']['rx']['latitude'] == -33.8688
@@ -338,7 +341,7 @@ class TestTowerSelect:
             data=json.dumps(payload),
             content_type='application/json',
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 202
 
         with open(user_path) as f:
             saved = yaml.safe_load(f)


### PR DESCRIPTION
## Why this exists

#52 and #53 both report **MERGED**, but neither reached `main`. They were stacked PRs, so GitHub merged each into its *base branch* rather than into `main`:

| PR | reported | actually merged into |
|---|---|---|
| #51 | MERGED | `main` ✅ |
| #52 | MERGED | `20260803-serialize-async-apply` |
| #53 | MERGED | `20260803-reconcile-orphans` |

Because #51 was merged to `main` before #52 landed on its base, the chain never collapsed. `main` currently has only #51's content.

## What this brings

Exactly the two missing commits, nothing else:

- `f7f678a` — self-heal containers left half-created by an interrupted restart (#52)
- `22534b3` — refuse config changes mid-install, and queue the last two apply routes (#53)

`git log origin/20260803-reconcile-orphans..origin/main` is a single commit (#51's own merge), and the file delta is confined to what those two commits changed. No divergence, no rework.

## What's missing from `main` without it

Both of these are load-bearing, not polish:

- **Orphan self-heal.** A `docker compose` recreate interrupted by a timeout — or by systemd killing retina-gui's control group during a redeploy — leaves containers renamed to `<hash>_<name>`. Nothing clears them, every later apply fails on the name conflict, and **the state survives a reboot**. Without this, a node in that state is permanently unable to accept a config change.
- **Mender install guard.** `/config/apply`, `/towers/select` and `/api/mode` will otherwise run config-merger against manifests Mender is mid-replacement of, skip the restart because the install set `mode.txt=spectrum`, and report success anyway.
- Plus `/towers/select` and `/calibrate/apply` moving onto the async queue, which is what keeps them under the 100s Cloudflare tunnel cutoff.

## Verification

Everything here was verified on jonathan-node-2 earlier today — orphan self-heal against a manufactured `56f30a56ce9b_tar1090`, and `/towers/select` returning 202 in 0s with `user.yml` written before the response.

Suite at this tip: `429 passed, 7 failed`, all 7 pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)