### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,13 @@ jobs:
 
       - name: Dead code
         run: pre-commit run --all-files --show-diff-on-failure
+
+      # pytest is not in requirements.txt — that file is the runtime dependency
+      # set for the device image, and pytest has no business shipping there.
+      - run: pip install -r requirements.txt 'pytest>=8.0'
+
+      # pytest.ini supplies testpaths=tests and pythonpath=src, so no arguments
+      # are needed here. This suite had never run in CI until 86cb4jfk7; the
+      # four mender tests it now protects had been failing for two months.
+      - name: Tests
+        run: pytest


### PR DESCRIPTION
Second half of [86cb4jfk7](https://app.clickup.com/t/86cb4jfk7). [#61](https://github.com/offworldlabs/retina-gui/pull/61) fixed the seven failing tests; this makes them load-bearing.

## Why this matters more than it sounds

This repo has **485 tests that have never run in CI**. Two things followed directly from that:

- Commit `6204888` — *"**Temp** inclusion of -dev tagged releases"* — survived **two months** while four tests contradicted it. The GUI was offering release candidates to devices as the latest stable OS the whole time.
- The tower-search tests were making **real requests to `tower-finder.retina.fm`** on every run, because their mocks patched a branch the code no longer took. Nobody saw the warnings.

Both were found by running the suite once. Neither could recur with this step in place.

## The change

```yaml
      - run: pip install -r requirements.txt 'pytest>=8.0'
      - name: Tests
        run: pytest
```

`pytest.ini` already supplies `testpaths=tests` and `pythonpath=src`, so no arguments are needed. pytest is installed alongside `requirements.txt` rather than added to it — that file is the runtime dependency set for the device image, and test tooling has no business shipping there.

## Cost

**~3m50s** added to the job, which roughly quadruples its runtime. Stated plainly because it is a real trade: the alternative is a suite that provides no signal, which is what the two bugs above cost.

## Verification

Ran the exact CI commands in a clean venv from a pristine checkout: **485 passed**, exit 0. Also confirmed `pytest` exits non-zero if its path breaks, so a misconfigured step fails loudly rather than reporting a silent pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZcazeseXVpu8XrYA2tE1V