### PR TITLE
20260804 - Hold the user with a running calibration, and say what actually failed

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, redirect, request
 from flask_wtf.csrf import CSRFProtect
 import os
 import subprocess
@@ -140,6 +140,51 @@ app.register_blueprint(mode_bp)
 app.register_blueprint(network_bp)
 app.register_blueprint(calibrate_bp)
 app.register_blueprint(tracker_preview_bp)
+
+
+# Paths that must keep working while a run holds the GUI: the config page
+# itself, its assets, and the endpoints its modal polls to show progress and
+# to cancel. Everything else is a navigation away from a run the user cannot
+# see from anywhere else.
+_CALIBRATION_ALLOWED_PREFIXES = (
+    '/config',        # the page, plus /config/apply/status and /config/rf-status
+    '/calibrate',     # status, cancel, apply
+    '/static',
+    '/favicon',
+)
+
+
+@app.before_request
+def _keep_the_user_with_the_running_calibration():
+    """While Auto-Calibrate is running, hold the browser on the config page.
+
+    A run owns the SDR for up to 15 minutes and blocks every config change
+    for its duration, but it is only visible in one place — the modal on
+    /config. Navigating away used to leave it running invisibly, with no way
+    to cancel it short of waiting out the budget or restarting the GUI.
+    Rather than let someone strand a run they cannot see, send them back to
+    the one page that can show and stop it.
+
+    Deliberately keyed on is_running() alone, never the lock file. The lock
+    survives a GUI crash by design, and a stale one here would lock the user
+    out of the entire interface with no way to reach the button that clears
+    it. is_running() is in-memory, so a restart always frees the GUI.
+
+    Only GETs are redirected. POSTs to other routes already refuse with a
+    409 and an explanation, which is more useful to a caller than a redirect
+    to an HTML page.
+    """
+    if request.method != 'GET':
+        return None
+    if request.path.startswith(_CALIBRATION_ALLOWED_PREFIXES):
+        return None
+    # The setup wizard redirects /config back to itself, so locking during
+    # the wizard would bounce the browser between the two forever.
+    if device_state.is_setup_wizard_in_progress():
+        return None
+    if calibrator.is_running():
+        return redirect('/config')
+    return None
 
 
 if __name__ == "__main__":

--- a/src/apply_service.py
+++ b/src/apply_service.py
@@ -37,6 +37,31 @@ path never queues work against itself.
 import threading
 from datetime import datetime, timezone
 
