### PR TITLE
20260812 - Prove the radio responds before calibrating, and unwedge it when it doesn't

### DIFF
--- a/src/apply_service.py
+++ b/src/apply_service.py
@@ -67,6 +67,7 @@ PHASE_LABELS = {
     'merging': 'Merging configuration',
     'stopping_spectrum': 'Releasing the SDR',
     'restarting_sdr': 'Restarting the SDR service',
+    'resetting_sdr': 'SDR service stuck — forcing it down',
     'settling': 'Waiting for the SDR to settle',
     'recreating': 'Restarting radar services',
     'repairing': 'Cleaning up after an interrupted restart',
@@ -121,14 +122,23 @@ class ApplyService:
         with self._lock:
             return self._status['state'] == 'running'
 
-    def request(self):
+    def request(self, bypass_guard=False):
         """Start an apply, or coalesce into the one already running.
 
         Returns the current status dict. Never blocks on the actual work.
         Raises ConfigChangeRefused if the configured guard says something
         else is using the SDR right now.
+
+        bypass_guard exists for exactly one caller: Auto-Calibrate's own
+        preflight recovery (see calibrator._run_recovery_apply). The guard's
+        job is to stop a config apply pulling the SDR out from under a
+        running calibration — but there the calibration *is* the caller, it
+        holds the calibration lock itself, and restarting the stack is the
+        only way to unwedge the device it is about to search with. Refusing
+        it there would mean the guard blocking the one apply that exists to
+        make the run possible. No route should ever pass this.
         """
-        if self._guard is not None:
+        if self._guard is not None and not bypass_guard:
             ok, reason = self._guard()
             if not ok:
                 raise ConfigChangeRefused(reason)

--- a/src/calibrator.py
+++ b/src/calibrator.py
@@ -139,12 +139,47 @@ Two success modes, with genuinely different dwell strategies:
     rejects mode=adsb at the /start endpoint — exposing it to users is a
     separate decision not yet made.
 
-Nothing is written to user.yml during a run, and nothing here touches
-config-merger or Docker: every setting this engine applies goes through
-blah2's live retune protocol (see blah2_client.retune) and is in-memory
-only. That keeps the whole run on sub-second HTTP calls and keeps this
-module free of any Flask/subprocess/Docker import. Persisting a
-successful result is a separate, explicit step (POST /calibrate/apply).
+Before the search starts, a preflight (see _preflight) parks the device at
+the safe corner — max gain reduction on both tuners, max LNA state — at
+whatever frequency blah2 is *actually* on, and requires an ack for it. That
+one retune does two jobs: it proves the SDRplay API is still answering
+control calls, and it leaves the radio at its least sensitive setting before
+any candidate is tried. On a healthy node it costs a couple of seconds and
+nothing else happens.
+
+If the ack never comes, the device is wedged, and a live retune provably
+cannot rescue it: once the SDRplay API starts returning ServiceNotResponding
+it keeps doing so (see _apply), so every later retune in the run fails too.
+The only lever that works is a restart from a safe config. The preflight
+therefore writes the safe corner to user.yml and runs the ordinary
+config-apply path — sdrplay_apiService restart, settle, container recreate —
+then re-probes until the device answers or PREFLIGHT_RECOVERY_PROBE_SECONDS
+expires. If it never answers, the run is abandoned before any tower is
+tried, with a message naming the real fault.
+
+Without this, the wedged case was near-invisible: every retune failed, every
+tower came back tuning_not_applied, and the whole run finished in 30-60
+seconds behind a summary message about there being no aircraft overhead.
+
+That user.yml write is a deliberate exception to the rule below, and it is
+**not** reverted. It only ever happens on a device that was already
+unresponsive, where max attenuation is a working state rather than a
+degraded one; a run that reaches /calibrate/apply overwrites it anyway; and
+reverting it would cost a second container restart that could leave the node
+deaf if it failed in between. The run reports that it did this and what the
+previous values were, so the user can restore them deliberately. For the
+same reason, a run whose preflight had to recover the device does not
+restore the original tuning on a non-success outcome (see _run) — putting a
+just-recovered radio back on the sensitive settings that wedged it is the
+one thing not to do.
+
+Apart from that preflight, nothing is written to user.yml during a run, and
+nothing here touches config-merger or Docker: every setting this engine
+applies goes through blah2's live retune protocol (see blah2_client.retune)
+and is in-memory only. That keeps the whole search on sub-second HTTP calls,
+and this module still imports no Flask, subprocess or Docker — the recovery
+restart goes through an injected ApplyService. Persisting a successful
+result is a separate, explicit step (POST /calibrate/apply).
 
 On a genuine user cancellation or an unexpected/CalibrationError
 exception, the original tuning is restored, unchanged from before. On
@@ -201,6 +236,26 @@ ADSB_GAIN_STEP_DB = 5
 # traffic), just not one derived from a shrinking per-tower time division.
 ADSB_DESCENT_DEADLINE_SECONDS = 120
 
+# Preflight recovery (see _preflight). The apply timeout has to cover the
+# whole config-apply path — config-merger, the sdrplay_apiService restart,
+# routes.mode's own 30s settle, and a container recreate measured at ~47s —
+# with enough headroom that a slow node isn't declared dead for being slow.
+# The probe window then covers blah2 coming up and claiming the device
+# afterwards; SDRplay hardware needs a real 20-60s settle before it answers
+# again, so anything shorter reports a false failure on a device that was
+# about to recover.
+#
+# These two are bounded from above, not just chosen: the preflight runs
+# *before* TOTAL_BUDGET_SECONDS starts (see _run), so their sum is added to
+# a run's total wall time, and the whole thing still has to finish inside
+# the 1200s after which retina-gui's own CALIBRATE_LOCK_TIMEOUT and
+# blah2-arm's watchdog stop treating calibrate.lock as live and restart the
+# stack underneath the run. 180 + 60 + 900 = 1140 leaves a minute of
+# margin; raising either without lowering TOTAL_BUDGET_SECONDS spends it.
+PREFLIGHT_RECOVERY_APPLY_TIMEOUT_SECONDS = 180
+PREFLIGHT_RECOVERY_PROBE_SECONDS = 60
+PREFLIGHT_APPLY_POLL_SECONDS = 1.0
+
 # Retune protocol timing.
 ACK_TIMEOUT_SECONDS = 2.0
 ACK_POLL_SECONDS = 0.2
@@ -252,6 +307,9 @@ TRACKER_FEED_POLL_SECONDS = 0.2
 # stop treating calibrate.lock as live — past that point the watchdog would
 # restart the stack underneath a still-running calibration. Raising this
 # above ~20 minutes means raising both of those, in both repos, together.
+# Note this is no longer a run's whole wall time: the preflight's recovery
+# branch runs ahead of this clock, and its own two constants are sized
+# against the same 1200s ceiling — see PREFLIGHT_RECOVERY_APPLY_TIMEOUT_SECONDS.
 TOTAL_BUDGET_SECONDS = 900
 
 # Hard per-tower ceiling on the descent phase, whatever the run budget is —
@@ -314,9 +372,18 @@ class Calibrator:
     DeviceState and is managed by the caller (routes/calibrate.py).
     """
 
-    def __init__(self, blah2_client, retina_tracker_client):
+    def __init__(self, blah2_client, retina_tracker_client,
+                 config_mgr=None, apply_service=None):
         self._client = blah2_client
         self._tracker_client = retina_tracker_client
+        # Both are only used by _preflight's recovery branch, and only when
+        # the safe-corner probe has already failed. Left as None (every
+        # engine-level test, and dev mode) the probe still runs and still
+        # aborts the run with an accurate message — there is simply no
+        # restart to attempt. Injected rather than imported so this module
+        # keeps its no-Flask/no-subprocess property (see module docstring).
+        self._config_mgr = config_mgr
+        self._apply_service = apply_service
         self._lock = threading.Lock()
         self._cancel = threading.Event()
         self._thread = None
@@ -353,6 +420,10 @@ class Calibrator:
             "result": None,
             "error": None,
             "original": None,
+            # None until the preflight has something to report. Only set when
+            # the device had to be recovered — a clean probe is unremarkable
+            # and says nothing the UI needs to show. See _preflight.
+            "preflight": None,
             "history": [],
         }
 
@@ -547,6 +618,126 @@ class Calibrator:
             self._last_applied_fc = int(status["fc"])
         else:
             self._last_applied_fc = int(original_fc)
+
+    # ── Preflight ──────────────────────────────────────────────
+
+    def _preflight(self, original):
+        """Park the device at the safe corner and prove it still responds,
+        recovering it by restart if it doesn't. See the module docstring for
+        the full rationale.
+
+        Runs after _seed_last_applied_fc, and deliberately probes at the
+        frequency blah2 is *actually* on rather than at original["fc"]:
+        moving fc from an unknown, possibly sensitive gain is the exact
+        hazard _apply's handover exists to avoid, and this call has no
+        proven-safe state to hand over from. Gain reduction and LNA state
+        only ever increase here, so the probe is safe from any starting
+        point.
+
+        Returns None if the device is usable. Raises CalibrationError with a
+        message naming the real fault if it is not — there is no point
+        starting a search against a radio that cannot be tuned.
+        """
+        self._update(phase="preflight")
+        fc = self._last_applied_fc
+        try:
+            self._apply_tuning(fc, GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX,
+                               LNA_STATE_MAX)
+            return
+        except CalibrationError as e:
+            # Rebound: `as e` is unbound at the end of the except block, and
+            # this message is still needed several branches below.
+            probe_error = e
+
+        if self._apply_service is None or self._config_mgr is None:
+            raise CalibrationError(
+                f"The radio is not accepting tuning commands ({probe_error}). "
+                "Restart the radar services and try again.")
+
+        self._update(phase="recovering")
+        # Recorded before the write, so a run that dies anywhere below still
+        # reports that it intervened — and _run still knows not to restore.
+        self._set_preflight(recovered=False, restarted=True, previous=dict(original))
+        try:
+            self._persist_safe_corner()
+        except Exception as e:
+            # Without this write the restart brings blah2 straight back up on
+            # the tuning that wedged it, so there is no point doing it.
+            raise CalibrationError(
+                "The radio stopped accepting tuning commands, and its safe "
+                f"settings could not be saved: {e}") from e
+
+        error = self._run_recovery_apply()
+        if error:
+            raise CalibrationError(
+                f"The radio stopped accepting tuning commands, and restarting "
+                f"it failed: {error}")
+
+        # blah2 has to come up and claim the device before it can ack
+        # anything, so this retries rather than asking once.
+        deadline = time.monotonic() + PREFLIGHT_RECOVERY_PROBE_SECONDS
+        last_error = probe_error
+        while True:
+            try:
+                self._apply_tuning(fc, GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX,
+                                   LNA_STATE_MAX)
+                self._set_preflight(recovered=True, restarted=True,
+                                    previous=dict(original))
+                return
+            except CalibrationError as e:
+                last_error = e
+            if time.monotonic() >= deadline:
+                raise CalibrationError(
+                    f"The radio is still not accepting tuning commands after a "
+                    f"restart ({last_error}). It has been set to maximum "
+                    f"attenuation; the SDRplay service may need attention on "
+                    f"the node itself.")
+            self._sleep(PREFLIGHT_APPLY_POLL_SECONDS)
+
+    def _persist_safe_corner(self):
+        """Write the safe corner to user.yml so the stack restart below
+        brings blah2 up on it. The one user.yml write this engine makes, and
+        the reason it is not reverted, are covered in the module docstring."""
+        user_config = self._config_mgr.load_user_config() or {}
+        device = user_config.setdefault("capture", {}).setdefault("device", {})
+        device["gainReduction"] = [GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX]
+        device["lnaState"] = LNA_STATE_MAX
+        self._config_mgr.save_user_config(user_config)
+
+    def _run_recovery_apply(self):
+        """Run the ordinary config-apply path and wait for it to finish.
+
+        ApplyService.request() returns immediately (it exists precisely so a
+        closed tab can't interrupt a restart), so this polls to completion.
+        bypass_guard is required: that guard refuses config applies while a
+        calibration is running, which is normally exactly right — this is the
+        one caller that owns the run doing the restarting.
+
+        Returns None on success, or a message on failure.
+        """
+        try:
+            self._apply_service.request(bypass_guard=True)
+        except Exception as e:
+            return str(e)
+
+        deadline = time.monotonic() + PREFLIGHT_RECOVERY_APPLY_TIMEOUT_SECONDS
+        while True:
+            status = self._apply_service.get_status()
+            state = status.get("state")
+            if state == "done":
+                return None
+            if state == "failed":
+                return status.get("error") or "the restart failed"
+            if time.monotonic() >= deadline:
+                return "the restart did not finish in time"
+            # ignore_cancel: a cancel arriving mid-restart must not leave
+            # containers half-recreated with nobody waiting on them. The run
+            # aborts at the next _check_cancel, once the stack is settled.
+            self._sleep(PREFLIGHT_APPLY_POLL_SECONDS, ignore_cancel=True)
+
+    def _set_preflight(self, **kwargs):
+        with self._lock:
+            self._status["preflight"] = dict(kwargs)
 
     def _safe_fc_handover(self, ignore_cancel=False):
         """Retune to the safe corner at the frequency currently in use,
@@ -1308,9 +1499,21 @@ class Calibrator:
         # module docstring). None until/unless tower index 0 is actually
         # reached.
         top_tower_resolved = None
-        run_deadline = time.monotonic() + budget_seconds
 
         try:
+            # Ahead of the budget clock deliberately: a recovery restart can
+            # take ~90s, and charging that to the search would silently
+            # shorten every tower's dwell for a node that was already having
+            # a bad day. Raises if the radio can't be tuned at all, which
+            # ends the run here rather than after three towers of
+            # tuning_not_applied.
+            self._preflight(original)
+            run_deadline = time.monotonic() + budget_seconds
+            # Rebase the elapsed counter onto the same instant, or the UI
+            # shows a recovery's ~90s counting against a budget that has not
+            # started yet. started_at keeps the true wall-clock start.
+            self._update(_started_monotonic=time.monotonic())
+
             for index, tower in enumerate(towers):
                 self._check_cancel()
                 # MODE_ADSB has no time division (see module docstring) — the
@@ -1489,7 +1692,18 @@ class Calibrator:
         # second cancel click while this is in flight must not be able
         # to abort it, or blah2 could be left tuned to the last (failed)
         # candidate.
-        if state != "done" and not no_track_fallback_applied:
+        # A run whose preflight had to restart a wedged device never restores
+        # the original tuning: those are the settings the radio was stuck on,
+        # and putting a just-recovered device back on them is the one move
+        # guaranteed to undo the recovery. user.yml already holds the safe
+        # corner in that case (see _persist_safe_corner), so skipping this
+        # keeps the live tuning agreeing with the persisted one rather than
+        # fighting it. Keyed on `restarted`, not `recovered`: a cancel
+        # arriving between the restart and the first successful probe still
+        # leaves a device that must not be handed those values back.
+        with self._lock:
+            restarted = bool((self._status.get("preflight") or {}).get("restarted"))
+        if state != "done" and not no_track_fallback_applied and not restarted:
             self._update(phase="restoring")
             try:
                 self._apply(original["fc"], original["gain_a"], original["gain_b"],

--- a/src/routes/mode.py
+++ b/src/routes/mode.py
@@ -50,6 +50,71 @@ def _write_mode(mode):
         pass  # dev: no /data — in-memory cache is the fallback
 
 
+def restart_sdrplay_service(on_phase=None):
+    """Restart sdrplay_apiService, forcing it if the unit will not stop.
+
+    `systemctl restart sdrplay.service` is not reliable on the failure that
+    matters most. When the SDRplay device has wedged — the state auto-calibrate
+    exists to recover from — the unit hangs in `deactivating (stop-sigterm)`
+    because sdrplay_apiService ignores SIGTERM, and the restart never returns.
+
+    This was a bare `subprocess.run(..., timeout=30)`. Confirmed live on
+    jonathan-node-2 against a genuinely wedged RSPduo (blah2 crash-looping on
+    `MaxDevs=1023 NumDevs=0 / Error: No devices found`): the timeout fired,
+    TimeoutExpired propagated out of run_config_merger_and_restart, reached
+    ApplyService as 'Command timed out', and **the container recreate never
+    ran** — so the one path that can recover the device aborted half-way, and
+    Auto-Calibrate's preflight reported it could not restart the radio.
+
+    The fallback is the sequence that did work by hand on that node: SIGKILL
+    the service process, which releases the stuck systemd job, then clear the
+    failed state and start it again. The device stayed enumerated on USB
+    throughout, so no unbind/rebind is needed — only the API service is stuck.
+
+    Never raises: every caller here treats the restart as best-effort, and a
+    node without sdrplay.service at all (dev machines) must stay a no-op.
+    Returns None normally, or a short description of what it had to do.
+    """
+    if on_phase is not None:
+        on_phase('restarting_sdr', None)
+    try:
+        result = subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
+                                capture_output=True, timeout=30)
+        if result.returncode == 0:
+            return None
+        detail = 'systemctl restart returned non-zero'
+    except subprocess.TimeoutExpired:
+        detail = 'systemctl restart hung (service stuck stopping)'
+    except (FileNotFoundError, OSError):
+        return None  # no systemd/sdrplay here — dev machine
+
+    if on_phase is not None:
+        on_phase('resetting_sdr', None)
+    try:
+        # -f (full command line), not -x: the kernel truncates comm to 15
+        # chars, so the 18-char name never matches an -x pattern. That bug is
+        # why blah2-arm's own sdrplay-restart.sh is a silent no-op, while
+        # script/blah2_rspduo_restart.bash works.
+        #
+        # The pattern is bracketed so it cannot match a shell command line
+        # that merely *carries* it — running the unbracketed form over ssh
+        # matches the invoking shell and kills the session.
+        subprocess.run(['pkill', '-9', '-f', '[s]drplay_apiService'],
+                       capture_output=True, timeout=15)
+        # Killing the process is what releases the stuck job, but systemd
+        # needs a moment to reap it before the unit is actionable again.
+        time.sleep(3)
+        subprocess.run(['systemctl', 'reset-failed', 'sdrplay.service'],
+                       capture_output=True, timeout=15)
+        # Often a no-op: the restart queued above usually completes on its own
+        # once the process dies. Harmless when it already has.
+        subprocess.run(['systemctl', 'start', 'sdrplay.service'],
+                       capture_output=True, timeout=30)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return f'{detail}; forced reset also failed ({type(e).__name__})'
+    return f'{detail}; forced a reset of sdrplay_apiService'
+
+
 def _settle(seconds, on_phase):
     """Sleep out the SDRplay settle window, reporting the remaining time.
 
@@ -129,10 +194,10 @@ def _run_config_merger_and_restart_locked(retina_node_path, on_phase):
 
     # Force a clean sdrplay_apiService restart so the USB device is properly
     # re-initialised before blah2 claims it.  Mirrors what the watchdog does.
-    # Non-fatal: no-op on dev machines without sdrplay.service.
-    on_phase('restarting_sdr', None)
-    subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
-                   capture_output=True, timeout=30)
+    # Non-fatal: no-op on dev machines without sdrplay.service, and it forces
+    # the service down rather than timing out when the device has wedged —
+    # see restart_sdrplay_service, which reports its own phases.
+    restart_sdrplay_service(on_phase)
 
     # See SDRPLAY_RESTART_SETTLE_SECONDS — without this, recreating the
     # containers immediately after the restart request returns has
@@ -301,8 +366,7 @@ def _set_mode_locked(mode, current_mode, retina_node_path):
 
         # Force a clean sdrplay_apiService restart so the USB device is
         # properly re-initialised before SDRconnect claims it.  Non-fatal.
-        subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
-                       capture_output=True, timeout=30)
+        restart_sdrplay_service()
 
         result = subprocess.run(['systemctl', 'start', 'sdrconnect.service'],
                                 capture_output=True, text=True, timeout=30)
@@ -334,8 +398,7 @@ def _set_mode_locked(mode, current_mode, retina_node_path):
 
         # Force a clean sdrplay_apiService restart so the USB device is
         # properly re-initialised before blah2 claims it.  Non-fatal.
-        subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
-                       capture_output=True, timeout=30)
+        restart_sdrplay_service()
 
         result = subprocess.run(
             ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate',
@@ -420,8 +483,7 @@ def _enforce_radar_mode_locked(retina_node_path: str) -> None:
         )
         subprocess.run(['systemctl', 'stop', 'sdrconnect.service'],
                        capture_output=True, timeout=30)
-        subprocess.run(['systemctl', 'restart', 'sdrplay.service'],
-                       capture_output=True, timeout=30)
+        restart_sdrplay_service()
         subprocess.run(
             ['docker', 'compose', '-p', 'retina-node', 'up', '-d', '--force-recreate',
              'blah2', 'blah2_api', 'blah2_web', 'blah2_host', 'retina-tracker'],

--- a/src/services.py
+++ b/src/services.py
@@ -128,7 +128,13 @@ blah2_client = Blah2Client(BLAH2_API_URL)
 # get a second conversation, it gets a socket nobody ever reads from.
 retina_tracker_client = RetinaTrackerClient(
     RETINA_TRACKER_HOST, RETINA_TRACKER_PORT, RETINA_TRACKER_EVENTS_PATH)
-calibrator = Calibrator(blah2_client, retina_tracker_client)
+# config_mgr/apply_service are only reached by the preflight's recovery
+# branch — writing the safe corner to user.yml and restarting the stack when
+# the radio has stopped accepting retunes (see calibrator._preflight). The
+# apply_service reference resolves here because ApplyService is constructed
+# above; its own guard resolves `calibrator` lazily, so the cycle is fine.
+calibrator = Calibrator(blah2_client, retina_tracker_client,
+                        config_mgr=config_mgr, apply_service=apply_service)
 tracker_capture = TrackerCaptureService(blah2_client, retina_tracker_client)
 
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -1365,6 +1365,8 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
     var lastStatus = null;
 
     var PHASE_LABELS = {
+        preflight: 'Checking the radio responds…',
+        recovering: 'Radio unresponsive — restarting it…',
         descending: 'Maximizing gain, backing off overload…',
         refining: 'Refining gain…',
         dwelling: 'Watching for aircraft…',
@@ -1455,6 +1457,31 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
             + 'has finished.</div>';
     }
 
+    // The preflight only reports when it had to intervene. A clean probe is
+    // unremarkable; a restart is not — it persisted maximum attenuation to
+    // the config, deliberately and without reverting it (see calibrator.py's
+    // module docstring), so the user has to be told what was replaced or
+    // their gain settings appear to have changed by themselves.
+    function preflightNotice(status) {
+        var pf = status.preflight;
+        if (!pf || !pf.restarted) return '';
+        var was = pf.previous
+            ? ' Its previous setting was gain reduction A ' + pf.previous.gain_a
+              + ' dB / B ' + pf.previous.gain_b + ' dB, LNA state '
+              + pf.previous.lna_state + ', which you can restore in the '
+              + 'Capture fields below.'
+            : '';
+        var lead = pf.recovered
+            ? 'The radio had stopped accepting tuning commands and was restarted.'
+            : 'The radio had stopped accepting tuning commands.';
+        return '<div style="margin-top:10px;padding:8px 10px;border-radius:6px;'
+            + 'background:oklch(0.96 0.04 85);border:1px solid var(--warn,#b7791f);'
+            + 'color:var(--warn,#b7791f);font-size:12.5px;">'
+            + '<strong>' + lead + '</strong> It has been set to maximum '
+            + 'attenuation (gain reduction 59/59, LNA state 9) and that has '
+            + 'been saved to the configuration.' + was + '</div>';
+    }
+
     function render(status) {
         lastStatus = status;
         setConfigLockedOut(status.state === 'running');
@@ -1491,7 +1518,7 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
             }
             // Warn the moment a deployment starts, not once the run has
             // already died of it.
-            var warnNow = updateWarning(status);
+            var warnNow = updateWarning(status) + preflightNotice(status);
             errorEl.style.display = warnNow ? '' : 'none';
             errorEl.innerHTML = warnNow;
             return;
@@ -1511,7 +1538,8 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
                 + mhz(status.result.fc) + ', gain reduction A ' + status.result.gain_a
                 + ' dB / B ' + status.result.gain_b + ' dB, LNA state ' + status.result.lna_state
                 + '.' + adsbNote
-                + '<br>The radar is running with this tuning now. Persist it to keep it after restarts.';
+                + '<br>The radar is running with this tuning now. Persist it to keep it after restarts.'
+                + preflightNotice(status);
             applyBtn.style.display = '';
         } else {
             phaseText.textContent = status.state === 'cancelled' ? 'Cancelled' : 'No calibration found';
@@ -1526,7 +1554,7 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
             // A deployment restarting the radar is the explanation, so lead
             // with it rather than leaving the per-tower failures to imply
             // something about the tuning or the sky.
-            errorEl.innerHTML += updateWarning(status);
+            errorEl.innerHTML += updateWarning(status) + preflightNotice(status);
             var diagnosis = diagnose(status.history || []);
             if (diagnosis) {
                 errorEl.innerHTML += '<div style="margin-top:8px;padding:8px 10px;'

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -13,6 +13,7 @@ auto-emit a confirmed-track event after `confirm_after` frames (None =
 never confirms), and reset() clears that count, mirroring the real
 sidecar's RESET wiping accumulated state between candidate towers.
 """
+import copy
 import json
 import os
 from datetime import datetime, timedelta
@@ -186,6 +187,12 @@ class FakeRetinaTrackerClient:
 
 
 ORIGINAL = {"fc": 98_000_000, "gain_a": 40, "gain_b": 41, "lna_state": 4}
+# Same tuning at a frequency no tower in these tests uses — for the cases
+# that script a retune failure at TOWER's own fc. The preflight probes at
+# whatever frequency the device is already on (see calibrator._preflight),
+# so starting there keeps such a script aimed at the tower it is about,
+# rather than at the preflight.
+ORIGINAL_ELSEWHERE = dict(ORIGINAL, fc=90_100_000)
 TOWER = {"name": "Tower One", "fc": 98_000_000}
 TOWER_TWO = {"name": "Tower Two", "fc": 105_100_000}
 TOWER_THREE = {"name": "Tower Three", "fc": 213_000_000}
@@ -573,8 +580,13 @@ class TestDeviceCrashHandling:
             retune_fail_rule=lambda fc, ga, gb, lna: fc == TOWER["fc"],
             detection=detection)
         tracker_client = FakeRetinaTrackerClient(confirm_after=1)
+        # Started from a frequency that still works, so the preflight's own
+        # safe-corner probe passes and the run actually reaches the towers.
+        # A device that cannot be tuned even where it already sits is a
+        # different fault, and _preflight ends the run on it deliberately —
+        # see TestPreflight.
         status = run_to_completion(Calibrator(client, tracker_client),
-                                   [TOWER, TOWER_TWO])
+                                   [TOWER, TOWER_TWO], original=ORIGINAL_ELSEWHERE)
         assert status["state"] == "done"
         assert status["result"]["tower_name"] == "Tower Two"
         assert len(status["history"]) == 2
