### PR TITLE
20260804 - Give every tower a real dwell, and stop trusting tuning that never applied

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4,79 +4,25 @@ import os
 import subprocess
 import sys
 
-from config_manager import ConfigManager
-from device_state import DeviceState
-from mender import MenderClient
-from network_manager import NetworkManager
-from ssh_keys import SSHKeyManager
-
-PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Configuration and shared services live in their own module because this one
+# is executed twice — once as __main__ (systemd runs `python3 src/app.py`) and
+# again as `app` the first time a route does `from app import ...`. Anything
+# constructed here would therefore exist twice in one process. See services.py
+# for what that broke. Re-exported below so `from app import ...` is unchanged.
+from services import (  # noqa: F401  (re-exported for routes)
+    PROJECT_ROOT, DEV_MODE, DATA_DIR, USER_CONFIG_PATH, MERGED_CONFIG_PATH,
+    RETINA_NODE_PATH, RETINA_SPECTRUM_URL, NODE_ID_FILE, TOWER_FINDER_URL,
+    BLAH2_API_URL, RETINA_TRACKER_HOST, RETINA_TRACKER_PORT,
+    RETINA_TRACKER_EVENTS_PATH, MENDER_SERVICES,
+    ssh_keys, network_mgr, config_mgr, mender, device_state,
+    apply_service, blah2_client, retina_tracker_client, calibrator,
+    tracker_capture,
+)
 app = Flask(__name__,
             template_folder=os.path.join(PROJECT_ROOT, 'templates'),
             static_folder=os.path.join(PROJECT_ROOT, 'static'))
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', os.urandom(32).hex())
 csrf = CSRFProtect(app)
-
-DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
-
-# Configurable paths - override via environment for local dev.
-# In dev mode, default to a writable local directory instead of the on-device paths.
-DATA_DIR = os.environ.get('DATA_DIR',
-    os.path.join(PROJECT_ROOT, 'dev_data') if DEV_MODE else '/data/retina-gui'
-)
-USER_CONFIG_PATH = os.environ.get('USER_CONFIG_PATH',
-    os.path.join(PROJECT_ROOT, 'dev_data', 'user.yml') if DEV_MODE else '/data/retina-node/config/user.yml'
-)
-MERGED_CONFIG_PATH = os.environ.get('MERGED_CONFIG_PATH',
-    os.path.join(PROJECT_ROOT, 'dev_data', 'config.yml') if DEV_MODE else '/data/retina-node/config/config.yml'
-)
-RETINA_NODE_PATH = os.environ.get('RETINA_NODE_PATH', '/data/mender-docker-compose/current/manifests')
-RETINA_SPECTRUM_URL = os.environ.get('RETINA_SPECTRUM_URL', 'http://localhost:3020')
-NODE_ID_FILE = os.environ.get('NODE_ID_FILE', '/data/mender/node_id')
-TOWER_FINDER_URL = os.environ.get('TOWER_FINDER_URL', 'https://tower-finder.retina.fm')
-# blah2_api runs with network_mode: host and listens directly on this port —
-# NOT the :8080 blah2_host nginx proxy, which doesn't forward /capture/* at all.
-BLAH2_API_URL = os.environ.get('BLAH2_API_URL', 'http://localhost:3000')
-# retina-tracker sidecar (network_mode: host, see retina-node's docker-compose.yml)
-RETINA_TRACKER_HOST = os.environ.get('RETINA_TRACKER_HOST', 'localhost')
-RETINA_TRACKER_PORT = int(os.environ.get('RETINA_TRACKER_PORT', '30100'))
-# Path the sidecar streams JSONL track events to (-s flag, see its compose
-# command) — tailed rather than read over the TCP socket, since retina-tracker's
-# --tcp mode is input-only (see retina_tracker_client.py's module docstring).
-RETINA_TRACKER_EVENTS_PATH = os.environ.get('RETINA_TRACKER_EVENTS_PATH',
-    os.path.join(PROJECT_ROOT, 'dev_data', 'retina-tracker-events.jsonl') if DEV_MODE
-    else '/data/retina-node/retina-tracker/output/events.jsonl'
-)
-DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
-
-# Shared services
-ssh_keys = SSHKeyManager(os.path.join(DATA_DIR, "authorized_keys"))
-network_mgr = NetworkManager(dev_mode=DEV_MODE)
-
-config_mgr = ConfigManager(
-    user_config_path=USER_CONFIG_PATH,
-    merged_config_path=MERGED_CONFIG_PATH,
-    retina_node_path=RETINA_NODE_PATH,
-)
-
-mender = MenderClient(
-    server_url=os.environ.get('MENDER_SERVER_URL', 'https://hosted.mender.io'),
-    release_name=os.environ.get('MENDER_RELEASE_NAME', 'retina-node'),
-    device_type=os.environ.get('MENDER_DEVICE_TYPE', 'pi5-v3-arm64'),
-    dev_mode=DEV_MODE,
-    dev_data_dir=DATA_DIR,
-)
-
-MENDER_SERVICES = ["mender-authd", "mender-updated", "mender-connect"]
-
-device_state = DeviceState(
-    data_dir=DATA_DIR,
-    mender_services=MENDER_SERVICES,
-    mender_conf_path="/data/mender/mender.conf",
-    mender_conf_backup_dir="/data/mender-cloud-disabled",
-    mender_conf_backup_path="/data/mender-cloud-disabled/mender.conf",
-    dev_mode=DEV_MODE,
-)
 
 if not DEV_MODE:
     device_state.apply_startup_preferences()
@@ -135,26 +81,10 @@ except Exception:
     pass
 
 
-from apply_service import ApplyService
-from blah2_client import Blah2Client
-from calibrator import Calibrator
-from retina_tracker_client import RetinaTrackerClient
-from tracker_capture import TrackerCaptureService
-
-apply_service = ApplyService(RETINA_NODE_PATH, dev_mode=DEV_MODE)
-blah2_client = Blah2Client(BLAH2_API_URL)
-retina_tracker_client = RetinaTrackerClient(
-    RETINA_TRACKER_HOST, RETINA_TRACKER_PORT, RETINA_TRACKER_EVENTS_PATH)
-calibrator = Calibrator(blah2_client, retina_tracker_client)
-tracker_capture = TrackerCaptureService(blah2_client, retina_tracker_client)
-
-
-def _on_calibration_complete(status):
-    """Runs on the calibration thread when a run reaches a terminal state."""
-    device_state.release_calibration_lock()
-
-
-calibrator.on_complete = _on_calibration_complete
+# apply_service, blah2_client, retina_tracker_client, calibrator and
+# tracker_capture are constructed in services.py and imported at the top of
+# this file — they must exist once per process, and this module body runs
+# twice. See services.py.
 
 # Never auto-start under pytest: conftest.py's app_client fixture reloads this
 # module per-test, and start() spawns a permanent, never-stopped background

--- a/src/calibrator.py
+++ b/src/calibrator.py
@@ -92,10 +92,16 @@ callback (_on_track_event) registered once with that same client — the one
 tracker-preview already tails. Because a confirmed track from one candidate
 tower is physically meaningless at another (different fc/tx position means
 different delay/Doppler geometry), a {"type": "RESET"} message clears the
-sidecar's tracker in place before each tower's descent+dwell (see
-RetinaTrackerClient.reset()) — mirroring blah2's own fc-triggered tracker
-reset. Reset scope is per-tower only: since any confirmed track ends the
-search immediately, finer-grained reset scope has no effect on correctness.
+sidecar's tracker in place (see RetinaTrackerClient.reset()) — mirroring
+blah2's own fc-triggered tracker reset. That reset happens at the start of
+every *dwell*, and again after a mid-dwell backoff, so a confirmation can
+only be earned from frames observed at the tuning it is reported against
+(see _reset_tracker). It used to be per-tower, on the reasoning that any
+confirmed track ends the search immediately so finer scope could not matter.
+That assumed this calibration is the sidecar's only source, which it is not:
+tracker_capture's always-on capture shares the same client, so the tracker is
+fed throughout the descent too, and a per-tower reset left a confirmed track
+waiting before the dwell had observed anything at all.
 Evidence grading is coarser than an in-process tracker could offer
 (EVIDENCE_NONE/DETECTIONS/ACTIVE only, no tentative/associated distinction)
 — the sidecar's events stream only reports confirmed (ACTIVE) tracks, the
@@ -106,8 +112,15 @@ Two success modes, with genuinely different dwell strategies:
     sidecar only ever emits one once a track has been promoted to ACTIVE —
     see retina_tracker/tracker.py::process_frame). No independent way to
     tell "bad gain" from "no aircraft right now", so this mode is
