### PR TITLE
Fix the seven failing tests — including a live OTA bug the suite was already catching

### DIFF
--- a/src/mender.py
+++ b/src/mender.py
@@ -354,12 +354,11 @@ def get_latest_stable_from_github(
 def parse_os_version(tag: str) -> tuple[int, ...] | None:
     """Extract semver tuple from owl-os version strings.
 
-    Handles formats: 'os-v0.1.0', 'v0.1.0', '0.1.0',
-    and pre-release variants like 'os-v0.1.0-dev', 'v0.1.0-rc1'.
-    Returns the numeric version tuple (0, 1, 0) — suffix is ignored for comparison.
-    Returns None for non-matching strings.
+    Handles formats: 'os-v0.1.0', 'v0.1.0', '0.1.0'.
+    Returns version tuple (0, 1, 0) for stable releases.
+    Returns None for RCs, dev, or non-matching strings.
     """
-    match = re.match(r"^(?:os-)?v?(\d+)\.(\d+)\.(\d+)(?:[-.].+)?$", tag)
+    match = re.match(r"^(?:os-)?v?(\d+)\.(\d+)\.(\d+)$", tag)
     if match:
         return tuple(int(x) for x in match.groups())
     return None
@@ -374,14 +373,15 @@ _owl_os_release_cache: dict[str, tuple[float, tuple[str | None, str | None]]] = 
 def get_latest_owl_os_from_github(
     repo: str = "offworldlabs/owl-os",
 ) -> tuple[str | None, str | None]:
-    """Get latest owl-os version tag from GitHub releases.
+    """Get latest stable owl-os version tag from GitHub releases.
 
-    Queries GitHub releases API, includes both stable and pre-release builds
-    (tags matching os-v*.*.*[-suffix]), and returns the highest semver version.
+    Queries GitHub releases API, filters to stable versions
+    (tags matching os-v*.*.*), and returns the highest semver version.
+    Pre-releases are excluded: a device offered an -rc or -dev image as its
+    "latest" would be updated onto an untested build.
     Result (including errors) is cached for _OWL_OS_RELEASE_CACHE_TTL seconds.
 
-    Returns (version_tag, error) tuple. version_tag is like 'os-v0.2.0' or
-    'os-v0.2.1-dev'.
+    Returns (version_tag, error) tuple. version_tag is like 'os-v0.2.0'.
     """
     cached = _owl_os_release_cache.get(repo)
     if cached and time.monotonic() - cached[0] < _OWL_OS_RELEASE_CACHE_TTL:
@@ -396,20 +396,20 @@ def get_latest_owl_os_from_github(
         if resp.status_code != 200:
             result = None, f"GitHub API error: {resp.status_code}"
         else:
-            found = []
+            stable = []
             for release in resp.json():
                 tag = release.get("tag_name", "")
                 if not tag.startswith("os-v"):
                     continue
                 version = parse_os_version(tag)
                 if version:
-                    found.append((tag, version))
+                    stable.append((tag, version))
 
-            if not found:
-                result = None, "No owl-os releases found"
+            if not stable:
+                result = None, "No stable owl-os releases found"
             else:
-                found.sort(key=lambda x: x[1], reverse=True)
-                result = found[0][0], None
+                stable.sort(key=lambda x: x[1], reverse=True)
+                result = stable[0][0], None
     except requests.RequestException as e:
         result = None, str(e)
 

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -45,14 +45,14 @@ SAMPLE_TOWER_RESPONSE = {
 class TestTowerSearch:
     """Tests for POST /towers/search proxy route."""
 
-    @patch('routes.towers.http_requests.post')
-    def test_search_returns_towers(self, mock_post, app_client):
+    @patch('routes.towers.http_requests.get')
+    def test_search_returns_towers(self, mock_get, app_client):
         """Proxy returns tower data from Tower-Finder API."""
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = SAMPLE_TOWER_RESPONSE
         mock_resp.raise_for_status.return_value = None
-        mock_post.return_value = mock_resp
+        mock_get.return_value = mock_resp
 
         resp = app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
         assert resp.status_code == 200
@@ -60,8 +60,8 @@ class TestTowerSearch:
         assert data['count'] == 1
         assert data['towers'][0]['callsign'] == 'ATN6'
 
-        mock_post.assert_called_once()
-        assert '/api/towers' in mock_post.call_args[0][0]
+        mock_get.assert_called_once()
+        assert '/api/towers' in mock_get.call_args[0][0]
 
     def test_search_missing_body(self, app_client):
         """Returns 400 when request body is missing."""
@@ -73,38 +73,40 @@ class TestTowerSearch:
         resp = app_client.post('/towers/search', json={'lat': -33.8688})
         assert resp.status_code == 400
 
-    @patch('routes.towers.http_requests.post')
-    def test_search_timeout(self, mock_post, app_client):
+    @patch('routes.towers.http_requests.get')
+    def test_search_timeout(self, mock_get, app_client):
         """Returns 504 on timeout."""
         import requests
-        mock_post.side_effect = requests.Timeout()
+        mock_get.side_effect = requests.Timeout()
 
         resp = app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
         assert resp.status_code == 504
         data = json.loads(resp.data)
         assert 'timed out' in data['error'].lower()
 
-    @patch('routes.towers.http_requests.post')
-    def test_search_upstream_error(self, mock_post, app_client):
+    @patch('routes.towers.http_requests.get')
+    def test_search_upstream_error(self, mock_get, app_client):
         """Returns 502 when Tower-Finder API is unreachable."""
         import requests
-        mock_post.side_effect = requests.ConnectionError()
+        mock_get.side_effect = requests.ConnectionError()
 
         resp = app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
         assert resp.status_code == 502
 
-    @patch('routes.towers.http_requests.post')
-    def test_search_forwards_body(self, mock_post, app_client):
+    @patch('routes.towers.http_requests.get')
+    def test_search_forwards_body(self, mock_get, app_client):
         """Forwards entire JSON body to Tower-Finder API."""
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"towers": [], "count": 0}
         mock_resp.raise_for_status.return_value = None
-        mock_post.return_value = mock_resp
+        mock_get.return_value = mock_resp
 
         body = {'lat': 38.9, 'lon': -77.0, 'altitude': 50, 'limit': 10, 'source': 'us', 'radius_km': 100}
         app_client.post('/towers/search', json=body)
 
-        forwarded = mock_post.call_args[1]['json']
+        # The plain (no-measurements) search forwards via query params on a GET;
+        # the JSON-body form is the measurement-enriched POST branch.
+        forwarded = mock_get.call_args[1]['params']
         assert forwarded['lat'] == 38.9
         assert forwarded['lon'] == -77.0
         assert forwarded['altitude'] == 50


### PR DESCRIPTION
Part of [86cb4jfk7](https://app.clickup.com/t/86cb4jfk7). This repo's suite has never run in CI ([86cb43xya](https://app.clickup.com/t/86cb43xya) switched four other repos on; this one was out of scope). Running it gives **478 passed, 7 failed**.

The seven turn out to have **two unrelated causes**, needing opposite fixes.

## 1. Four mender failures — the tests were right, the code has a live bug

```
6204888 (2026-06-14) "Temp inclusion of -dev tagged releases in the check
                      to test these changes without making a stable release."
```

That commit made `parse_os_version` accept `-rc`/`-dev` tags and had `get_latest_owl_os_from_github` rank them alongside stable ones, rewriting the docstrings to match. **It has been live for two months**, so the GUI has been offering release candidates and dev builds to devices as the latest *stable* OS.

The four tests asserting the original behaviour date from February and March. They have been failing ever since, unnoticed, because nothing ran them.

Reverted. **No test changes were needed** — they were correct.

## 2. Three tower-search failures — tests predate a new code branch

`routes/towers.py` picks its method by payload: `POST` when the body has `measurements` (the enriched search), `GET` otherwise. Four tests patched `http_requests.post` while sending no measurements, so the mock never applied and **the real request escaped to production**:

```
WARNING  Tower search failed: 500 Server Error for url:
         https://tower-finder.retina.fm/api/towers?lat=-33.8688&lon=151.2093
```

Three failed on the resulting 502. The fourth, `test_search_upstream_error`, **passed** — it expects a 502, and the genuine failure produced one. Green for entirely the wrong reason, so it is fixed here too even though it was not red.

Repointed at `.get`; `test_search_forwards_body` now asserts the query params the GET branch sends rather than a JSON body.

## Verification

- **485 passed, 0 failed** (was 478/7)
- **Zero live-endpoint calls** across the whole suite — previously the tower tests hit `tower-finder.retina.fm` on every run, including from developer machines

## Known gap, pre-existing

Nothing covers the measurement-enriched `POST` branch. It had no coverage before either — the tests that appeared to exercise it were silently taking the `GET` path. Worth a follow-up rather than smuggling new tests into a fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZcazeseXVpu8XrYA2tE1V