@@ -1022,7 +1034,11 @@ class TestSafeFrequencyHandover:
         cal = Calibrator(client, FakeRetinaTrackerClient())
         run_to_completion(cal, [TOWER], dwell=0.05)
 
-        applied = client.applied
+        # applied[0] is the preflight's own safe-corner probe, which lands on
+        # the same tuning the first descent candidate then asks for. That
+        # duplicate is the liveness check, not a handover, so the search's
+        # own retunes are what this assertion is about.
+        applied = client.applied[1:]
         safe_corner = (GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX, LNA_STATE_MAX)
         # Only the descent's own legitimate visits to the safe corner should
         # appear — no consecutive duplicate pair from a spurious handover.
@@ -1045,7 +1061,11 @@ class TestSafeFrequencyHandover:
 
         client = FakeBlah2Client(retune_fail_rule=fail_handover)
         cal = Calibrator(client, FakeRetinaTrackerClient())
-        status = run_to_completion(cal, [TOWER, TOWER_TWO], dwell=0.05)
+        # Elsewhere to start with, so the failure scripted above is the
+        # handover into TOWER and not the preflight probe — see
+        # ORIGINAL_ELSEWHERE.
+        status = run_to_completion(cal, [TOWER, TOWER_TWO], dwell=0.05,
+                                   original=ORIGINAL_ELSEWHERE)
         # The run still reached a terminal state rather than erroring out.
         assert status["state"] in ("failed", "done")
         assert len(status["history"]) == 2