-    time-boxed — each tower gets a fair share of the overall budget (see
-    _run) and gives up when that runs out.
+    time-boxed. The two phases are budgeted *separately* (see _run):
+    descent runs under its own fixed ceiling (DESCENT_BACKSTOP_SECONDS),
+    and only the dwell divides what is left of the run budget across the
+    towers still to go. They deliberately do not share one deadline — an
+    earlier design gave each tower a single descent+dwell allowance, which
+    meant a descent long enough to exhaust it left zero dwell and returned
+    "skipped_no_time". On any node whose descent walks more than a few LNA
+    states that happened on every tower, so a whole run could be spent
+    retuning without ever once watching for an aircraft.
   - MODE_ADSB: a confirmed-track event only counts if the sidecar's own
     tracker matched it to a real aircraft (retina-tracker's Track class does
     this matching natively, from the same per-detection "adsb" field
@@ -194,13 +207,37 @@ ACK_POLL_SECONDS = 0.2
 APPLY_RETRY_DELAY_SECONDS = 0.5
 RF_STATUS_TIMEOUT_SECONDS = 6.0
 RF_STATUS_POLL_SECONDS = 0.3
-OVERLOAD_SETTLE_SECONDS = 2.0
+# How long to let a new gain/LNA candidate settle before reading its overload
+# state. This does not have to cover the overload *reporting* latency: blah2
+# posts an overload-status change as soon as it sees one (its capture thread
+# polls the device every 250ms and posts on change), so a candidate that
+# actually clips is reported promptly regardless of this value. What this
+# covers is the physical settle after the retune. Note that _read_overload
+# waits for a report newer than the candidate's appliedAt, and blah2 only
+# emits an unchanged state on a 2s heartbeat — so on a *clean* probe that
+# heartbeat, not this constant, is usually what bounds the wait.
+OVERLOAD_SETTLE_SECONDS = 1.0
 
 # Dwell: how long to wait for a confirmed track at one tuning. No fixed
 # default — each tower's share of the overall budget is computed dynamically
 # in _run() as (time remaining / towers remaining), so a slow descent or an
 # early tower's full-length dwell can't silently starve the towers after it.
 DWELL_POLL_SECONDS = 1.0
+
+# How often the dwell re-reads overload state. A single probe reading cannot
+# tell a genuinely clean operating point from one that clips intermittently,
+# and the dwell is by far the longest phase — so a marginal point accepted by
+# descent gets sat on for minutes. Observed on a live node: descent settled at
+# lna_state 3, the device then cycled Overload_Detected/Corrected there for the
+# whole dwell, and by the end the SDRplay API had stopped answering control
+# calls altogether, so every later retune in that run failed. Watching during
+# the dwell catches what one probe cannot.
+DWELL_OVERLOAD_CHECK_SECONDS = 5.0
+
+# How many times a dwell retreats before giving up on the tower. Each backoff
+# costs part of the dwell window, and a point needing several is not one worth
+# dwelling on.
+MAX_DWELL_BACKOFFS = 2
 
 # MODE_TRACK's retina-tracker feed loop polls faster than blah2's own CPI
 # cadence (measured ~0.9-1s on the desk node) so a new detection frame is
@@ -209,8 +246,30 @@ DWELL_POLL_SECONDS = 1.0
 # timestamp, so polling faster than the CPI rate is free, not wasteful.
 TRACKER_FEED_POLL_SECONDS = 0.2
 
-# Overall run budget.
-TOTAL_BUDGET_SECONDS = 600
+# Overall run budget. Kept comfortably below the 20 minutes at which both
+# retina-gui's own CALIBRATE_LOCK_TIMEOUT (device_state.py) and blah2-arm's
+# watchdog (blah2_rspduo_restart.bash, CALIBRATE_LOCK_TIMEOUT_SECONDS=1200)
+# stop treating calibrate.lock as live — past that point the watchdog would
+# restart the stack underneath a still-running calibration. Raising this
+# above ~20 minutes means raising both of those, in both repos, together.
+TOTAL_BUDGET_SECONDS = 900
+
+# Hard per-tower ceiling on the descent phase, whatever the run budget is —
+# a backstop against a device that has wedged and is burning the full retune
+# timeout on every probe, not a normal operating limit. It sits above the
+# ~4.5 minute worst case for a healthy node (one that never overloads walks
+# all 9 LNA states, ~10-11 probes each).
+DESCENT_BACKSTOP_SECONDS = 300
+
+# The share of a tower's own time slice that descent may consume before it
+# is cut off. This is what actually guarantees every tower gets watched:
+# descent and dwell are budgeted separately (see _run), but "separately"
+# alone is not enough — three towers each taking the full backstop above
+# would still swallow a 900s run whole and leave nothing to dwell on,
+# which is the original bug wearing a different hat. Capping descent at a
+# fraction of the slice means the remainder is always there for the dwell,
+# so no tower can ever be tuned and then not looked at.
+MAX_DESCENT_FRACTION = 0.7
 
 # Success modes.
 MODE_TRACK = "track"
@@ -265,6 +324,10 @@ class Calibrator:
         # Latest confirmed-track event the sidecar has emitted (see
         # _on_track_event) — read via _take_confirmed_event().
         self._last_confirmed_event = None
+        # Frequency blah2 was last successfully tuned to, so _apply knows
+        # when it is about to change fc and must hand over via the safe
+        # corner first (see _apply). None until the first successful apply.
+        self._last_applied_fc = None
         # Deferred to start() rather than done here: __init__ runs at app
         # boot regardless of whether a run ever happens, and registering
         # eagerly would start retina_tracker_client's tail thread that early
@@ -316,9 +379,11 @@ class Calibrator:
         first (normally the currently-configured tower).
         original: {"fc": int, "gain_a": int, "gain_b": int} — restored on any
         non-success terminal state.
-        dwell_seconds: fixed per-tower budget override, mainly for tests.
-        Leave as None to divide the remaining time evenly across the
-        remaining towers each time a new tower starts (the production path).
+        dwell_seconds: fixed per-tower *dwell* window override, mainly for
+        tests. Leave as None (the production path) to divide whatever run
+        time remains after each tower's descent evenly across the towers
+        still to go. Descent is never taken out of this — it runs under its
+        own DESCENT_BACKSTOP_SECONDS ceiling.
         mode: MODE_TRACK (any confirmed track) or MODE_ADSB (confirmed track
         that also matches a real aircraft's expected position, per the
         node's own truth.adsb.delay_tolerance/doppler_tolerance config — the
@@ -351,6 +416,9 @@ class Calibrator:
             # isn't actually enforced (see module docstring).
             self._status["progress"]["budget_seconds"] = (
                 None if mode == MODE_ADSB else budget_seconds)
+        # Seeded from the device itself at the top of _run, NOT from config —
+        # see _seed_last_applied_fc for why the two are not interchangeable.
+        self._last_applied_fc = None
         self._cancel.clear()
         self._thread = threading.Thread(
             target=self._run, args=(list(towers), dict(original),
@@ -421,10 +489,85 @@ class Calibrator:
     def _apply(self, fc, gain_a, gain_b, lna_state, ignore_cancel=False):
         """Request a retune and wait for blah2's ack. Returns appliedAt (ms).
 
+        A frequency change is preceded by a separate retune to the safe
+        corner at the *current* frequency. blah2's driver applies fc before
+        gain within one retune (RspDuo::retune does Update_Tuner_Frf, then
+        Update_Tuner_Gr), so a single call that moves both would park the
+        front end on the new frequency while still at the old one's gain.
+        Reaching a new tower from a sensitive operating point therefore
+        saturates the device before the attenuation this call is asking for
+        ever lands — and the driver returns early on that failure, so the
+        gain update is not merely late, it never executes. Worse, once the
+        SDRplay API returns ServiceNotResponding (which is what a hard
+        overload looks like from out here) it stays that way, so the retry
+        cannot get the rescuing attenuation through either.
+
+        Measured directly: 213 MHz at (59, 59, lna 9) is clean when reached
+        from a safe state, and saturates when reached from (49, 20, lna 1)
+        at 201 MHz — same destination, same requested gain, different
+        starting point. Going via the safe corner costs one extra retune
+        per tower change and removes the exposure entirely.
+
         ignore_cancel: used only by the restore-on-failure path, which must
         run to completion even if the user cancels (again) while it's in
         flight — otherwise blah2 could be left tuned to a failed candidate.
         """
+        if self._last_applied_fc is not None and int(fc) != self._last_applied_fc:
+            self._safe_fc_handover(ignore_cancel=ignore_cancel)
+        applied_at = self._apply_tuning(fc, gain_a, gain_b, lna_state,
+                                        ignore_cancel=ignore_cancel)
+        self._last_applied_fc = int(fc)
+        return applied_at
+
+    def _seed_last_applied_fc(self, original_fc):
+        """Record the frequency blah2 is *actually* on, before the search
+        starts, so _apply can tell a real frequency change from a no-op.
+
+        This must come from the device, not from the merged config. The two
+        diverge routinely: a run that finds a track and is never persisted
+        leaves the radio on the winning frequency while config.yml still
+        holds the old one. Seeding from config there makes the calibrator
+        believe it is already on the first tower's frequency when it is not,
+        so _apply sees no change and skips the safe-corner handover —
+        switching that protection off in precisely the case where the device
+        has drifted furthest from what config claims.
+
+        Seen live, and it wedged the radio: config said 545MHz, blah2 was
+        actually on 213MHz at (59,44,lna5) from an unpersisted run, and the
+        first retune moved fc to a strong local tower at that sensitive gain
+        with no handover. Every subsequent retune failed and the whole run
+        came back tuning_not_applied in 42 seconds.
+
+        An empty retune status is not ambiguous: it means blah2 has acked no
+        retune since it booted, so it is still on the frequency from
+        config.yml — which is exactly what the caller passed as `original`.
+        """
+        status = self._client.get_retune_status()
+        if status and status.get("fc") is not None:
+            self._last_applied_fc = int(status["fc"])
+        else:
+            self._last_applied_fc = int(original_fc)
+
+    def _safe_fc_handover(self, ignore_cancel=False):
+        """Retune to the safe corner at the frequency currently in use,
+        immediately before a frequency change (see _apply).
+
+        Best-effort: a failure here is not raised. If the device won't take
+        even this, the caller's own retune is about to surface the problem
+        through the normal path, and _probe already treats that as an
+        overload at the candidate. Raising here instead would only turn a
+        contained per-candidate failure into an aborted run.
+        """
+        try:
+            self._apply_tuning(self._last_applied_fc, GAIN_REDUCTION_MAX,
+                               GAIN_REDUCTION_MAX, LNA_STATE_MAX,
+                               ignore_cancel=ignore_cancel)
+        except CalibrationError:
+            pass
+
+    def _apply_tuning(self, fc, gain_a, gain_b, lna_state, ignore_cancel=False):
+        """One retune request plus ack wait. Callers should normally use
+        _apply, which adds the safe-corner handover on a frequency change."""
         last_error = None
         for attempt in range(2):
             self._check_cancel(ignore_cancel=ignore_cancel)
@@ -443,8 +586,18 @@ class Calibrator:
                     return status.get("appliedAt", 0)
                 time.sleep(ACK_POLL_SECONDS)
             last_error = "blah2 did not acknowledge the retune"
+        # Deliberately does not guess which of the two it was. An
+        # unacknowledged retune means either the radar is down, or the
+        # front end is so overloaded that the SDRplay API has stopped
+        # responding to control calls — from here those look identical,
+        # and they need opposite responses from the user. The previous
+        # wording ("Is the radar running?") named only the first, which
+        # is actively misleading on a strong-signal node where the second
+        # is the common case.
         raise CalibrationError(
-            f"Retune failed: {last_error}. Is the radar running?")
+            f"Retune failed: {last_error}. Either the radar is not running, "
+            "or this tower is strong enough to overload the receiver even at "
+            "minimum gain")
 
     def _read_overload(self, applied_at_ms):
         """Overload flags from an overload-status report newer than
@@ -499,6 +652,52 @@ class Calibrator:
         except CalibrationError as e:
             return applied_at, True, True, str(e)
         return applied_at, overload_a, overload_b, None
+
+    def _verify_applied(self, fc, gain_a, gain_b, lna_state):
+        """Confirm blah2 is really tuned to this before dwelling on it.
+
+        Returns (applied_at_ms, None) if it is, or (None, reason) if not.
+
+        A retune that fails does not stop the run — _probe folds the failure
+        into an overload reading so the descent can retreat — but until now
+        nothing checked, before dwelling, whether the tuning the descent
+        settled on was ever actually accepted. It could not simply trust
+        _descend's applied_at either: when a candidate's own retune never
+        completes, _probe returns the *previous* candidate's timestamp, so
+        the dwell's `timestamp >= applied_at` guard still passes for
+        detections produced by the old tuning. The result was a dwell that
+        looked entirely healthy while measuring a different frequency, and
+        reported its outcome against the tower it thought it was on.
+        Observed live: a dwell ran for minutes labelled WWLP/201MHz while
+        blah2 was still on 545MHz.
+
+        Comparing against the last acknowledged retune closes that: it is
+        the device's own account of what it is tuned to, so it catches a
+        failed retune, a generation blah2 abandoned (see its
+        MAX_RETUNE_ATTEMPTS), and anything else that retuned the radio
+        behind this run's back.
+        """
+        status = self._client.get_retune_status()
+        if not status:
+            return None, "blah2 has not acknowledged any tuning"
+
+        actual = (status.get("fc"), status.get("gainReductionA"),
+                  status.get("gainReductionB"), status.get("lnaState"))
+        if actual != (fc, gain_a, gain_b, lna_state):
+            # blah2_api reports a generation it gave up on (newer blah2 only,
+            # absent on older builds) — a more specific reason when present.
+            rejected = status.get("rejected") or {}
+            if rejected:
+                return None, (
+                    f"blah2 abandoned the retune after {rejected.get('attempts')} "
+                    f"attempts; it is still tuned to fc={actual[0]} "
+                    f"gain=({actual[1]},{actual[2]}) lna={actual[3]}")
+            return None, (
+                f"blah2 is tuned to fc={actual[0]} gain=({actual[1]},{actual[2]}) "
+                f"lna={actual[3]}, not the resolved fc={fc} "
+                f"gain=({gain_a},{gain_b}) lna={lna_state}")
+
+        return status.get("appliedAt", 0), None
 
     def _safe_revert(self, fc, gain_a, gain_b, lna_state, fallback_applied_at):
         """Best-effort re-apply of a previously-proven-safe candidate, after
@@ -673,8 +872,11 @@ class Calibrator:
         right there rather than climbing a ladder toward states it
         already knows are worse.
 
-        deadline: this tower's shared descent+dwell budget (monotonic
-        clock). Never exceeded — see _descend_reference/_descend_surveillance.
+        deadline: this tower's descent-only ceiling (monotonic clock), a
+        backstop against a wedged device rather than a share of the run
+        budget — the dwell window is derived separately once this returns
+        (see _run). Never exceeded — see
+        _descend_reference/_descend_surveillance.
 
         Returns (gain_a, gain_b, lna_state, applied_at_ms).
         """
@@ -732,12 +934,44 @@ class Calibrator:
         _dwell_adsb instead — see the module docstring.)
         """
         self._update(phase="dwelling")
+        # Start from a genuinely empty tracker — see _reset_tracker.
+        self._reset_tracker()
         max_evidence = EVIDENCE_NONE
         max_detections = 0
         last_timestamp = None
+        backoffs = 0
+        next_overload_check = time.monotonic() + DWELL_OVERLOAD_CHECK_SECONDS
+        overload_baseline = self._overload_reading()
 
         while time.monotonic() < dwell_deadline:
             self._check_cancel()
+
+            # A single probe reading cannot distinguish a clean operating
+            # point from one that clips intermittently, so keep watching the
+            # one we settled on — see DWELL_OVERLOAD_CHECK_SECONDS.
+            if time.monotonic() >= next_overload_check:
+                next_overload_check = time.monotonic() + DWELL_OVERLOAD_CHECK_SECONDS
+                reading = self._overload_reading()
+                clipped_a, clipped_b = self._overload_since(overload_baseline, reading)
+                if clipped_a or clipped_b:
+                    overload_baseline = reading
+                    self._update_rf(clipped_a, clipped_b)
+                    if backoffs >= MAX_DWELL_BACKOFFS:
+                        tower_entry["outcome"] = "unstable_overload"
+                        tower_entry["max_evidence"] = max_evidence
+                        tower_entry["max_detections"] = max_detections
+                        return None
+                    backoffs += 1
+                    gain_a, gain_b, lna_state, applied_at = self._dwell_backoff(
+                        fc, gain_a, gain_b, lna_state, applied_at,
+                        clipped_a, clipped_b, backoffs, tower_entry)
+                    # Everything before the retreat was measured at a tuning
+                    # we have now abandoned — restart the tracker and the
+                    # freshness guard so nothing from it is credited to the
+                    # tuning we end up reporting.
+                    self._reset_tracker()
+                    last_timestamp = None
+                    overload_baseline = self._overload_reading()
 
             detection = self._client.get_detection()
             timestamp = detection.get("timestamp") if detection else None
@@ -755,9 +989,17 @@ class Calibrator:
             if confirmed is not None:
                 tower_entry["outcome"] = "confirmed_track"
                 tower_entry["max_evidence"] = EVIDENCE_ACTIVE
+                # Report the tuning actually in effect — a mid-dwell backoff
+                # may have moved it since descent resolved (see
+                # _dwell_backoff), and history's final_* must agree with the
+                # result the user is offered to persist.
+                tower_entry["final_gain_a"] = gain_a
+                tower_entry["final_gain_b"] = gain_b
+                tower_entry["final_lna_state"] = lna_state
                 return {
                     "tower_name": tower.get("name"), "fc": fc,
                     "gain_a": gain_a, "gain_b": gain_b,
+                    "lna_state": lna_state,
                     "track_id": confirmed.get("track_id"),
                 }
 
@@ -768,7 +1010,119 @@ class Calibrator:
         tower_entry["outcome"] = "no_confirmed_track"
         tower_entry["max_evidence"] = max_evidence
         tower_entry["max_detections"] = max_detections
+        # As on the success path: a mid-dwell backoff may have moved these
+        # since descent resolved them, and the no-track fallback reads the
+        # top tower's final values to decide where to leave the device.
+        tower_entry["final_gain_a"] = gain_a
+        tower_entry["final_gain_b"] = gain_b
+        tower_entry["final_lna_state"] = lna_state
         return None
+
+    def _reset_tracker(self):
+        """Clear the sidecar's tracker and any confirmed event already held.
+
+        Called at the start of every dwell, and again after a mid-dwell
+        backoff, so a confirmation can only ever be earned from frames
+        observed at the tuning it will be reported against.
+
+        Per-tower reset is not sufficient, and the reasoning that said it was
+        assumed this calibration is the sidecar's only source. It isn't:
+        tracker_capture's always-on capture shares this same client, because
+        the sidecar accepts one connection at a time. So the tracker is fed
+        continuously whether or not a dwell is running, and a tower-start
+        reset leaves the whole descent — 150s on a live node — for a track to
+        accumulate and confirm before the dwell starts. The dwell's first
+        check then finds it already waiting and credits it to the resolved
+        tuning, having observed none of it. Seen live as a confirmed track
+        with dwell_seconds 0.0.
+
+        The applied_at guard does not close this: it only requires the
+        event's *latest* detection to post-date the retune, which a track
+        built across the descent still satisfies.
+        """
+        self._tracker_client.reset()
+        with self._lock:
+            self._last_confirmed_event = None
+
+    def _overload_reading(self):
+        """Current overload level plus blah2's monotonic onset counts (the
+        counts are None on an older blah2 that doesn't report them)."""
+        rf = self._client.get_overload_status()
+        if not rf:
+            return None
+        return {
+            "level_a": bool(rf.get("overloadA")),
+            "level_b": bool(rf.get("overloadB")),
+            "count_a": rf.get("overloadCountA"),
+            "count_b": rf.get("overloadCountB"),
+        }
+
+    @staticmethod
+    def _overload_since(baseline, current):
+        """Did either tuner clip at or since the baseline reading?
+
+        Both signals are needed, because they cover different shapes of the
+        same problem and each is blind to the other's:
+
+        - The *level* catches overload that is still happening now. That is
+          the persistent case, where a count taken after the onset never
+          rises again and so reveals nothing.
+        - The *counts* catch episodes that began and ended between two polls.
+          This hardware clips and recovers fast enough for that to be the
+          normal case — measured on a live node, 9 detect/correct cycles
+          inside 90s with every level sample reading false throughout.
+
+        Watching only the level misses oscillation; watching only the counts
+        misses a steady overload already in progress when the dwell began.
+        """
+        if not current:
+            return False, False
+        clipped_a, clipped_b = current["level_a"], current["level_b"]
+        if baseline and current["count_a"] is not None and baseline["count_a"] is not None:
+            clipped_a = clipped_a or current["count_a"] > baseline["count_a"]
+            clipped_b = clipped_b or current["count_b"] > baseline["count_b"]
+        return clipped_a, clipped_b
+
+    def _dwell_backoff(self, fc, gain_a, gain_b, lna_state, applied_at,
+                       overload_a, overload_b, attempt, tower_entry):
+        """Retreat one step toward safety after overload appeared mid-dwell.
+
+        Same direction of travel as the descent's own reverts: more
+        attenuation on whichever channel is clipping, and if a channel is
+        already at the gain ceiling, one step up the shared LNA axis with
+        both gains reset to the ceiling too — moving LNA is not per-channel,
+        so its neighbours have to be reproved from the safe end (see
+        _descend). Best-effort: if the device will not take the retreat,
+        report the values we asked for and let the dwell carry on; the
+        caller gives up after MAX_DWELL_BACKOFFS either way.
+
+        Returns the (gain_a, gain_b, lna_state, applied_at) now in effect.
+        """
+        new_a, new_b, new_lna = gain_a, gain_b, lna_state
+        if overload_a:
+            new_a = min(gain_a + DESCENT_STEP_DB, GAIN_REDUCTION_MAX)
+        if overload_b:
+            new_b = min(gain_b + DESCENT_STEP_DB, GAIN_REDUCTION_MAX)
+        # Gain alone cannot help a channel already at the ceiling — the
+        # clipping is upstream of it, so back the LNA off instead.
+        if ((overload_a and new_a == gain_a) or (overload_b and new_b == gain_b)) \
+                and lna_state < LNA_STATE_MAX:
+            new_lna = lna_state + 1
+            new_a = new_b = GAIN_REDUCTION_MAX
+
+        entry = {"phase": "dwell_overload_backoff", "attempt": attempt,
+                 "overload_a": overload_a, "overload_b": overload_b,
+                 "from": {"gain_a": gain_a, "gain_b": gain_b, "lna_state": lna_state},
+                 "to": {"gain_a": new_a, "gain_b": new_b, "lna_state": new_lna}}
+        tower_entry.setdefault("dwell_backoffs", []).append(entry)
+
+        new_applied_at, revert_error = self._safe_revert(
+            fc, new_a, new_b, new_lna, applied_at)
+        if revert_error:
+            entry["device_error"] = True
+            entry["device_error_detail"] = revert_error
+        self._set_current(gain_a=new_a, gain_b=new_b, lna_state=new_lna)
+        return new_a, new_b, new_lna, new_applied_at
 
     def _dwell_adsb(self, tower, fc, gain_a, initial_gain_b, lna_state, tower_entry):
         """MODE_ADSB's dwell: no time budget. Starting from descent's clean
@@ -822,6 +1176,11 @@ class Calibrator:
                     self._set_current(gain_b=previous_gain_b)
                 break
 
+            # Each gain candidate is its own watch, so each starts from an
+            # empty tracker — otherwise a match earned at the previous, more
+            # attenuating candidate would be credited to this one. See
+            # _reset_tracker.
+            self._reset_tracker()
             aircraft_seen = False
             last_timestamp = None
             while True:
@@ -929,6 +1288,10 @@ class Calibrator:
     # ── Run loop ───────────────────────────────────────────────
 
     def _run(self, towers, original, budget_seconds, dwell_seconds, mode):
+        # Must happen before the first retune: the safe-corner handover can
+        # only tell a frequency change from a no-op if it knows where the
+        # radio actually is. See _seed_last_applied_fc.
+        self._seed_last_applied_fc(original["fc"])
         result = None
         error = None
         state = "failed"
@@ -953,11 +1316,13 @@ class Calibrator:
                 self._set_current(tower_index=index, tower_name=tower.get("name"),
                                   fc=fc, gain_a=GAIN_REDUCTION_MAX,
                                   gain_b=GAIN_REDUCTION_MAX, lna_state=LNA_STATE_MAX)
-                # New geometry — a track confirmed at the previous tower (or
-                # an earlier gain candidate at this one) means nothing here.
-                self._tracker_client.reset()
-                with self._lock:
-                    self._last_confirmed_event = None
+                # The sidecar is reset at the start of each *dwell*, not here
+                # — see _reset_tracker. Resetting per tower is not enough:
+                # this client is shared with tracker_capture's always-on feed
+                # (the sidecar accepts one connection), so between a
+                # tower-start reset and the dwell the tracker keeps being fed
+                # for the whole descent and can confirm a track before the
+                # dwell begins.
                 # tower_entry stays thread-local until the tower is finished —
                 # it is only shared (appended to status history) once the run
                 # thread stops mutating it
@@ -968,24 +1333,28 @@ class Calibrator:
                     "outcome": "not_reached",
                 }
 
+                tower_started = time.monotonic()
                 if mode == MODE_ADSB:
                     # Descent is still time-bounded (it's a fast,
                     # traffic-independent overload-avoidance loop) — just not
                     # via a shrinking per-tower share of the overall budget.
-                    descent_deadline = time.monotonic() + ADSB_DESCENT_DEADLINE_SECONDS
+                    descent_deadline = tower_started + ADSB_DESCENT_DEADLINE_SECONDS
+                    tower_share = None
                 else:
-                    # This tower's total budget (descent + dwell together), so
-                    # a slow descent shrinks its own dwell rather than
-                    # overrunning into towers after it. Fixed dwell_seconds
-                    # (tests) keeps the old fixed-window behaviour; None
-                    # (production) divides whatever's left evenly across the
-                    # remaining towers.
-                    if dwell_seconds is not None:
-                        descent_deadline = min(time.monotonic() + dwell_seconds, run_deadline)
-                    else:
-                        towers_remaining = len(towers) - index
-                        time_left = max(run_deadline - time.monotonic(), 0)
-                        descent_deadline = time.monotonic() + (time_left / towers_remaining)
+                    # This tower's slice of what's left. Computed fresh per
+                    # tower so unused time from a quick tower rolls forward
+                    # rather than being lost, and so no tower can overrun
+                    # into the ones after it.
+                    towers_remaining = len(towers) - index
+                    time_left = max(run_deadline - tower_started, 0)
+                    tower_share = time_left / towers_remaining
+                    # Descent may only take part of the slice; the rest is
+                    # reserved for the dwell so this tower is always
+                    # actually watched. See MAX_DESCENT_FRACTION.
+                    descent_deadline = min(
+                        tower_started + tower_share * MAX_DESCENT_FRACTION,
+                        tower_started + DESCENT_BACKSTOP_SECONDS,
+                        run_deadline)
 
                 try:
                     gain_a, gain_b, lna_state, applied_at = self._descend(
@@ -997,30 +1366,73 @@ class Calibrator:
                         top_tower_resolved = (gain_a, gain_b, lna_state)
                     self._set_current(gain_a=gain_a, gain_b=gain_b, lna_state=lna_state)
 
-                    if mode == MODE_ADSB:
+                    # Never dwell on tuning the device did not actually take:
+                    # the dwell would measure whatever it is really on and
+                    # report the answer against this tower. See
+                    # _verify_applied.
+                    verified_at, tuning_error = self._verify_applied(
+                        fc, gain_a, gain_b, lna_state)
+                    if tuning_error:
+                        tower_entry["outcome"] = "tuning_not_applied"
+                        tower_entry["tuning_error"] = tuning_error
+                        tower_entry["device_error"] = True
+                        result = None
+                    elif mode == MODE_ADSB:
+                        applied_at = verified_at
                         result = self._dwell_adsb(tower, fc, gain_a, gain_b, lna_state,
                                                   tower_entry)
-                    elif time.monotonic() >= descent_deadline:
-                        # Descent alone used this tower's whole budget —
-                        # be honest that it was never actually watched,
-                        # rather than recording a misleading "checked,
-                        # nothing there".
-                        tower_entry["outcome"] = "skipped_no_time"
-                        result = None
                     else:
-                        dwell_started = time.monotonic()
-                        result = self._dwell(tower, fc, gain_a, gain_b, lna_state, applied_at,
-                                             descent_deadline, tower_entry)
-                        tower_entry["dwell_seconds"] = round(time.monotonic() - dwell_started, 1)
+                        # Use the device's own applied-at, not descent's —
+                        # descent's can be a previous candidate's timestamp
+                        # when a retune failed, which would let stale
+                        # detections through the dwell's freshness guard.
+                        applied_at = verified_at
+                        # Dwell gets the rest of this tower's slice — the
+                        # part descent was capped out of. A slow descent
+                        # therefore shortens its own dwell but can never
+                        # delete it. Fixed dwell_seconds (tests) pins the
+                        # window to a known length instead.
+                        now = time.monotonic()
+                        if dwell_seconds is not None:
+                            dwell_deadline = min(now + dwell_seconds, run_deadline)
+                        else:
+                            dwell_deadline = min(tower_started + tower_share, run_deadline)
+
+                        if dwell_deadline <= now:
+                            # The run budget is genuinely exhausted — this
+                            # tower was tuned but never actually watched. Say
+                            # so, rather than recording a misleading
+                            # "checked, nothing there".
+                            tower_entry["outcome"] = "skipped_no_time"
+                            result = None
+                        else:
+                            dwell_started = now
+                            result = self._dwell(tower, fc, gain_a, gain_b, lna_state,
+                                                 applied_at, dwell_deadline, tower_entry)
+                            tower_entry["dwell_seconds"] = round(
+                                time.monotonic() - dwell_started, 1)
                 finally:
                     if (any(e.get("device_error") for e in tower_entry.get("descent", ())) or
                             any(e.get("device_error") for e in tower_entry.get("gains_tried", ()))):
                         tower_entry["device_error"] = True
+                    # A mid-dwell backoff moves the operating point after
+                    # descent resolved it, so re-read the tower's own final
+                    # values here — the no-track fallback leaves the device
+                    # on these, and must not restore one already abandoned
+                    # for overloading.
+                    if index == 0 and tower_entry.get("final_lna_state") is not None:
+                        top_tower_resolved = (tower_entry["final_gain_a"],
+                                              tower_entry["final_gain_b"],
+                                              tower_entry["final_lna_state"])
                     self._append_history(tower_entry)
                     self._update_progress(towers_tried=index + 1)
 
                 if result is not None:
-                    result["lna_state"] = lna_state
+                    # MODE_TRACK's dwell reports its own lna_state, which may
+                    # have moved since descent resolved it (see
+                    # _dwell_backoff). Only fill it in for a dwell that
+                    # didn't — never overwrite it with a stale value.
+                    result.setdefault("lna_state", lna_state)
                     state = "done"
                     break
 

--- a/src/routes/calibrate.py
+++ b/src/routes/calibrate.py
@@ -11,7 +11,12 @@ bp = Blueprint('calibrate', __name__, url_prefix='/calibrate')
 
 # Total towers tried per run, including the currently-configured one — the
 # tower-finder already ranks by expected signal, so this is the best N.
-MAX_TOWERS = 5
+# Deliberately small: every tower costs a full descent (up to ~4.5 minutes on
+# a node that never overloads) plus its own dwell, and dwell is where success
+# actually comes from. Towers past the top-ranked one are speculative, so
+# trading tower count for dwell time is the right way round — a run that
+# searches five towers but dwells on none of them searches nothing at all.
+MAX_TOWERS = 3
 
 # AGC bandwidths that enable hardware AGC on the reference channel — the AGC
 # would fight the gain search, so calibration refuses to run with these set.

--- a/src/services.py
+++ b/src/services.py
@@ -1,0 +1,122 @@
+"""Process-wide configuration and shared service singletons.
+
+Everything here must exist exactly once per process. It lives in its own
+module for a specific reason: `app.py` is executed *twice*.
+
+systemd starts it as `python3 src/app.py`, so its module body runs under the
+name `__main__`. Route handlers then do `from app import calibrator` at
+request time, and because `__main__` and `app` are distinct entries in
+sys.modules, Python imports the same file a second time and runs the whole
+body again. Anything constructed at app.py's module level therefore exists
+twice, in one process.
+
+For stateless helpers that is merely wasteful. For anything owning a socket,
+a thread, or in-memory run state it is a bug, and one that bit hard:
+retina-tracker's sidecar accepts a single TCP connection at a time, so two
+RetinaTrackerClient instances meant two connections, one of which was
+accepted and served while the other sat unread in the kernel's backlog
+forever. Which instance won was a startup race. When the calibrator held the
+losing one, its detection frames and its tracker RESET went into a socket
+nobody was reading -- silently, because confirmed-track events arrive over a
+*file* tail that kept working, fed by tracker_capture's always-on capture.
+Auto-Calibrate appeared to work while its own feed reached nothing, and
+credited tracks it had never observed.
+
+Importing these from here fixes that: `services` is only ever reachable under
+one name, so it executes once no matter how many times app.py does. app.py
+re-exports the names, so `from app import ...` continues to work unchanged.
+"""
+
+import os
+
+from apply_service import ApplyService
+from blah2_client import Blah2Client
+from calibrator import Calibrator
+from config_manager import ConfigManager
+from device_state import DeviceState
+from mender import MenderClient
+from network_manager import NetworkManager
+from retina_tracker_client import RetinaTrackerClient
+from ssh_keys import SSHKeyManager
+from tracker_capture import TrackerCaptureService
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+DEV_MODE = os.environ.get('DEV_MODE', '').lower() in ('1', 'true', 'yes')
+
+# Configurable paths - override via environment for local dev.
+# In dev mode, default to a writable local directory instead of the on-device paths.
+DATA_DIR = os.environ.get('DATA_DIR',
+    os.path.join(PROJECT_ROOT, 'dev_data') if DEV_MODE else '/data/retina-gui'
+)
+USER_CONFIG_PATH = os.environ.get('USER_CONFIG_PATH',
+    os.path.join(PROJECT_ROOT, 'dev_data', 'user.yml') if DEV_MODE else '/data/retina-node/config/user.yml'
+)
+MERGED_CONFIG_PATH = os.environ.get('MERGED_CONFIG_PATH',
+    os.path.join(PROJECT_ROOT, 'dev_data', 'config.yml') if DEV_MODE else '/data/retina-node/config/config.yml'
+)
+RETINA_NODE_PATH = os.environ.get('RETINA_NODE_PATH', '/data/mender-docker-compose/current/manifests')
+RETINA_SPECTRUM_URL = os.environ.get('RETINA_SPECTRUM_URL', 'http://localhost:3020')
+NODE_ID_FILE = os.environ.get('NODE_ID_FILE', '/data/mender/node_id')
+TOWER_FINDER_URL = os.environ.get('TOWER_FINDER_URL', 'https://tower-finder.retina.fm')
+# blah2_api runs with network_mode: host and listens directly on this port —
+# NOT the :8080 blah2_host nginx proxy, which doesn't forward /capture/* at all.
+BLAH2_API_URL = os.environ.get('BLAH2_API_URL', 'http://localhost:3000')
+# retina-tracker sidecar (network_mode: host, see retina-node's docker-compose.yml)
+RETINA_TRACKER_HOST = os.environ.get('RETINA_TRACKER_HOST', 'localhost')
+RETINA_TRACKER_PORT = int(os.environ.get('RETINA_TRACKER_PORT', '30100'))
+# Path the sidecar streams JSONL track events to (-s flag, see its compose
+# command) — tailed rather than read over the TCP socket, since retina-tracker's
+# --tcp mode is input-only (see retina_tracker_client.py's module docstring).
+RETINA_TRACKER_EVENTS_PATH = os.environ.get('RETINA_TRACKER_EVENTS_PATH',
+    os.path.join(PROJECT_ROOT, 'dev_data', 'retina-tracker-events.jsonl') if DEV_MODE
+    else '/data/retina-node/retina-tracker/output/events.jsonl'
+)
+
+MENDER_SERVICES = ["mender-authd", "mender-updated", "mender-connect"]
+
+# ── Shared services ────────────────────────────────────────────
+
+ssh_keys = SSHKeyManager(os.path.join(DATA_DIR, "authorized_keys"))
+network_mgr = NetworkManager(dev_mode=DEV_MODE)
+
+config_mgr = ConfigManager(
+    user_config_path=USER_CONFIG_PATH,
+    merged_config_path=MERGED_CONFIG_PATH,
+    retina_node_path=RETINA_NODE_PATH,
+)
+
+mender = MenderClient(
+    server_url=os.environ.get('MENDER_SERVER_URL', 'https://hosted.mender.io'),
+    release_name=os.environ.get('MENDER_RELEASE_NAME', 'retina-node'),
+    device_type=os.environ.get('MENDER_DEVICE_TYPE', 'pi5-v3-arm64'),
+    dev_mode=DEV_MODE,
+    dev_data_dir=DATA_DIR,
+)
+
+device_state = DeviceState(
+    data_dir=DATA_DIR,
+    mender_services=MENDER_SERVICES,
+    mender_conf_path="/data/mender/mender.conf",
+    mender_conf_backup_dir="/data/mender-cloud-disabled",
+    mender_conf_backup_path="/data/mender-cloud-disabled/mender.conf",
+    dev_mode=DEV_MODE,
+)
+
+apply_service = ApplyService(RETINA_NODE_PATH, dev_mode=DEV_MODE)
+blah2_client = Blah2Client(BLAH2_API_URL)
+# One client per sidecar, shared by every feature that talks to it — its TCP
+# server accepts a single connection at a time, so a second instance does not
+# get a second conversation, it gets a socket nobody ever reads from.
+retina_tracker_client = RetinaTrackerClient(
+    RETINA_TRACKER_HOST, RETINA_TRACKER_PORT, RETINA_TRACKER_EVENTS_PATH)
+calibrator = Calibrator(blah2_client, retina_tracker_client)
+tracker_capture = TrackerCaptureService(blah2_client, retina_tracker_client)
+
+
+def _on_calibration_complete(status):
+    """Runs on the calibration thread when a run reaches a terminal state."""
+    device_state.release_calibration_lock()
+
+
+calibrator.on_complete = _on_calibration_complete

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,6 +236,13 @@ def app_client(temp_dir, config_files, test_manifests_dir):
 
     # Import app after setting env vars (reload to pick up new paths)
     import importlib
+    # services.py holds the env-derived config and the shared singletons (it
+    # exists because app.py's module body runs twice in production — see its
+    # docstring). It must be reloaded first: reloading app alone would leave
+    # the singletons bound to whatever paths were read at first import,
+    # ignoring the env vars this fixture just set.
+    import services as services_module
+    importlib.reload(services_module)
     import app as app_module
     importlib.reload(app_module)
 
@@ -267,6 +274,13 @@ def app_client_no_retina(temp_dir, config_files):
     os.environ['NODE_ID_FILE'] = node_id_file
 
     import importlib
+    # services.py holds the env-derived config and the shared singletons (it
+    # exists because app.py's module body runs twice in production — see its
+    # docstring). It must be reloaded first: reloading app alone would leave
+    # the singletons bound to whatever paths were read at first import,
+    # ignoring the env vars this fixture just set.
+    import services as services_module
+    importlib.reload(services_module)
     import app as app_module
     importlib.reload(app_module)
 
@@ -291,6 +305,13 @@ def app_client_no_node_id(temp_dir, config_files_no_node_id, test_manifests_dir)
     os.environ['NODE_ID_FILE'] = node_id_file
 
     import importlib
+    # services.py holds the env-derived config and the shared singletons (it
+    # exists because app.py's module body runs twice in production — see its
+    # docstring). It must be reloaded first: reloading app alone would leave
+    # the singletons bound to whatever paths were read at first import,
+    # ignoring the env vars this fixture just set.
+    import services as services_module
+    importlib.reload(services_module)
     import app as app_module
     importlib.reload(app_module)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,47 @@ import yaml
 from unittest.mock import patch, MagicMock
 
 
+class TestSharedServiceSingletons:
+    """Anything owning a socket, a thread or in-memory run state must exist
+    exactly once per process.
+
+    app.py's module body executes twice: systemd runs it as `__main__`
+    (`python3 src/app.py`), and the first time a route does
+    `from app import ...` Python imports the same file again under the name
+    `app`. Anything constructed at app.py's module level therefore exists
+    twice in a single process.
+
+    That was not academic. retina-tracker's sidecar accepts one TCP
+    connection at a time, so two RetinaTrackerClient instances produced two
+    connections, one served and one left unread in the kernel backlog
+    forever. Which one won was a startup race, and when the calibrator held
+    the loser its detection frames and tracker RESET went nowhere — silently,
+    since confirmed-track events arrive over a file tail that kept working on
+    tracker_capture's feed. Auto-Calibrate looked healthy while its own feed
+    reached nothing.
+
+    Constructing them in services.py fixes it, because that module is only
+    reachable under one name. These assertions fail if one migrates back.
+    """
+
+    def test_services_are_shared_not_reconstructed_by_app(self):
+        import app
+        import services
+
+        for name in ("retina_tracker_client", "calibrator", "tracker_capture",
+                     "blah2_client", "apply_service", "device_state",
+                     "config_mgr"):
+            assert getattr(app, name) is getattr(services, name), (
+                f"app.{name} is a second instance — it must be imported from "
+                "services, not constructed in app.py, which runs twice")
+
+    def test_calibrator_and_tracker_capture_share_one_sidecar_client(self):
+        import services
+
+        assert services.calibrator._tracker_client is services.retina_tracker_client
+        assert services.tracker_capture._tracker_client is services.retina_tracker_client
+
+
 class TestIndexRoute:
     """Test the home page (/)."""
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -43,13 +43,25 @@ class FakeBlah2Client:
     """
 
     def __init__(self, overload_rule=None, detection=None, adsb_tracks=None,
-                 retune_fail_rule=None, overload_status_fail_rule=None):
+                 retune_fail_rule=None, overload_status_fail_rule=None,
+                 transient_overload=False):
         self.clock_ms = 1000
         self.generation = 0
         self.applied = []
         self.retune_error = None
         self.ack_enabled = True
         self.rf_enabled = True
+        # Monotonic onset counts, mirroring blah2's own. Real overload is an
+        # event stream, not a stable property of the tuning: the device clips
+        # and recovers faster than anything polls it.
+        self.overload_counts = [0, 0]
+        self._last_overload = (False, False)
+        # When set, an overload episode is over before anyone can observe it:
+        # the reported *level* stays False while the counts still rise. This
+        # is what real hardware does (measured: 9 detect/correct cycles in 90s
+        # with every level sample reading false), and modelling it is what
+        # makes a level-watching consumer fail these tests as it should.
+        self.transient_overload = transient_overload
         self.overload_rule = overload_rule or (lambda fc, ga, gb, lna: (False, False))
         self.detection = detection or (lambda client: None)
         self.adsb_tracks = adsb_tracks or (lambda client: None)
@@ -99,8 +111,22 @@ class FakeBlah2Client:
             return None
         overload_a, overload_b = self.overload_rule(
             cur["fc"], cur["gain_a"], cur["gain_b"], cur["lna_state"])
+        # Count onsets, exactly as blah2's driver callback does.
+        if overload_a and not self._last_overload[0]:
+            self.overload_counts[0] += 1
+        if overload_b and not self._last_overload[1]:
+            self.overload_counts[1] += 1
+        self._last_overload = (overload_a, overload_b)
+        if self.transient_overload:
+            # Episode already over by the time anyone looks — counts rose,
+            # level reads clean. A consumer that only samples the level sees
+            # nothing at all here.
+            self._last_overload = (False, False)
+            overload_a = overload_b = False
         return {"overloadA": overload_a, "overloadB": overload_b,
-                "timestamp": self._now()}
+                "timestamp": self._now(),
+                "overloadCountA": self.overload_counts[0],
+                "overloadCountB": self.overload_counts[1]}
 
     def get_detection(self):
         return self.detection(self)