+
+class ConfigChangeRefused(Exception):
+    """Raised by request() when something is using the SDR that an apply
+    would pull out from under it.
+
+    The check lives here, not in the routes, because routes are exactly what
+    gets forgotten. /api/mode and /mender/install each grew their own
+    calibration guard, but /config/apply and /towers/select — added later —
+    did not, and nothing caught it. Demonstrated on a live node: clicking
+    Apply Changes during an Auto-Calibrate run recreated all seven
+    containers underneath it, after which every retune failed and the run
+    carried on to report an ordinary-looking "no confirmed track". Both of
+    those buttons sit on the same page as the Auto-Calibrate one.
+
+    Every path that restarts the stack for a config change funnels through
+    request(), so guarding it covers the routes that exist and the ones that
+    do not yet. Raising rather than returning a refusal is deliberate: a
+    caller that forgets to handle this gets a 500, not a silent 202 that
+    claims work was queued when it was not.
+    """
+
+    def __init__(self, reason):
+        super().__init__(reason)
+        self.reason = reason
+
 PHASE_LABELS = {
     'waiting_for_lock': 'Waiting for another restart to finish',
     'merging': 'Merging configuration',
@@ -55,9 +80,14 @@ def _utcnow():
 class ApplyService:
     """One-at-a-time config apply with progress and request coalescing."""
 
-    def __init__(self, retina_node_path, dev_mode=False, restart_fn=None):
+    def __init__(self, retina_node_path, dev_mode=False, restart_fn=None,
+                 guard=None):
         self._retina_node_path = retina_node_path
         self._dev_mode = dev_mode
+        # Optional callable returning (ok, reason). Checked by request()
+        # before any work starts — see ConfigChangeRefused for why the check
+        # belongs here rather than in each route.
+        self._guard = guard
         # Injected collaborator, same idiom as Calibrator's clients: tests
         # pass a fake instead of monkeypatching routes.mode, which conftest's
         # importlib.reload(app) would swap out from under them anyway.
@@ -94,9 +124,15 @@ class ApplyService:
     def request(self):
         """Start an apply, or coalesce into the one already running.
 
-        Returns the current status dict. Never raises, never blocks on the
-        actual work.
+        Returns the current status dict. Never blocks on the actual work.
+        Raises ConfigChangeRefused if the configured guard says something
+        else is using the SDR right now.
         """
+        if self._guard is not None:
+            ok, reason = self._guard()
+            if not ok:
+                raise ConfigChangeRefused(reason)
+
         if self._dev_mode:
             with self._lock:
                 self._status = self._idle_status()

--- a/src/calibrator.py
+++ b/src/calibrator.py
@@ -740,6 +740,11 @@ class Calibrator:
 
         Returns (gain_a, applied_at_ms, still_overloaded).
         """
+        # Reset the phase on entry: the surveillance stage below sets it to
+        # "refining", and the LNA loop re-enters both stages many times per
+        # tower, so without this the UI reports "Refining gain" for most of a
+        # descent that is in fact walking the whole ladder again.
+        self._update(phase="descending")
         gain_a = GAIN_REDUCTION_MAX
         clean_gain_a = None
         applied_at, overload_a, _, device_error = self._probe(
@@ -790,6 +795,7 @@ class Calibrator:
 
         Returns (gain_b, applied_at_ms, still_overloaded).
         """
+        self._update(phase="descending")
         gain_b = GAIN_REDUCTION_MAX
         clean_gain_b = None
         reverted = False

--- a/src/routes/calibrate.py
+++ b/src/routes/calibrate.py
@@ -84,7 +84,7 @@ def _fetch_alternate_towers(merged, current_fc, limit):
 @bp.route("/start", methods=["POST"])
 def start():
     """Start an auto-calibration run against the live radar."""
-    from app import calibrator, config_mgr, device_state
+    from app import apply_service, calibrator, config_mgr, device_state
     from routes.mode import get_current_mode
 
     if not config_mgr.is_retina_node_installed():
@@ -96,6 +96,19 @@ def start():
     ok, reason = device_state.can_start_calibration()
     if not ok:
         return jsonify({"success": False, "error": reason}), 409
+
+    # The refusal has to run both ways. ApplyService stops a config apply
+    # starting during a run; this stops a run starting during an apply, which
+    # nothing covered — can_start_calibration() knows about Mender installs
+    # but not about the ~45s stack restart an apply performs. Hit by accident
+    # while testing: Apply Changes, then Auto-Calibrate a few seconds later,
+    # and every retune failed against restarting containers. All three towers
+    # came back tuning_not_applied, which is honest but is a whole run wasted
+    # on something that could simply have been refused.
+    if apply_service.is_running():
+        return jsonify({"success": False,
+                        "error": "A configuration change is still being applied. "
+                                 "Wait for it to finish before calibrating"}), 409
 
     merged = config_mgr.load_merged_config()
     capture = merged.get('capture', {}) or {}
@@ -160,8 +173,28 @@ def start():
 
 @bp.route("/status", methods=["GET"])
 def status():
-    from app import calibrator
-    return jsonify(calibrator.get_status())
+    from app import calibrator, device_state
+
+    payload = calibrator.get_status()
+
+    # A Mender deployment pushed from the server installs autonomously —
+    # mender-updated polls on its own and retina-gui is never consulted, so
+    # unlike /mender/install there is no guard that can refuse it. It
+    # replaces the containers underneath a run, after which every retune
+    # fails; the run then reports tuning_not_applied and gets abandoned for
+    # no reason the user can see. Annotating the status the modal already
+    # polls turns that from a mystery into an explanation. Cheap enough to
+    # do on every poll: it is a file-exists check plus a small JSON read.
+    #
+    # Deliberately reported rather than prevented. Blocking deployments
+    # would mean publishing Mender Update Control maps, and a map left
+    # behind by a crashed GUI would stall the fleet's updates - a worse
+    # failure than the one being avoided. Judged an accepted risk: the
+    # overlap window is narrow and the run already fails safely.
+    in_progress, reason = device_state.is_any_update_in_progress()
+    payload["system_update"] = reason if in_progress else None
+
+    return jsonify(payload)
 
 
 @bp.route("/cancel", methods=["POST"])

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -6,6 +6,7 @@ from config_schema import (
     CaptureFormConfig, LocationFormConfig, RetinaTrackerConfig,
 )
 from form_utils import schema_to_form_fields
+from apply_service import ConfigChangeRefused
 
 bp = Blueprint('config', __name__)
 
@@ -89,6 +90,16 @@ def save_config():
     capture_flat, location_flat, truth_data, tar1090_data, retina_tracker_data = ConfigManager.parse_flat_form_data(request.form.to_dict())
 
     all_errors = {}
+
+    # Refuse the save itself, not just the apply that follows it. The form
+    # posts here and the page then auto-POSTs /config/apply, so guarding only
+    # the apply would leave the user with changes written to user.yml that
+    # were never applied — and silently swept into the next merge, including
+    # the one /calibrate/apply performs on a successful run.
+    from app import calibrator, device_state as _device_state
+    if calibrator.is_running() or _device_state.is_calibration_locked()[0]:
+        all_errors['_form'] = ("Auto-calibration is running. Cancel it before "
+                               "changing configuration.")
 
     if capture_flat:
         try:
@@ -215,7 +226,13 @@ def apply_config():
         return jsonify({"success": False,
                         "error": f"{reason}. Apply your changes once it finishes."}), 409
 
-    return jsonify({"success": True, "status": apply_service.request()}), 202
+    # An in-flight calibration is refused inside request() rather than here,
+    # so no future route can reintroduce the gap this one had — see
+    # ApplyService.ConfigChangeRefused.
+    try:
+        return jsonify({"success": True, "status": apply_service.request()}), 202
+    except ConfigChangeRefused as refused:
+        return jsonify({"success": False, "error": refused.reason}), 409
 
 
 @bp.route("/config/apply/status", methods=["GET"])

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -4,6 +4,7 @@ import requests as http_requests
 from pydantic import ValidationError
 from config_schema import LocationFormConfig
 from config_manager import ConfigManager
+from apply_service import ConfigChangeRefused
 
 bp = Blueprint('towers', __name__, url_prefix='/towers')
 
@@ -236,4 +237,10 @@ def select():
     # for minutes when it lands behind another restart. Poll
     # /config/apply/status for progress; the queue always merges whatever is
     # in user.yml when it runs, so it necessarily picks up the write above.
-    return jsonify({"success": True, "status": apply_service.request()}), 202
+    # A calibration in flight is refused inside request() — see
+    # ApplyService.ConfigChangeRefused for why that check is not repeated
+    # here.
+    try:
+        return jsonify({"success": True, "status": apply_service.request()}), 202
+    except ConfigChangeRefused as refused:
+        return jsonify({"success": False, "error": refused.reason}), 409

--- a/src/services.py
+++ b/src/services.py
@@ -103,7 +103,25 @@ device_state = DeviceState(
     dev_mode=DEV_MODE,
 )
 
-apply_service = ApplyService(RETINA_NODE_PATH, dev_mode=DEV_MODE)
+def config_change_guard():
+    """Refuse a config apply while Auto-Calibrate is using the SDR.
+
+    Both signals are needed, as elsewhere: is_running() is authoritative for
+    this process and never expires, while the lock file also covers a run
+    left behind by a crashed or restarted GUI. See ApplyService's
+    ConfigChangeRefused for why this is enforced there rather than per-route.
+
+    `calibrator` is defined below this point, which is fine: the name is
+    resolved when the guard runs, not when it is defined.
+    """
+    if calibrator.is_running() or device_state.is_calibration_locked()[0]:
+        return False, ("Auto-calibration is running. Cancel it before "
+                       "changing configuration")
+    return True, None
+
+
+apply_service = ApplyService(RETINA_NODE_PATH, dev_mode=DEV_MODE,
+                             guard=config_change_guard)
 blah2_client = Blah2Client(BLAH2_API_URL)
 # One client per sidecar, shared by every feature that talks to it — its TCP
 # server accepts a single connection at a time, so a second instance does not

--- a/templates/config.html
+++ b/templates/config.html
@@ -120,7 +120,10 @@
 
         {% if config_errors %}
         <div style="background:oklch(0.96 0.04 25);border:1px solid var(--danger);border-radius:var(--r-md);padding:12px 16px;margin-bottom:18px;font-size:13px;color:var(--danger);">
-            Please fix the highlighted fields below.
+            {# A form-level refusal (e.g. a calibration holding the SDR) has no
+               field to highlight, so say what actually happened instead. #}
+            {{ config_errors['_form'] if config_errors.get('_form')
+               else 'Please fix the highlighted fields below.' }}
         </div>
         {% endif %}
 
@@ -1377,14 +1380,84 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         return m + ':' + (r < 10 ? '0' : '') + r;
     }
 
+    function escapeHtml(s) {
+        var d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+
+    // Per-tower outcomes the engine records but the run's summary message
+    // cannot express. Without these every failure reads as "probably no
+    // aircraft", including the ones that never looked for one.
+    var OUTCOME_TEXT = {
+        no_confirmed_track: 'watched, but nothing confirmed',
+        confirmed_track: 'confirmed a track',
+        skipped_no_time: 'never watched — the search ran out of time here',
+        tuning_not_applied: 'never watched — the radio did not accept this tuning',
+        unstable_overload: 'stopped — the signal kept overloading the receiver',
+        not_reached: 'not reached'
+    };
+
+    function diagnose(history) {
+        if (!history.length) return '';
+        var watched = history.filter(function(h) {
+            return h.outcome === 'no_confirmed_track' || h.outcome === 'confirmed_track';
+        }).length;
+        var lines = history.map(function(h) {
+            var txt = OUTCOME_TEXT[h.outcome] || h.outcome || 'unknown';
+            var extra = '';
+            if (h.dwell_seconds) extra = ' (' + Math.round(h.dwell_seconds) + 's)';
+            if (h.tuning_error) extra += ' — ' + escapeHtml(h.tuning_error);
+            return '<div>' + escapeHtml(h.tower_name || 'Tower') + ': ' + txt + extra + '</div>';
+        });
+        var lead = watched === 0
+            ? '<strong>No tower was actually watched, so this is not evidence '
+              + 'about aircraft.</strong><br>'
+            : '';
+        return lead + lines.join('');
+    }
+
     function setTerminalButtons() {
         spinner.style.display = 'none';
         cancelBtn.style.display = 'none';
         closeBtn.style.display = '';
     }
 
+    // The server refuses config changes during a run (see ApplyService's
+    // ConfigChangeRefused), but being refused after filling in a form is a
+    // poor way to find out. Reflect it in the page too.
+    function setConfigLockedOut(locked) {
+        var apply = document.getElementById('applyBtn');
+        if (apply) {
+            apply.disabled = locked;
+            apply.title = locked
+                ? 'Auto-calibration is running. Cancel it before changing configuration.'
+                : '';
+        }
+        // Tower controls apply immediately (they POST /towers/select, which
+        // restarts the stack), so they need locking out too.
+        document.querySelectorAll('#towerPresetSelect, .tower-remove-btn')
+            .forEach(function(el) { el.disabled = locked; });
+    }
+
+    // A server-pushed Mender deployment installs on its own schedule and
+    // cannot be refused from here, so it can replace the containers under a
+    // run. Say so rather than let the run die unexplained.
+    function updateWarning(status) {
+        if (!status.system_update) return '';
+        return '<div style="margin-top:10px;padding:8px 10px;border-radius:6px;'
+            + 'background:oklch(0.96 0.04 85);border:1px solid var(--warn,#b7791f);'
+            + 'color:var(--warn,#b7791f);font-size:12.5px;">'
+            + '<strong>A system update is installing.</strong> '
+            + escapeHtml(status.system_update)
+            + '. It restarts the radar, so this calibration will not complete '
+            + 'and its results should be ignored. Run it again once the update '
+            + 'has finished.</div>';
+    }
+
     function render(status) {
         lastStatus = status;
+        setConfigLockedOut(status.state === 'running');
         if (status.state === 'running') {
             phaseText.textContent = PHASE_LABELS[status.phase] || 'Starting…';
             if (status.current) {
@@ -1416,6 +1489,11 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
                     + ', LNA state ' + status.best_attempt.lna_state
                     + ': ' + status.best_attempt.reason;
             }
+            // Warn the moment a deployment starts, not once the run has
+            // already died of it.
+            var warnNow = updateWarning(status);
+            errorEl.style.display = warnNow ? '' : 'none';
+            errorEl.innerHTML = warnNow;
             return;
         }
 
@@ -1438,7 +1516,23 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         } else {
             phaseText.textContent = status.state === 'cancelled' ? 'Cancelled' : 'No calibration found';
             errorEl.style.display = '';
-            errorEl.textContent = status.error || '';
+            errorEl.innerHTML = escapeHtml(status.error || '');
+            // The run's own message assumes the towers were actually watched.
+            // When they weren't — the tuning never reached the device, the
+            // operating point kept clipping, or time ran out mid-search —
+            // saying "no aircraft was overhead" is simply wrong, and it is
+            // the failure the user most needs to distinguish. Report what the
+            // engine actually determined, per tower.
+            // A deployment restarting the radar is the explanation, so lead
+            // with it rather than leaving the per-tower failures to imply
+            // something about the tuning or the sky.
+            errorEl.innerHTML += updateWarning(status);
+            var diagnosis = diagnose(status.history || []);
+            if (diagnosis) {
+                errorEl.innerHTML += '<div style="margin-top:8px;padding:8px 10px;'
+                    + 'background:var(--surface-2,rgba(128,128,128,.08));border-radius:6px;'
+                    + 'color:var(--ink-2);font-size:12.5px;">' + diagnosis + '</div>';
+            }
             if (status.best_attempt) {
                 best.style.display = '';
                 best.innerHTML = 'Closest attempt: ' + mhz(status.best_attempt.fc)
@@ -1480,18 +1574,54 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         applyBtn.textContent = 'Persist to config';
     }
 
+    // Show the in-progress view rather than the "start a run" prompt — used
+    // both when starting one and when reattaching to one already going.
+    function showRunning() {
+        setupEl.style.display = 'none';
+        startBtn.style.display = 'none';
+        setupCancelBtn.style.display = 'none';
+        phase.style.display = 'flex';
+        spinner.style.display = '';
+        cancelBtn.style.display = '';
+    }
+
     btn.addEventListener('click', function() {
         resetModal();
         modal.show();
     });
 
+    // A run outlives the page: it is a background thread on the node, not
+    // something this tab owns. Without reattaching, navigating away or
+    // refreshing left it going with no way to see or cancel it — the Cancel
+    // button only ever appeared for the tab that started the run, so the only
+    // recourse was to wait out the full budget. Reattach on load so any tab
+    // can watch and stop it.
+    (function reattachIfRunning() {
+        fetch('/calibrate/status')
+            .then(function(r) { return r.json(); })
+            .then(function(status) {
+                if (status.state !== 'running') return;
+                resetModal();
+                showRunning();
+                render(status);
+                modal.show();
+                poll();
+            })
+            .catch(function() { /* nothing running, or GUI busy — ignore */ });
+    })();
+
+    // Leaving does not stop the run, but people assume it does, and a run
+    // holds the SDR and blocks config changes for its whole budget.
+    window.addEventListener('beforeunload', function(e) {
+        if (lastStatus && lastStatus.state === 'running') {
+            e.preventDefault();
+            e.returnValue = '';
+        }
+    });
+
     startBtn.addEventListener('click', function() {
         var mode = document.querySelector('input[name="calMode"]:checked').value;
-        setupEl.style.display = 'none';
-        startBtn.style.display = 'none';
-        setupCancelBtn.style.display = 'none';
-        phase.style.display = 'flex';
-        cancelBtn.style.display = '';
+        showRunning();
         fetch('/calibrate/start', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -617,6 +617,168 @@ class TestApplyConfigRoute:
         assert data['settle_remaining'] == 12
 
 
+class TestNavigationLockedToConfigDuringCalibration:
+    """A run is only visible in one place — the modal on /config — while it
+    owns the SDR for up to 15 minutes and blocks every config change.
+    Navigating away stranded it: nothing else in the GUI showed it was
+    happening, and the Cancel button existed only on that page. So while one
+    is running, GET navigation is held on /config."""
+
+    def _calibrating(self, app_module, running=True):
+        return patch.object(app_module.calibrator, 'is_running', return_value=running)
+
+    def test_home_redirects_to_config(self, app_client):
+        import app as app_module
+        with self._calibrating(app_module):
+            response = app_client.get('/')
+        assert response.status_code == 302
+        assert response.headers['Location'].endswith('/config')
+
+    def test_config_page_itself_is_reachable(self, app_client):
+        import app as app_module
+        with self._calibrating(app_module):
+            response = app_client.get('/config')
+        assert response.status_code == 200
+
+    def test_the_modals_own_endpoints_keep_working(self, app_client):
+        """Redirecting these would break the very window doing the watching
+        and cancelling."""
+        import app as app_module
+        with self._calibrating(app_module):
+            for path in ('/calibrate/status', '/config/apply/status'):
+                assert app_client.get(path).status_code == 200, path
+
+    def test_static_assets_are_not_redirected(self, app_client):
+        import app as app_module
+        with self._calibrating(app_module):
+            response = app_client.get('/static/common.css')
+        assert response.status_code != 302
+
+    def test_nothing_is_locked_when_no_run_is_going(self, app_client):
+        import app as app_module
+        with self._calibrating(app_module, running=False):
+            assert app_client.get('/').status_code == 200
+
+    def test_posts_are_left_to_their_own_guards(self, app_client):
+        """A 409 with a reason is more use to a caller than a redirect to
+        HTML, and those guards already exist."""
+        import app as app_module
+        with self._calibrating(app_module):
+            response = app_client.post('/api/mode', data=json.dumps({'mode': 'spectrum'}),
+                                       content_type='application/json')
+        assert response.status_code == 409
+
+    def test_the_wizard_is_not_locked_and_cannot_loop(self, app_client):
+        """/config redirects into the wizard while it is in progress, so
+        locking navigation to /config during the wizard would bounce the
+        browser between the two forever."""
+        import app as app_module
+        with self._calibrating(app_module), \
+             patch.object(app_module.device_state, 'is_setup_wizard_in_progress',
+                          return_value=True):
+            response = app_client.get('/set-up')
+        assert response.status_code != 302
+
+    def test_a_stale_lock_file_does_not_lock_the_whole_gui(self, app_client):
+        """The lock outlives a crashed GUI by design. Keying navigation off
+        it would strand the user with no reachable way to clear it, so only
+        the in-memory signal is used here."""
+        import app as app_module
+        with patch.object(app_module.calibrator, 'is_running', return_value=False), \
+             patch.object(app_module.device_state, 'is_calibration_locked',
+                          return_value=(True, {})):
+            assert app_client.get('/').status_code == 200
+
+
+class TestConfigChangesDuringCalibration:
+    """A config apply restarts the whole stack, which pulls the SDR out from
+    under an Auto-Calibrate run.
+
+    Demonstrated on a live node before this guard existed: clicking Apply
+    Changes mid-run recreated all seven containers, after which every retune
+    failed and the run carried on to report an ordinary-looking "no confirmed
+    track" — a plausible negative result from a search that had stopped
+    happening. /api/mode and /mender/install each grew their own calibration
+    check; /config/apply and /towers/select, added later, did not.
+
+    The check now lives in ApplyService.request(), the one place every
+    config-driven restart funnels through, so a future route cannot reopen
+    the same hole by forgetting it.
+    """
+
+    def _calibrating(self, app_module):
+        return patch.object(app_module.calibrator, 'is_running', return_value=True)
+
+    def test_config_apply_refused(self, app_client):
+        import app as app_module
+        with self._calibrating(app_module):
+            response = app_client.post('/config/apply')
+
+        assert response.status_code == 409
+        body = json.loads(response.data)
+        assert body['success'] is False
+        assert 'Auto-calibration is running' in body['error']
+
+    def test_tower_select_refused(self, app_client):
+        import app as app_module
+        payload = {"rx_latitude": -33.8688, "rx_longitude": 151.2093,
+                   "rx_altitude": 45.0, "tx_latitude": -33.82,
+                   "tx_longitude": 151.185, "tx_altitude": 100.0,
+                   "tx_callsign": "ATN6"}
+        with self._calibrating(app_module):
+            response = app_client.post('/towers/select', data=json.dumps(payload),
+                                       content_type='application/json')
+
+        assert response.status_code == 409
+        assert 'Auto-calibration is running' in json.loads(response.data)['error']
+
+    def test_config_save_refused(self, app_client):
+        """Refused at the save, not just the apply that follows it —
+        otherwise the change lands in user.yml unapplied and is swept into
+        the next merge, including /calibrate/apply's own."""
+        import app as app_module
+        with self._calibrating(app_module):
+            response = app_client.post('/config/save', data={'capture.fc': '99000000'})
+
+        assert response.status_code == 200  # re-rendered form, not a redirect
+        assert b'Auto-calibration is running' in response.data
+
+    def test_a_stale_lock_file_also_refuses(self, app_client):
+        """is_running() is blind to a run left behind by a crashed GUI, so
+        the on-disk lock is checked too."""
+        import app as app_module
+        with patch.object(app_module.calibrator, 'is_running', return_value=False), \
+             patch.object(app_module.device_state, 'is_calibration_locked',
+                          return_value=(True, {})):
+            response = app_client.post('/config/apply')
+
+        assert response.status_code == 409
+        assert 'Auto-calibration is running' in json.loads(response.data)['error']
+
+    def test_allowed_again_once_the_run_finishes(self, app_client):
+        import app as app_module
+        with patch.object(app_module.calibrator, 'is_running', return_value=False), \
+             patch.object(app_module.device_state, 'is_calibration_locked',
+                          return_value=(False, None)), \
+             patch.object(app_module, 'apply_service') as svc:
+            svc.request.return_value = {'state': 'running'}
+            response = app_client.post('/config/apply')
+
+        assert response.status_code == 202
+        svc.request.assert_called_once()
+
+    def test_guard_lives_in_apply_service_not_only_the_routes(self):
+        """The point of the fix: a new caller of request() inherits the
+        refusal without having to remember it."""
+        from apply_service import ApplyService, ConfigChangeRefused
+
+        service = ApplyService('/tmp/nowhere',
+                               guard=lambda: (False, 'Auto-calibration is running'))
+        with pytest.raises(ConfigChangeRefused) as excinfo:
+            service.request()
+        assert 'Auto-calibration is running' in excinfo.value.reason
+
+
 class TestApplyDuringMenderInstall:
     """A Mender install replaces the compose manifests an apply's
     config-merger runs against, and mender-update's own docker commands sit

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1457,6 +1457,44 @@ class TestRoutes:
         names = [t["name"] for t in towers]
         assert "Cached Tower" in names
 
+    def test_start_refuses_while_a_config_apply_is_still_running(self, app_client):
+        """The refusal has to run both ways.
+
+        ApplyService blocks an apply starting during a run. Nothing blocked a
+        run starting during an apply — can_start_calibration() knows about
+        Mender installs but not about the ~45s stack restart an apply
+        performs. Hit by accident on a live node: Apply Changes, then
+        Auto-Calibrate a few seconds later, and every retune failed against
+        restarting containers. All three towers came back
+        tuning_not_applied — honest, but a whole run wasted on something
+        that could just have been refused.
+        """
+        import app as app_module
+        with patch.object(app_module.apply_service, 'is_running', return_value=True):
+            resp = app_client.post('/calibrate/start', json={"mode": "track"})
+
+        assert resp.status_code == 409
+        assert 'configuration change' in resp.get_json()['error']
+
+    def test_status_reports_a_system_update_in_progress(self, app_client):
+        """A server-pushed Mender deployment installs autonomously — nothing
+        here can refuse it, unlike /mender/install. It restarts the radar
+        underneath a run, after which every retune fails and the run reports
+        tuning_not_applied for no reason the user can see. The modal already
+        polls this endpoint, so it carries the explanation."""
+        import app as app_module
+        with patch.object(app_module.device_state, 'is_any_update_in_progress',
+                          return_value=(True, 'Installing retina-node-v0.5.0')):
+            body = app_client.get('/calibrate/status').get_json()
+        assert body['system_update'] == 'Installing retina-node-v0.5.0'
+
+    def test_status_reports_no_update_when_none_is_running(self, app_client):
+        import app as app_module
+        with patch.object(app_module.device_state, 'is_any_update_in_progress',
+                          return_value=(False, None)):
+            body = app_client.get('/calibrate/status').get_json()
+        assert body['system_update'] is None
+
     def test_status_returns_idle_initially(self, app_client):
         resp = app_client.get('/calibrate/status')
         assert resp.status_code == 200
@@ -1468,6 +1506,34 @@ class TestRoutes:
                           return_value={"state": "idle", "result": None}):
             resp = app_client.post('/calibrate/apply')
         assert resp.status_code == 409
+
+    def test_apply_is_not_blocked_by_the_config_change_guard(self, app_client):
+        """The guard that refuses config changes mid-run must not refuse the
+        calibration's *own* apply.
+
+        Both go through ApplyService.request(), and persisting a result is
+        the entire payoff of a successful run — so a guard that cannot tell
+        the two apart would block the feature's happy path while looking
+        like it was protecting it. It can: by the time /calibrate/apply is
+        reachable the run has reached a terminal state, so is_running() is
+        false and the lock has been released.
+
+        Exercises the real guard, unlike the route test below which mocks
+        request() and would pass either way.
+        """
+        import app as app_module
+        import services
+
+        with patch.object(app_module.calibrator, 'is_running', return_value=False), \
+             patch.object(app_module.device_state, 'is_calibration_locked',
+                          return_value=(False, None)):
+            ok, reason = services.config_change_guard()
+        assert ok, f"the calibration's own apply would be refused: {reason}"
+
+        # ...and it does refuse while the run is still going.
+        with patch.object(app_module.calibrator, 'is_running', return_value=True):
+            ok, _ = services.config_change_guard()
+        assert not ok
 
     def test_apply_writes_user_config(self, app_client, config_files):
         import app as app_module


### PR DESCRIPTION
Follow-up to #55. That branch made the search engine correct; this one stops a run being invisible or misrepresented. Verified live on `jonathan-node-2` with everything deployed.

## Nothing stopped a config change restarting the stack under a run

`/api/mode` and `/mender/install` each grew their own calibration guard. `/config/apply` and `/towers/select`, added later, did not — and nothing caught it.

Demonstrated live: clicking **Apply Changes** during a run recreated all seven containers, after which every retune failed and the run carried on to report an ordinary-looking "no confirmed track" — a plausible negative result from a search that had stopped happening. Both buttons sit on the same page as the Auto-Calibrate one.

The check now lives in `ApplyService.request()`, which every config-driven restart funnels through, so a route added later inherits it rather than having to remember it. It **raises** rather than returning a refusal: a caller that forgets to handle it gets a 500, not a silent 202 claiming work was queued. `/config/save` is refused too, so changes can't land in `user.yml` unapplied and get swept into the next merge — including the one `/calibrate/apply` performs.

## The refusal now runs both ways

Nothing stopped a *run* starting during an *apply*. `can_start_calibration()` knew about Mender installs but not about the ~45s stack restart an apply performs.

Found by accident while testing this branch: Apply Changes, then Auto-Calibrate a few seconds later, and all three towers came back `tuning_not_applied`. Honest — but a whole run wasted on something that could simply have been refused. That accident also proved the #55/blah2-arm#54 chain end-to-end on a failure nobody staged: blah2 retired the doomed generation, the `rejected` signal reached retina-gui, and `_verify_applied` named the reason per tower instead of dwelling on dead tuning.

## A run was only visible in one place

It owns the SDR for up to 15 minutes and blocks every config change for its duration, but the only sign of it was the modal on `/config` — and Cancel existed solely in the tab that started it. Navigating away left it running invisibly with no way to stop it short of waiting out the budget.

- GET navigation is held on `/config` while a run is going (allowlist: `/config*`, `/calibrate*`, `/static*`, `/favicon*`)
- The modal reattaches on page load, so any tab or a reload can watch and cancel
- `beforeunload` warns; Apply and tower controls disable during a run

Keyed on `is_running()` alone, **never** the lock file: that lock outlives a crashed GUI by design, and a stale one here would lock someone out of the whole interface with no reachable way to clear it. The setup wizard is exempt, since `/config` redirects into it and the two would bounce forever. Both hazards are tested.

## Failures now say what happened

The engine records `skipped_no_time`, `tuning_not_applied`, `unstable_overload` — and the modal discarded all of it in favour of the run's summary, which assumes the towers were watched and blames absent aircraft. When nothing was actually dwelt on it now leads with exactly that: **"No tower was actually watched, so this is not evidence about aircraft."**

## Mender deployments are reported, not prevented

A server-pushed deployment installs autonomously and can't be refused from here, so it can replace the containers under a run. The existing state scripts already publish that state, so the modal reports it — live while it happens, and again in the failure — rather than letting the run die unexplained.

Deliberately reported rather than gated: preventing it means an `ArtifactInstall_Enter` script refusing deployments, which is a fleet-wide decision living in owl-os. Accepted risk, recorded in the code.

## Also

The descent phase label stuck on "Refining gain" for most of a descent — the surveillance stage set it and the LNA loop re-enters both stages many times per tower.

## Verification

On `jonathan-node-2`, everything deployed:

| | |
|---|---|
| `GET /` during a run | 302 → `/config` |
| `/config`, `/calibrate/status`, `/static/*` | 200 — allowlist intact |
| `POST /config/apply` / `/towers/select` during a run | **409** |
| `POST /config/save` during a run | 200 with the reason rendered |
| `POST /calibrate/start` during an apply | **409** |
| `POST /config/apply` with **no** run | **202** — normal operation untouched |
| `phase` during descent | `descending`, not stuck on `refining` |
| after cancel | `GET /` → 200, device restored, 0 errors |

**463 passed / 7 pre-existing failures** (dev-tag mender, tower-search).

## Still out of scope

Duplicate frame feed (~5% measured — `tracker_capture` and the calibrator both push the same detections to the sidecar), a Mender deployment that *reboots* mid-run still loses the run silently, and blah2-arm's `sdrplay-restart.sh` `pkill -x` no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)