@@ -1271,27 +1291,283 @@ class TestAdsbMode:
         assert "Invalid mode" in error
 
 
+class FakeConfigManager:
+    """Stand-in for ConfigManager — only the two user.yml accessors the
+    preflight's recovery branch touches."""
+
+    def __init__(self, user_config=None):
+        self.user_config = copy.deepcopy(user_config) if user_config else {}
+        self.saves = 0
+
+    def load_user_config(self):
+        return copy.deepcopy(self.user_config)
+
+    def save_user_config(self, config):
+        self.user_config = copy.deepcopy(config)
+        self.saves += 1
+
+
+class FakeApplyService:
+    """Stand-in for ApplyService. request() returns immediately and
+    get_status() reports the scripted outcome, as the real one does.
+    on_request is how a test makes the radio start answering again — it
+    stands in for the restart actually reinitialising the device."""
+
+    def __init__(self, outcome="done", error=None, on_request=None):
+        self.requests = []
+        self._outcome = outcome
+        self._error = error
+        self._on_request = on_request
+        self._status = {"state": "idle", "error": None}
+
+    def request(self, bypass_guard=False):
+        self.requests.append({"bypass_guard": bypass_guard})
+        if self._on_request is not None:
+            self._on_request()
+        self._status = {"state": self._outcome, "error": self._error}
+        return dict(self._status)
+
+    def get_status(self):
+        return dict(self._status)
+
+
+def wedged_until_restart():
+    """A device that refuses every retune until an apply happens — the
+    live failure this preflight exists for. Returns (rule, clear) for
+    FakeBlah2Client's retune_fail_rule and FakeApplyService's on_request."""
+    wedged = {"still": True}
+    def rule(fc, gain_a, gain_b, lna_state):
+        return wedged["still"]
+    def clear():
+        wedged["still"] = False
+    return rule, clear
+
+
+@pytest.fixture
+def fast_preflight(fast, monkeypatch):
+    """`fast`, plus the preflight's own recovery timings."""
+    monkeypatch.setattr(calmod, "PREFLIGHT_RECOVERY_PROBE_SECONDS", 0.2)
+    monkeypatch.setattr(calmod, "PREFLIGHT_RECOVERY_APPLY_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(calmod, "PREFLIGHT_APPLY_POLL_SECONDS", 0.01)
+
+
+class TestPreflight:
+    """Before any tower is tried, the radio is parked at the safe corner and
+    proved to still accept tuning commands — and recovered by restart if it
+    doesn't. See calibrator._preflight."""
+
+    def test_healthy_device_is_parked_at_the_safe_corner_first(self, fast_preflight):
+        client = FakeBlah2Client()
+        config_mgr = FakeConfigManager()
+        apply_service = FakeApplyService()
+        cal = Calibrator(client, FakeRetinaTrackerClient(),
+                         config_mgr=config_mgr, apply_service=apply_service)
+        status = run_to_completion(cal, [TOWER], dwell=0.05)
+
+        first = client.applied[0]
+        assert (first["fc"], first["gain_a"], first["gain_b"], first["lna_state"]) == (
+            ORIGINAL["fc"], GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX, LNA_STATE_MAX)
+        # A healthy node pays for the probe and nothing else: no restart, no
+        # user.yml write, and nothing to report about it.
+        assert apply_service.requests == []
+        assert config_mgr.saves == 0
+        assert status["preflight"] is None
+
+    def test_probe_stays_on_the_frequency_the_device_is_actually_on(self, fast_preflight):
+        # blah2 left on another tower by an unpersisted earlier run while
+        # config still says ORIGINAL. Moving fc from an unknown gain is the
+        # hazard the safe corner exists to avoid, and the probe has nothing
+        # proven-safe to hand over from — so it must not move fc at all.
+        client = FakeBlah2Client()
+        client.generation = 7
+        client.applied.append({
+            "fc": TOWER_THREE["fc"], "gain_a": 30, "gain_b": 30, "lna_state": 2,
+            "generation": 7, "applied_at": 500})
+        cal = Calibrator(client, FakeRetinaTrackerClient(),
+                         config_mgr=FakeConfigManager(),
+                         apply_service=FakeApplyService())
+        run_to_completion(cal, [TOWER], dwell=0.05)
+
+        probe = client.applied[1]
+        assert probe["fc"] == TOWER_THREE["fc"]
+        assert (probe["gain_a"], probe["gain_b"], probe["lna_state"]) == (
+            GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX, LNA_STATE_MAX)
+
+    def test_wedged_device_is_recovered_and_the_run_proceeds(self, fast_preflight):
+        rule, clear = wedged_until_restart()
+        client = FakeBlah2Client(retune_fail_rule=rule,
+                                 detection=moving_track_detections())
+        config_mgr = FakeConfigManager(
+            {"capture": {"device": {"gainReduction": [30, 30], "lnaState": 2},
+                         "fc": ORIGINAL["fc"]}})
+        apply_service = FakeApplyService(on_request=clear)
+        cal = Calibrator(client, FakeRetinaTrackerClient(confirm_after=1),
+                         config_mgr=config_mgr, apply_service=apply_service)
+        status = run_to_completion(cal, [TOWER], dwell=3.0)
+
+        # The one apply this engine ever makes, and the one caller allowed
+        # past the config-change guard.
+        assert apply_service.requests == [{"bypass_guard": True}]
+        # The safe corner is written into user.yml so the restart brings
+        # blah2 up on it, without disturbing the rest of the section.
+        assert config_mgr.user_config["capture"]["device"] == {
+            "gainReduction": [GAIN_REDUCTION_MAX, GAIN_REDUCTION_MAX],
+            "lnaState": LNA_STATE_MAX}
+        assert config_mgr.user_config["capture"]["fc"] == ORIGINAL["fc"]
+        assert status["preflight"]["recovered"] is True
+        assert status["preflight"]["previous"] == ORIGINAL
+        # And having recovered it, the run did its actual job.
+        assert status["state"] == "done"
+
+    def test_unrecoverable_device_ends_the_run_before_any_tower(self, fast_preflight):
+        client = FakeBlah2Client(retune_fail_rule=lambda fc, ga, gb, lna: True)
+        config_mgr = FakeConfigManager()
+        apply_service = FakeApplyService()
+        cal = Calibrator(client, FakeRetinaTrackerClient(),
+                         config_mgr=config_mgr, apply_service=apply_service)
+        status = run_to_completion(cal, [TOWER, TOWER_TWO], dwell=0.05)
+
+        assert status["state"] == "failed"
+        # No tower was tried, so there is nothing to say about aircraft —
+        # which is the whole point. Before the preflight this ran all the
+        # way through, reported tuning_not_applied per tower, and led with
+        # "no aircraft was overhead".
+        assert status["history"] == []
+        assert "still not accepting tuning commands after a restart" in status["error"]
+        assert "maximum attenuation" in status["error"]
+        # It still tried, and it still left the device safe.
+        assert apply_service.requests == [{"bypass_guard": True}]
+        assert config_mgr.saves == 1
+        assert status["preflight"]["recovered"] is False
+
+    def test_failed_restart_is_reported_rather_than_swallowed(self, fast_preflight):
+        client = FakeBlah2Client(retune_fail_rule=lambda fc, ga, gb, lna: True)
+        apply_service = FakeApplyService(outcome="failed",
+                                         error="Command timed out")
+        cal = Calibrator(client, FakeRetinaTrackerClient(),
+                         config_mgr=FakeConfigManager(),
+                         apply_service=apply_service)
+        status = run_to_completion(cal, [TOWER], dwell=0.05)
+
+        assert status["state"] == "failed"
+        assert "restarting it failed" in status["error"]
+        assert "Command timed out" in status["error"]
+
+    def test_restart_that_never_finishes_gives_up(self, fast_preflight):
+        client = FakeBlah2Client(retune_fail_rule=lambda fc, ga, gb, lna: True)
+        # Never leaves 'running' — a restart that hung rather than failed.
+        apply_service = FakeApplyService(outcome="running")
+        cal = Calibrator(client, FakeRetinaTrackerClient(),
+                         config_mgr=FakeConfigManager(),
+                         apply_service=apply_service)
+        status = run_to_completion(cal, [TOWER], dwell=0.05)
+
+        assert status["state"] == "failed"
+        assert "did not finish in time" in status["error"]
+
+    def test_without_recovery_machinery_it_fails_fast(self, fast_preflight):
+        # No config_mgr/apply_service (dev mode, and every engine-level test
+        # above): the probe still runs and still ends the run honestly,
+        # there is just no restart to attempt.
+        client = FakeBlah2Client()
+        client.ack_enabled = False
+        status = run_to_completion(Calibrator(client, FakeRetinaTrackerClient()),
+                                   [TOWER], dwell=0.05)
+
+        assert status["state"] == "failed"
+        assert status["history"] == []
+        assert "Restart the radar services and try again" in status["error"]
+
+    def test_cancel_after_a_recovery_does_not_restore_the_wedging_tuning(
+            self, fast_preflight):
+        # The original tuning is what the radio was stuck on. Putting a
+        # just-recovered device back on it is the one move guaranteed to
+        # undo the recovery, so a recovered run skips the restore entirely.
+        import time as _time
+        rule, clear = wedged_until_restart()
+        client = FakeBlah2Client(retune_fail_rule=rule)
+        cal = Calibrator(client, FakeRetinaTrackerClient(),
+                         config_mgr=FakeConfigManager(),
+                         apply_service=FakeApplyService(on_request=clear))
+        started, error = cal.start([TOWER], ORIGINAL, budget_seconds=30,
+                                   dwell_seconds=30)
+        assert started, error
+        deadline = _time.monotonic() + 5
+        while _time.monotonic() < deadline:
+            if cal.get_status()["phase"] == "dwelling":
+                break
+            _time.sleep(0.01)
+        cal.cancel()
+        cal._thread.join(timeout=10)
+        status = cal.get_status()
+
+        assert status["state"] == "cancelled"
+        assert status["preflight"]["recovered"] is True
+        assert (client.current["gain_a"], client.current["gain_b"],
+                client.current["lna_state"]) != (
+            ORIGINAL["gain_a"], ORIGINAL["gain_b"], ORIGINAL["lna_state"])
+
+    def test_recovery_time_is_not_charged_to_the_search_budget(
+            self, fast, monkeypatch):
+        # A recovery restart can take ~90s. Starting the budget clock before
+        # it would silently shorten every tower's dwell on a node that was
+        # already having a bad day.
+        monkeypatch.setattr(calmod, "PREFLIGHT_RECOVERY_PROBE_SECONDS", 0.2)
+        monkeypatch.setattr(calmod, "PREFLIGHT_RECOVERY_APPLY_TIMEOUT_SECONDS", 5.0)
+        monkeypatch.setattr(calmod, "PREFLIGHT_APPLY_POLL_SECONDS", 0.05)
+        rule, clear = wedged_until_restart()
+        client = FakeBlah2Client(retune_fail_rule=rule)
+
+        polls = {"n": 0}
+        apply_service = FakeApplyService(on_request=clear)
+        real_get_status = apply_service.get_status
+        def slow_get_status():
+            polls["n"] += 1
+            # 'running' for the first few polls, i.e. a restart that took
+            # a meaningful slice of the budget below.
+            if polls["n"] <= 10:
+                return {"state": "running", "error": None}
+            return real_get_status()
+        apply_service.get_status = slow_get_status
+
+        cal = Calibrator(client, FakeRetinaTrackerClient(),
+                         config_mgr=FakeConfigManager(),
+                         apply_service=apply_service)
+        status = run_to_completion(cal, [TOWER, TOWER_TWO], budget=1.5,
+                                   dwell=None)
+
+        assert status["preflight"]["recovered"] is True
+        # Both towers still got looked at, rather than the second being
+        # eaten by time spent restarting before the search began.
+        assert status["progress"]["towers_tried"] == 2
+        assert [h["outcome"] for h in status["history"]] == [
+            "no_confirmed_track", "no_confirmed_track"]
+
+
 class TestFailureModes:
     def test_unreachable_blah2_fails_the_run(self, fast):
-        # A permanently broken retune is now folded into the same
-        # overload-handling path as a device wedge (see _probe/_safe_revert)
-        # rather than aborting the run outright — this tower can never
-        # confirm anything, so the run still correctly ends "failed", just
-        # via the ordinary no-track path rather than surfacing "Retune
-        # failed" directly. history[0]["device_error"] is what now proves
-        # blah2 was genuinely unreachable, not just "no aircraft."
+        # A radio that takes no retune at all is caught by the preflight
+        # before any tower is tried (see calibrator._preflight). It used to
+        # be folded into the per-candidate overload path, so the run walked
+        # all three towers, recorded tuning_not_applied on each, and
+        # finished behind a summary message about no aircraft being
+        # overhead — the exact confusion the preflight exists to remove.
+        # No history at all is the point: nothing was watched, so there is
+        # nothing to report about it.
         client = FakeBlah2Client()
         client.retune_error = "connection refused"
         status = run_to_completion(Calibrator(client, FakeRetinaTrackerClient()), [TOWER])
         assert status["state"] == "failed"
-        assert status["history"][0]["device_error"] is True
+        assert status["history"] == []
+        assert "not accepting tuning commands" in status["error"]
 
     def test_missing_ack_fails_the_run(self, fast):
         client = FakeBlah2Client()
         client.ack_enabled = False
         status = run_to_completion(Calibrator(client, FakeRetinaTrackerClient()), [TOWER])
         assert status["state"] == "failed"
-        assert status["history"][0]["device_error"] is True
+        assert status["history"] == []
+        assert "not accepting tuning commands" in status["error"]
 
     def test_missing_rf_status_fails_the_run(self, fast):
         client = FakeBlah2Client(detection=moving_track_detections())

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -491,6 +491,125 @@ class TestNoSelfDeadlock:
             assert result['error'] is None
 
 
+class TestRestartSdrplayService:
+    """A wedged SDRplay device leaves sdrplay.service hanging in
+    `deactivating (stop-sigterm)`, so `systemctl restart` never returns.
+    Confirmed live on jonathan-node-2 against a genuinely wedged RSPduo: the
+    bare subprocess call this replaces timed out, TimeoutExpired escaped
+    run_config_merger_and_restart into ApplyService as 'Command timed out',
+    and the container recreate never ran — aborting the one path that can
+    recover the device. See restart_sdrplay_service."""
+
+    @patch('subprocess.run')
+    def test_clean_restart_needs_no_force(self, mock_run):
+        import routes.mode as mode_module
+        mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+
+        assert mode_module.restart_sdrplay_service() is None
+        assert mock_run.call_count == 1
+        assert mock_run.call_args_list[0][0][0] == [
+            'systemctl', 'restart', 'sdrplay.service']
+
+    @patch('subprocess.run')
+    def test_hung_restart_is_forced_down_rather_than_raising(
+            self, mock_run, monkeypatch):
+        import routes.mode as mode_module
+        monkeypatch.setattr(mode_module.time, 'sleep', lambda s: None)
+
+        def fake_run(argv, **kwargs):
+            if argv[:2] == ['systemctl', 'restart']:
+                raise subprocess.TimeoutExpired(argv, 30)
+            return MagicMock(returncode=0, stdout='', stderr='')
+        mock_run.side_effect = fake_run
+
+        # The whole point: it reports rather than raising, so the caller's
+        # container recreate still runs.
+        detail = mode_module.restart_sdrplay_service()
+        assert detail is not None
+        assert 'hung' in detail
+
+        argvs = [c[0][0] for c in mock_run.call_args_list]
+        assert ['systemctl', 'restart', 'sdrplay.service'] in argvs
+        assert ['pkill', '-9', '-f', '[s]drplay_apiService'] in argvs
+        assert ['systemctl', 'reset-failed', 'sdrplay.service'] in argvs
+        assert ['systemctl', 'start', 'sdrplay.service'] in argvs
+
+    @patch('subprocess.run')
+    def test_kill_pattern_uses_f_and_cannot_self_match(self, mock_run,
+                                                       monkeypatch):
+        """-x matches the kernel's comm field, truncated to 15 chars, so the
+        18-char name never matches — that is why blah2-arm's own
+        sdrplay-restart.sh is a silent no-op. And the pattern is bracketed so
+        it cannot match a shell command line merely carrying it: the
+        unbracketed form run over ssh kills the invoking session."""
+        import routes.mode as mode_module
+        monkeypatch.setattr(mode_module.time, 'sleep', lambda s: None)
+
+        def fake_run(argv, **kwargs):
+            if argv[:2] == ['systemctl', 'restart']:
+                raise subprocess.TimeoutExpired(argv, 30)
+            return MagicMock(returncode=0, stdout='', stderr='')
+        mock_run.side_effect = fake_run
+        mode_module.restart_sdrplay_service()
+
+        kill = next(c[0][0] for c in mock_run.call_args_list
+                    if c[0][0][0] == 'pkill')
+        assert '-f' in kill and '-x' not in kill
+        pattern = kill[-1]
+        assert pattern.startswith('[s]')
+        # A command line carrying the bracketed pattern must not match it.
+        import re
+        assert not re.search(pattern, f'bash -c pkill -9 -f {pattern}')
+        # ...while the real service process still does.
+        assert re.search(pattern, '/opt/sdrplay_api/sdrplay_apiService')
+
+    @patch('subprocess.run')
+    def test_missing_systemd_is_a_silent_no_op(self, mock_run):
+        """Dev machines have no sdrplay.service and must not be forced."""
+        import routes.mode as mode_module
+        mock_run.side_effect = FileNotFoundError()
+
+        assert mode_module.restart_sdrplay_service() is None
+        assert mock_run.call_count == 1
+
+    @patch('subprocess.run')
+    def test_forced_reset_failing_still_does_not_raise(self, mock_run,
+                                                      monkeypatch):
+        import routes.mode as mode_module
+        monkeypatch.setattr(mode_module.time, 'sleep', lambda s: None)
+
+        def fake_run(argv, **kwargs):
+            raise subprocess.TimeoutExpired(argv, 30)
+        mock_run.side_effect = fake_run
+
+        detail = mode_module.restart_sdrplay_service()
+        assert 'forced reset also failed' in detail
+
+    @patch('subprocess.run')
+    def test_apply_completes_the_recreate_despite_a_hung_restart(
+            self, mock_run, app_client, temp_dir, monkeypatch):
+        """The regression this exists for, at the level that actually
+        mattered: the recreate must still happen."""
+        import routes.mode as mode_module
+        monkeypatch.setattr(mode_module, 'SDRPLAY_RESTART_SETTLE_SECONDS', 0)
+        monkeypatch.setattr(mode_module.time, 'sleep', lambda s: None)
+
+        def fake_run(argv, **kwargs):
+            if argv[:2] == ['systemctl', 'restart']:
+                raise subprocess.TimeoutExpired(argv, 30)
+            return MagicMock(returncode=0, stdout='', stderr='')
+        mock_run.side_effect = fake_run
+
+        phases = []
+        error = mode_module.run_config_merger_and_restart(
+            temp_dir, on_phase=lambda phase, detail=None: phases.append(phase))
+
+        assert error is None
+        assert 'resetting_sdr' in phases
+        assert any('--force-recreate' in c[0][0]
+                   for c in mock_run.call_args_list), "never recreated"
+
+
 class TestRestartSettleTime:
     """run_config_merger_and_restart() is the shared choke point every
     config-applying/mode-switching route funnels through (/api/mode,


### PR DESCRIPTION
## The problem

An Auto-Calibrate run against a radio that had stopped accepting retunes was near-invisible: every tower came back `tuning_not_applied`, and the whole run died in **30-60 seconds** behind a summary message about there being no aircraft overhead. The user hitting this had no way to tell a tuning problem from a dead radio.

## Two parts

**1. `Calibrator._preflight()`** — runs before the budget clock starts.

One retune to the safe corner (59, 59, LNA 9) at the frequency blah2 is *actually* on. Attenuation only ever increases, so it is safe from any starting point, and it does two jobs: parks the radio at its least sensitive setting before any candidate is tried, and proves the SDRplay API still answers control calls.

It has to be a retune. `/capture/overload-status` freshness was the obvious cheaper check and is wrong — `get_overload()` only reads atomics, so it looks perfectly healthy on a dead device nobody has asked to retune yet.

If the ack never comes, the device is wedged and a live retune cannot rescue it: once the SDRplay API returns `ServiceNotResponding` it keeps doing so. So the preflight writes the safe corner to `user.yml`, runs the ordinary config-apply path, and re-probes. If it never answers, the run is abandoned before any tower, naming the real fault.

**2. `restart_sdrplay_service()` in `routes/mode.py`** — replaces four bare `systemctl restart sdrplay.service` calls.

On a wedged device the unit hangs in `deactivating (stop-sigterm)` because `sdrplay_apiService` ignores SIGTERM. The 30s timeout escaped `run_config_merger_and_restart` as `'Command timed out'` and **the container recreate never ran** — aborting the one path that can recover the device. It now forces the service down (`pkill -9 -f`, `reset-failed`, `start`) and never raises.

## Live verification (jonathan-node-2, real RSPduo)

A wedge was induced deliberately with `gainReduction [20,20]` / `lnaState 1` at 213 MHz, reproducing `[RspDuo] MaxDevs=1023 NumDevs=0 / Error: No devices found` with blah2 crash-looping.

| Scenario | Result |
|---|---|
| Healthy device | preflight ~0.75s, first retune `(213 MHz, 59, 59, lna 9)`, `preflight: null`, no restart, no config write |
| Real wedge, before part 2 | detection/reporting correct, but recovery failed — recreate never ran |
| Real wedge, after part 2 | `restarting_sdr` → `resetting_sdr` → settling → **recreating** → `recovered: true` → descent, **~87s** |

After recovery: blah2 stable, zero `No devices found`, live retunes acking, real detections flowing.

## Worth a reviewer's attention

- **`pkill -9` now sits on a path every config apply and mode switch uses**, not just calibration. It only fires when the normal restart has already timed out or failed.
- **`ApplyService.request(bypass_guard=True)`** is a deliberate hole in the guard that stops config applies during a calibration. One caller: the preflight, which *is* the running calibration and holds the lock itself.
- **The `user.yml` write breaks the engine's "nothing writes user.yml during a run" rule, deliberately, and is not reverted.** It only happens on a device that was already unresponsive, where maximum attenuation is a working state rather than a degraded one. This is what let the node come back healthy in testing — on the wedging values it would have re-looped. For the same reason a recovered run never restores the original tuning.
- **Timing is bounded, not chosen.** The preflight runs ahead of `TOTAL_BUDGET_SECONDS`, so 180 + 60 + 900 = 1140 against the 1200s `CALIBRATE_LOCK_TIMEOUT` in this repo *and* blah2-arm's watchdog. Raising either constant without lowering the budget spends that margin.
- **`pkill` uses `-f` with a bracketed pattern.** `-x` matches the kernel's 15-char `comm` field so the 18-char name never matches — that bug is why blah2-arm's own `sdrplay-restart.sh` is a silent no-op. The brackets stop it matching a shell command line that merely carries the pattern.

## Not verified

Multi-tower runs (all live tests used `scope: "current_tower"`), MODE_ADSB (route-blocked), cancellation mid-restore, and wedges where USB itself de-enumerates — both induced wedges kept the device visible, so the unbind/rebind path was never exercised.

## Tests

478 pass; 15 new (9 `TestPreflight`, 6 `TestRestartSdrplayService`), 5 existing adjusted — three of those were asserting the old misleading behaviour. `ruff check` and `tools/check-dead-code.sh` both clean. The 7 remaining failures are pre-existing on `main` and unrelated (mender dev-tag loosening, towers tests hitting the live network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)