@@ -162,6 +188,7 @@ class FakeRetinaTrackerClient:
 ORIGINAL = {"fc": 98_000_000, "gain_a": 40, "gain_b": 41, "lna_state": 4}
 TOWER = {"name": "Tower One", "fc": 98_000_000}
 TOWER_TWO = {"name": "Tower Two", "fc": 105_100_000}
+TOWER_THREE = {"name": "Tower Three", "fc": 213_000_000}
 
 
 def moving_track_detections(delay=10.0, doppler=50.0, snr=15.0, step_ms=500):
@@ -709,6 +736,83 @@ class TestMultiTower:
             assert entry["outcome"] == "no_confirmed_track"
             assert entry.get("dwell_seconds", 0) > 0
 
+    def test_long_descent_no_longer_starves_its_own_dwell(self, fast, monkeypatch):
+        """Descent and dwell are budgeted separately, so a descent long
+        enough to have exhausted a shared per-tower allowance still leaves
+        the tower an actual dwell.
+
+        Regression: descent and dwell used to share one per-tower deadline
+        (remaining budget / remaining towers). On any node whose descent
+        walks more than a few LNA states that deadline expired mid-descent,
+        so every tower came back 'skipped_no_time' and a whole run could be
+        spent retuning without ever watching for an aircraft once. Measured
+        on real hardware: ~148s of descent against a 120s per-tower share.
+        """
+        # A clean node is the expensive case: nothing ever overloads, so the
+        # descent walks the entire LNA ladder (9 states, both tuners each).
+        monkeypatch.setattr(calmod, "OVERLOAD_SETTLE_SECONDS", 0.02)
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        started, error = cal.start([TOWER, TOWER_TWO], ORIGINAL, budget_seconds=6.0)
+        assert started, error
+        cal._thread.join(timeout=20)
+        status = cal.get_status()
+
+        first = status["history"][0]
+        # Descent ran to its natural end rather than being cut off...
+        assert first["final_lna_state"] == LNA_STATE_MIN
+        assert any(e.get("lna_state") == LNA_STATE_MIN for e in first["descent"])
+        # ...and the dwell it used to starve actually happened.
+        assert first["outcome"] == "no_confirmed_track"
+        assert first.get("dwell_seconds", 0) > 0
+
+    def test_every_tower_is_watched_even_when_every_descent_is_slow(self, fast, monkeypatch):
+        """The guarantee MAX_DESCENT_FRACTION buys: no tower is ever tuned
+        and then not looked at.
+
+        Budgeting descent and dwell separately is not sufficient on its own
+        — descents long enough to each hit their own ceiling would still
+        consume the whole run between them. Capping descent at a fraction
+        of each tower's slice is what makes a dwell unconditional.
+        """
+        monkeypatch.setattr(calmod, "OVERLOAD_SETTLE_SECONDS", 0.02)
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        # Deliberately tight: a full clean descent wants more than any one
+        # tower's slice here, so every tower's descent gets cut short.
+        started, error = cal.start([TOWER, TOWER_TWO, TOWER_THREE], ORIGINAL,
+                                   budget_seconds=3.0)
+        assert started, error
+        cal._thread.join(timeout=20)
+        status = cal.get_status()
+
+        assert len(status["history"]) == 3
+        for entry in status["history"]:
+            assert entry["outcome"] == "no_confirmed_track", (
+                f"{entry['tower_name']} was tuned but never watched")
+            assert entry.get("dwell_seconds", 0) > 0
+
+    def test_descent_backstop_bounds_descent_without_killing_dwell(self, fast, monkeypatch):
+        """The descent ceiling exists to contain a wedged device, not to
+        ration dwell: hitting it truncates the search but the tower is
+        still watched, because the dwell window is derived afterwards from
+        the run budget that remains."""
+        monkeypatch.setattr(calmod, "OVERLOAD_SETTLE_SECONDS", 0.02)
+        monkeypatch.setattr(calmod, "DESCENT_BACKSTOP_SECONDS", 0.05)
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        started, error = cal.start([TOWER], ORIGINAL, budget_seconds=5.0)
+        assert started, error
+        cal._thread.join(timeout=20)
+        status = cal.get_status()
+
+        entry = status["history"][0]
+        # Truncated well before the ladder's end...
+        assert entry["final_lna_state"] > LNA_STATE_MIN
+        # ...yet still dwelt, on budget the descent never got to consume.
+        assert entry["outcome"] == "no_confirmed_track"
+        assert entry.get("dwell_seconds", 0) > 0
+
     def test_slow_descent_yields_honest_skipped_outcome(self, fast):
         """If a tower's own descent consumes its whole share of the budget,
         it must be marked as never actually watched — not as a false
@@ -723,6 +827,228 @@ class TestMultiTower:
         status = cal.get_status()
         assert status["state"] == "failed"
         assert any(e["outcome"] == "skipped_no_time" for e in status["history"])
+
+
+class TestTuningVerifiedBeforeDwell:
+    """A dwell must never run against tuning the device did not take.
+
+    Regression: when a candidate's retune failed, _probe returned the
+    *previous* candidate's applied_at, so the dwell's freshness guard still
+    passed for detections produced by the old tuning. The dwell looked
+    healthy while measuring a different frequency and reported the answer
+    against the tower it thought it was on. Observed live: minutes of dwell
+    labelled WWLP/201MHz while blah2 was still tuned to 545MHz.
+    """
+
+    def test_tower_whose_retune_never_applied_is_not_dwelt_on(self, fast):
+        # blah2 refuses this tower's frequency outright, so nothing the
+        # descent asks for is ever actually applied there.
+        client = FakeBlah2Client(
+            retune_fail_rule=lambda fc, ga, gb, lna: fc == TOWER_TWO["fc"])
+        tracker_client = FakeRetinaTrackerClient(confirm_after=1)
+        cal = Calibrator(client, tracker_client)
+        status = run_to_completion(cal, [TOWER, TOWER_TWO], dwell=0.3)
+
+        second = status["history"][1]
+        assert second["outcome"] == "tuning_not_applied", (
+            f"dwelt on tuning that was never applied: {second}")
+        assert "tuning_error" in second
+        assert second.get("dwell_seconds") is None, "should not have dwelt at all"
+
+    def test_verified_tuning_still_dwells_normally(self, fast):
+        client = FakeBlah2Client(detection=moving_track_detections())
+        cal = Calibrator(client, FakeRetinaTrackerClient(confirm_after=1))
+        status = run_to_completion(cal, [TOWER], dwell=1.0)
+        assert status["state"] == "done"
+        assert status["history"][0]["outcome"] == "confirmed_track"
+
+
+class TestDwellOverloadBackoff:
+    """Descent takes one overload sample per candidate, which cannot tell a
+    clean operating point from one that clips intermittently. The dwell is
+    the long phase, so an unstable point accepted by descent is sat on for
+    minutes — observed live degrading the SDRplay API until every later
+    retune in the run failed. The dwell therefore keeps watching."""
+
+    def test_overload_during_dwell_retreats_toward_safety(self, fast, monkeypatch):
+        monkeypatch.setattr(calmod, "DWELL_OVERLOAD_CHECK_SECONDS", 0.02)
+        # Clean while descending, but the resolved point clips once dwelling.
+        state = {"dwelling": False}
+
+        def overload_rule(fc, ga, gb, lna):
+            return (state["dwelling"] and gb < GAIN_REDUCTION_MAX, False)
+
+        client = FakeBlah2Client(overload_rule=overload_rule)
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        original_dwell = cal._dwell
+
+        def dwell(*a, **kw):
+            state["dwelling"] = True
+            return original_dwell(*a, **kw)
+
+        cal._dwell = dwell
+        status = run_to_completion(cal, [TOWER], dwell=2.0)
+
+        entry = status["history"][0]
+        backoffs = entry.get("dwell_backoffs") or []
+        assert backoffs, "overload during dwell was not acted on"
+        first = backoffs[0]
+        # Retreat must move toward *more* attenuation, never less.
+        assert (first["to"]["gain_a"] >= first["from"]["gain_a"]
+                or first["to"]["lna_state"] > first["from"]["lna_state"])
+
+    def test_persistent_dwell_overload_gives_up_on_the_tower(self, fast, monkeypatch):
+        monkeypatch.setattr(calmod, "DWELL_OVERLOAD_CHECK_SECONDS", 0.02)
+        state = {"dwelling": False}
+        # Overloads at every setting once dwelling — no retreat can help.
+        client = FakeBlah2Client(
+            overload_rule=lambda fc, ga, gb, lna: (state["dwelling"], False))
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        original_dwell = cal._dwell
+
+        def dwell(*a, **kw):
+            state["dwelling"] = True
+            return original_dwell(*a, **kw)
+
+        cal._dwell = dwell
+        status = run_to_completion(cal, [TOWER], dwell=3.0)
+
+        entry = status["history"][0]
+        assert entry["outcome"] == "unstable_overload"
+        assert len(entry.get("dwell_backoffs") or []) == calmod.MAX_DWELL_BACKOFFS
+
+    def test_transient_overload_is_caught_even_though_the_level_reads_clean(
+            self, fast, monkeypatch):
+        """The case that matters, and the one a level-watching dwell misses.
+
+        Real overload episodes end faster than anyone polls: measured on a
+        live node, 9 detect/correct cycles inside 90s with every sample of
+        the level reading false throughout. A dwell that samples the flags
+        therefore sat on a visibly unstable operating point and never once
+        noticed. Comparing blah2's monotonic onset counts cannot miss an
+        episode regardless of poll rate.
+        """
+        monkeypatch.setattr(calmod, "DWELL_OVERLOAD_CHECK_SECONDS", 0.02)
+        state = {"dwelling": False}
+        client = FakeBlah2Client(
+            overload_rule=lambda fc, ga, gb, lna: (state["dwelling"], False),
+            transient_overload=True)
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        original_dwell = cal._dwell
+
+        def dwell(*a, **kw):
+            state["dwelling"] = True
+            return original_dwell(*a, **kw)
+
+        cal._dwell = dwell
+        status = run_to_completion(cal, [TOWER], dwell=2.0)
+
+        entry = status["history"][0]
+        # The level never reads True, so this only passes by counting.
+        assert entry.get("dwell_backoffs"), (
+            "transient overload went unnoticed - the dwell is watching the "
+            "level instead of the onset counts")
+
+    def test_stable_dwell_never_backs_off(self, fast, monkeypatch):
+        monkeypatch.setattr(calmod, "DWELL_OVERLOAD_CHECK_SECONDS", 0.02)
+        client = FakeBlah2Client()  # never overloads
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        status = run_to_completion(cal, [TOWER], dwell=1.0)
+        entry = status["history"][0]
+        assert entry["outcome"] == "no_confirmed_track"
+        assert not entry.get("dwell_backoffs")
+
+
+class TestSafeFrequencyHandover:
+    """blah2's driver applies fc before gain within one retune, so moving to
+    a new tower directly from a sensitive operating point parks the front end
+    on the new frequency at the old tower's gain. Verified on real hardware:
+    213 MHz at (59,59,lna 9) is clean from a safe state and saturates from
+    (49,20,lna 1) at 201 MHz — same destination, different origin. Every fc
+    change must therefore hand over via the safe corner first.
+    """
+
+    def test_frequency_change_is_preceded_by_the_safe_corner(self, fast):
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        run_to_completion(cal, [TOWER, TOWER_TWO], dwell=0.05)
+
+        # Every retune that changed fc must be immediately preceded by one
+        # at the previous fc sitting at the safe corner.
+        applied = client.applied
+        changes = [i for i in range(1, len(applied))
+                   if applied[i]["fc"] != applied[i - 1]["fc"]]
+        assert changes, "expected at least one frequency change"
+        for i in changes:
+            previous = applied[i - 1]
+            assert (previous["gain_a"], previous["gain_b"], previous["lna_state"]) == (
+                GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX, LNA_STATE_MAX), (
+                f"fc changed to {applied[i]['fc']} from an unsafe tuning: {previous}")
+
+    def test_handover_happens_when_the_device_has_drifted_from_config(self, fast):
+        """The handover must key off where the radio actually is, not where
+        config says it is.
+
+        Regression, seen live and it wedged the radio: a previous run had
+        found a track at 213MHz and was never persisted, so config.yml still
+        said 545MHz while blah2 sat on 213MHz at a sensitive gain. Seeding
+        from config made the calibrator believe it was already on the first
+        tower's frequency, so it saw no change, skipped the handover, and
+        moved fc into a strong local tower at that gain. Every retune after
+        that failed and the run died in 42s.
+        """
+        client = FakeBlah2Client()
+        # The radio is genuinely somewhere else — as after an unpersisted run.
+        client.retune(TOWER_TWO["fc"], 59, 44, 5)
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        drifted = len(client.applied)
+
+        # `original` reports the *config* frequency, which equals the first
+        # tower's — so a config-seeded handover would think nothing changed.
+        run_to_completion(cal, [TOWER], original=ORIGINAL, dwell=0.1)
+
+        first = client.applied[drifted]
+        assert first["fc"] == TOWER_TWO["fc"], (
+            "first retune should be the safe-corner handover at the "
+            f"device's real fc, got {first}")
+        assert (first["gain_a"], first["gain_b"], first["lna_state"]) == (
+            GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX, LNA_STATE_MAX), (
+            f"handover must be at the safe corner, got {first}")
+
+    def test_gain_only_steps_do_not_add_a_handover(self, fast):
+        """The handover is for frequency changes only — a descent's own
+        gain steps share one fc and must not pay for an extra retune each."""
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        run_to_completion(cal, [TOWER], dwell=0.05)
+
+        applied = client.applied
+        safe_corner = (GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX, LNA_STATE_MAX)
+        # Only the descent's own legitimate visits to the safe corner should
+        # appear — no consecutive duplicate pair from a spurious handover.
+        for i in range(1, len(applied)):
+            a, b = applied[i - 1], applied[i]
+            if a["fc"] == b["fc"]:
+                assert not (
+                    (a["gain_a"], a["gain_b"], a["lna_state"]) == safe_corner
+                    and (b["gain_a"], b["gain_b"], b["lna_state"]) == safe_corner), (
+                    f"redundant safe-corner retune at unchanged fc: {a} -> {b}")
+
+    def test_handover_failure_does_not_abort_the_run(self, fast):
+        """A device that won't even take the handover is not a fatal
+        condition — the caller's own retune surfaces it through the normal
+        per-candidate path instead."""
+        # Fail only the safe-corner retune at the first tower's frequency.
+        def fail_handover(fc, ga, gb, lna):
+            return (fc == TOWER["fc"] and (ga, gb, lna)
+                    == (GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX, LNA_STATE_MAX))
+
+        client = FakeBlah2Client(retune_fail_rule=fail_handover)
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        status = run_to_completion(cal, [TOWER, TOWER_TWO], dwell=0.05)
+        # The run still reached a terminal state rather than erroring out.
+        assert status["state"] in ("failed", "done")
+        assert len(status["history"]) == 2
 
 
 class TestNoTrackFallback:
@@ -756,17 +1082,51 @@ class TestNoTrackFallback:
 
 class TestTrackerSidecarIntegration:
     """Directly exercises the shared-sidecar-specific mechanics that don't
-    have another natural home: per-tower reset and the staleness guard on
+    have another natural home: per-dwell reset and the staleness guard on
     confirmed events (see calibrator.py's _take_confirmed_event)."""
 
-    def test_resets_tracker_before_each_towers_search(self, fast):
+    def test_resets_tracker_at_the_start_of_every_dwell(self, fast):
         client = FakeBlah2Client()
         tracker_client = FakeRetinaTrackerClient()
         cal = Calibrator(client, tracker_client)
-        started, error = cal.start([TOWER, TOWER_TWO], ORIGINAL, budget_seconds=0.05)
-        assert started, error
-        cal._thread.join(timeout=10)
+        run_to_completion(cal, [TOWER, TOWER_TWO], dwell=0.2)
+        # One per dwell — the scope that matters, since the sidecar is fed by
+        # tracker_capture throughout the descent too (see _reset_tracker).
         assert tracker_client.reset_calls == 2
+
+    def test_confirmation_waiting_before_the_dwell_is_not_credited(self, fast):
+        """The regression: a track confirmed from tracker_capture's always-on
+        feed *during the descent* must not be handed to the dwell as though
+        the dwell had observed it.
+
+        Reset used to be per-tower, so anything the sidecar accumulated over
+        the whole descent — 150s on a live node — was still there when the
+        dwell started. Seen live as a confirmed track with dwell_seconds 0.0,
+        credited to a tuning it had observed nothing at. The applied_at guard
+        does not catch it: the event's timestamp legitimately post-dates the
+        retune.
+        """
+        client = FakeBlah2Client()
+        # Never confirms from this dwell's own frames, so a success here
+        # could only have come from the pre-planted event below.
+        tracker_client = FakeRetinaTrackerClient()
+        cal = Calibrator(client, tracker_client)
+        original_dwell = cal._dwell
+
+        def dwell(*args, **kwargs):
+            # Stand in for the descent-time confirmation: recent enough to
+            # clear applied_at, but earned before this dwell watched anything.
+            cal._on_track_event({"track_id": "earned-during-descent",
+                                 "timestamp": 10 ** 13})
+            return original_dwell(*args, **kwargs)
+
+        cal._dwell = dwell
+        status = run_to_completion(cal, [TOWER], dwell=0.3)
+
+        assert status["state"] != "done", (
+            "credited a track the dwell never observed - the tracker is not "
+            "being reset at dwell start")
+        assert status["history"][0]["outcome"] == "no_confirmed_track"
 
     def test_stale_confirmed_event_before_applied_at_is_ignored(self):
         # A confirmed event generated before this candidate's applied_at —


### PR DESCRIPTION
Auto-Calibrate could spend an entire run retuning without once watching for an aircraft, and could report results it had not measured. Everything here is correctness in the search engine — the route guards and the reporting UI are deliberately left for a follow-up.

Found and verified against real hardware on `jonathan-node-2`.

## Descent and dwell no longer share one deadline

A tower's slice was spent on whichever came first, so a descent long enough to exhaust it left **zero dwell** and returned `skipped_no_time`. On any node whose descent walks more than a few LNA states that happened on *every* tower — measured here at ~148s of descent against a 120s slice — so a whole run searched nothing.

Descent is now capped at `MAX_DESCENT_FRACTION` of the slice with the remainder reserved, making a dwell unconditional. Budget 600→900s and `MAX_TOWERS` 5→3: towers past the top-ranked one are speculative, dwell time is where success comes from, and a run that searches five towers but dwells on none searches nothing at all.

## Frequency changes hand over via the safe corner

blah2's driver applies fc before gain within one retune, so moving to a new tower from a sensitive operating point parks the front end on the new frequency at the *old* one's gain — and it returns early on that failure, so the attenuation being asked for never executes.

The frequency it hands over *from* is read from the device, not from config. The two diverge whenever a run's result is not persisted, and trusting config there skips the handover in exactly the case where the radio has drifted furthest from it. That was not hypothetical — it wedged the radio in testing and every retune in that run failed.

## A dwell no longer runs against tuning the device did not take

The resolved tuning is checked against blah2's last acknowledged retune; on a mismatch the tower reports the new **`tuning_not_applied`** outcome and is skipped. The dwell's freshness guard uses the verified `appliedAt` rather than descent's, which could be a previous candidate's — which is how a dwell could look healthy while measuring a different frequency.

## A dwell watches for overload

Rather than trusting descent's single sample, it retreats toward safety up to `MAX_DWELL_BACKOFFS` times before giving up with the new **`unstable_overload`** outcome. Detection needs *both* blah2's onset counts and the level: counts alone miss overload already in progress when the dwell began, the level alone misses episodes that start and end between polls.

## The sidecar tracker resets per dwell, not per tower

Per-tower was justified on the reasoning that any confirmed track ends the search — which assumed this calibration is the sidecar's only source. It is not; `tracker_capture` feeds it throughout the descent too. Seen live as a confirmed track with `dwell_seconds 0.0`, credited to a tuning it had observed nothing at.

## Shared services move to `services.py`

`app.py`'s body runs twice — as `__main__` under systemd, and as `app` when a route first imports it — so it was building two `RetinaTrackerClient`s. The sidecar accepts one connection at a time, so the second sat unread in the kernel backlog forever, and which one the calibrator held was a startup race. When it lost, its frames and tracker resets went nowhere — silently, because events arrive over a file tail that kept working.

## Verification

A full 3-tower run on `jonathan-node-2`:
- **All three towers dwelt** — 450s of 900s watching, zero `skipped_no_time`
- Confirmed a **real ADS-B-matched aircraft** (`adsb_hex ab3c0a`, 19 detections, SNR 7.5–22.9) during a **53.8s dwell**, which `/calibrate/apply` then persisted end-to-end
- The dwell backoff fired on a real oscillation the level could not see, and the retreat held
- One connection to the sidecar; resets only at dwell start

**451 passed / 7 pre-existing failures** (dev-tag mender, tower-search).

## Companion

Requires blah2-arm#54 for the rejection signal and onset counts. Degrades gracefully without it — the counters are optional and the code falls back to the level.

## Deliberately out of scope

`/config/apply` and `/towers/select` still lack a calibration guard (demonstrated live restarting containers mid-run), and the modal does not surface any of the diagnostic outcomes — including the two added here. Both are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)