### PR TITLE
Let nodes register: consent records, a 32-char name cap, and the telemetry status card

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -23,6 +23,7 @@ from services import (  # noqa: F401  (re-exported for routes)
     RETINA_TRACKER_EVENTS_PATH,
     RETINA_TRACKER_HOST,
     RETINA_TRACKER_PORT,
+    TELEMETRY_STATUS_PATH,
     TOWER_FINDER_URL,
     USER_CONFIG_PATH,
     apply_service,
@@ -34,6 +35,7 @@ from services import (  # noqa: F401  (re-exported for routes)
     network_mgr,
     retina_tracker_client,
     ssh_keys,
+    telemetry_status,
     tracker_capture,
 )
 

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -21,6 +21,12 @@ from pydantic import VERSION, BaseModel, Field
 # Detect Pydantic version for Field() syntax
 PYDANTIC_V2 = VERSION.startswith("2.")
 
+# Transmitter names travel to the server as retina-telemetry's `tx_callsign`,
+# which the node-ingest spec caps at 32. Tower-Finder never returns anything
+# near it — the only way to exceed it is a hand-typed name, either in the
+# config form or the manual Add Tower dialog, so both are checked against this.
+TX_NAME_MAX_LENGTH = 32
+
 
 # ============================================================================
 # Config File Loading
@@ -147,7 +153,10 @@ class LocationFormConfig(BaseModel):
     tx_latitude: float = Field(ge=-90, le=90, title="Transmitter Latitude", description="decimal degrees")
     tx_longitude: float = Field(ge=-180, le=180, title="Transmitter Longitude", description="decimal degrees")
     tx_altitude: float = Field(title="Transmitter Altitude", description="meters")
-    tx_name: str = Field(title="Transmitter Name", description="location name")
+    # 32 chars is retina-telemetry's tx_callsign limit, not a display concern:
+    # a longer name means it cannot build a NodeConfig, so registration and
+    # every config resend fail and the node never reaches the server.
+    tx_name: str = Field(max_length=TX_NAME_MAX_LENGTH, title="Transmitter Name", description="location name")
 
 
 # ============================================================================

--- a/src/device_state.py
+++ b/src/device_state.py
@@ -18,12 +18,30 @@ import os
 import shutil
 import subprocess
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 INSTALL_LOCK_TIMEOUT = timedelta(minutes=40)
 MENDER_STATUS_TIMEOUT = timedelta(hours=2)
 SETUP_WIZARD_TIMEOUT = timedelta(hours=24)
 CALIBRATE_LOCK_TIMEOUT = timedelta(minutes=20)
+
+# Identifies the terms the owner was actually shown, so it is possible later to
+# say what a given owner agreed to. It must change whenever that text changes,
+# and "that text" is the whole agreements screen — the two checkbox labels in
+# templates/setup/_agreements.html as much as templates/eula.html, because the
+# publication disclosure lives in the checkbox wording rather than in the EULA.
+# A version that does not move when the wording does makes the record a lie.
+#
+# Deferred deliberately: nothing re-prompts an owner whose stored version is
+# older than this one. Changing the text today leaves existing nodes holding
+# their original record, which is correct but silent.
+TELEMETRY_CONSENT_VERSION = "2026-08-15"
+
+# What publication means here. Publishing is a condition of participation
+# rather than a choice, so there is no UI for it — see the disclosure in the
+# agreements step, which is what makes recording this honest. The wire supports
+# "private", so making it optional later is a UI change and nothing more.
+TELEMETRY_PUBLICATION_CHOICE = "public"
 
 
 class DeviceState:
@@ -49,6 +67,10 @@ class DeviceState:
         self.setup_wizard_completed_flag = os.path.join(data_dir, "setup-wizard-completed")
         self.calibrate_lock_file = os.path.join(data_dir, "calibrate.lock")
         self.towers_cache_file = os.path.join(data_dir, "towers-cache.json")
+        # Read by the retina-telemetry container, which refuses to register
+        # without it. The path is a cross-repo contract, not an internal
+        # detail — see save_telemetry_consent.
+        self.telemetry_consent_file = os.path.join(data_dir, "telemetry-consent.json")
         self.dev_mode = dev_mode
 
     # ── State Queries ──────────────────────────────────────────
@@ -387,6 +409,72 @@ class DeviceState:
         os.makedirs(os.path.dirname(self.setup_wizard_file), exist_ok=True)
         with open(self.setup_wizard_file, "w") as f:
             json.dump(data, f)
+
+    # ── Telemetry consent ──────────────────────────────────────
+
+    def get_telemetry_consent(self) -> dict | None:
+        """Read the recorded consent, or None if nothing was ever recorded."""
+        if not os.path.exists(self.telemetry_consent_file):
+            return None
+        try:
+            with open(self.telemetry_consent_file) as f:
+                consent = json.load(f)
+        except (OSError, ValueError):
+            return None
+        return consent if isinstance(consent, dict) else None
+
+    def save_telemetry_consent(self, version=TELEMETRY_CONSENT_VERSION):
+        """Record that the owner accepted the terms.
+
+        Writes the three records retina-telemetry requires — it refuses to
+        register without all three and will never write a default of its own,
+        because a record it invented would claim an owner agreed to something
+        they were never shown. That discipline only holds if this end never
+        writes one speculatively either: call this from the agreements step and
+        nowhere else.
+
+        Shape mirrors the wire's `Agreements` object one-for-one, so there is
+        no translation to get wrong between what the owner saw and what the
+        server is told.
+
+        `accepted_at` is timezone-aware on purpose. The wire types it
+        `AwareDatetime`, so a naive timestamp is rejected at the boundary and
+        the node silently never registers — and every other timestamp in this
+        class uses a naive `datetime.now()`, which makes copying the
+        surrounding idiom the natural way to break it.
+
+        Re-accepting the same version preserves the original `accepted_at`: the
+        record answers "when did they agree to this text", and a wizard re-run
+        that shows unchanged wording has not produced a new agreement. A
+        changed version is a genuine re-acceptance and re-dates all three.
+        """
+        existing = self.get_telemetry_consent() or {}
+        accepted_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        if existing.get("licence", {}).get("version") == version:
+            accepted_at = existing["licence"].get("accepted_at", accepted_at)
+
+        record = {"version": version, "accepted_at": accepted_at}
+        self._write_json_atomically(self.telemetry_consent_file, {
+            "licence": dict(record),
+            "remote_management": dict(record),
+            "publication": {**record, "choice": TELEMETRY_PUBLICATION_CHOICE},
+        })
+
+    def _write_json_atomically(self, path, payload):
+        """Write JSON via a temp file and a rename.
+
+        A half-written consent file reads as "not accepted" to
+        retina-telemetry, so the node goes quiet and looks like a telemetry
+        bug rather than an interrupted write.
+        """
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        temporary = path + ".tmp"
+        with open(temporary, "w") as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temporary, path)
 
     def clear_setup_wizard(self):
         """Clear wizard state (called on completion)."""

--- a/src/routes/home.py
+++ b/src/routes/home.py
@@ -8,7 +8,7 @@ bp = Blueprint('home', __name__)
 @bp.route("/")
 def index():
     """Home page with node ID, services, and SSH keys."""
-    from app import config_mgr, device_state, get_node_id, mender, ssh_keys
+    from app import config_mgr, device_state, get_node_id, mender, ssh_keys, telemetry_status
 
     if device_state.is_setup_wizard_in_progress():
         return redirect('/set-up')
@@ -27,12 +27,20 @@ def index():
     rx = location.get('rx', {}) or {}
     rx_name = rx.get('name', '')
 
+    # None when the telemetry package isn't installed, which is not a fault —
+    # the card is simply absent. See telemetry_status.py.
+    telemetry = telemetry_status.read()
+
     if request.args.get('demo') == '1':
         retina_node_version = retina_node_version or '0.9.0-demo'
         setup_needed = False
         setup_in_progress = False
         tx_name = tx_name or 'KPIX — 706 MHz UHF'
         rx_name = rx_name or 'San Francisco, CA'
+        telemetry = telemetry or {
+            'state': 'streaming', 'detail': None, 'node_ref': 'nde4f2k9xq7m3b8',
+            'node_id': node_id, 'stale': False, 'written_at': None,
+        }
 
     return render_template("index.html",
                            ssh_keys=keys,
@@ -43,6 +51,7 @@ def index():
                            setup_in_progress=setup_in_progress,
                            tx_name=tx_name,
                            rx_name=rx_name,
+                           telemetry=telemetry,
                            mode=get_current_mode())
 
 

--- a/src/routes/setup.py
+++ b/src/routes/setup.py
@@ -48,6 +48,26 @@ def save_step():
     return jsonify({"success": True})
 
 
+@bp.route("/set-up/consent", methods=["POST"])
+def consent():
+    """Record acceptance of the terms shown on the agreements step.
+
+    Deliberately posted from that step rather than at wizard completion. Every
+    node already in the field has completed the wizard and will never see it
+    again, so re-running /set-up is the re-consent path — and writing here
+    means an owner can tick, continue, and close the tab without going through
+    the location and tower steps or the docker work /set-up/complete triggers.
+
+    retina-telemetry re-reads the file on every state derivation rather than
+    caching it at startup, so this takes effect within seconds and needs no
+    restart or ordering with that container.
+    """
+    from app import device_state
+
+    device_state.save_telemetry_consent()
+    return jsonify({"success": True})
+
+
 @bp.route("/set-up/complete", methods=["POST"])
 def complete():
     """Mark setup wizard as complete."""

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -4,7 +4,7 @@ from pydantic import ValidationError
 
 from apply_service import ConfigChangeRefused
 from config_manager import ConfigManager
-from config_schema import LocationFormConfig
+from config_schema import TX_NAME_MAX_LENGTH, LocationFormConfig
 
 bp = Blueprint('towers', __name__, url_prefix='/towers')
 
@@ -105,6 +105,14 @@ def cache_add():
 
     if not callsign:
         return jsonify({"success": False, "error": "Name/callsign is required"}), 400
+    # Caught here as well as in LocationFormConfig so the rejection lands on the
+    # field the operator is typing into, rather than later when the tower is
+    # selected and the whole location block fails to validate.
+    if len(callsign) > TX_NAME_MAX_LENGTH:
+        return jsonify({
+            "success": False,
+            "error": f"Name/callsign must be {TX_NAME_MAX_LENGTH} characters or fewer",
+        }), 400
     if not (-90 <= latitude <= 90):
         return jsonify({"success": False, "error": "Latitude must be between -90 and 90"}), 400
     if not (-180 <= longitude <= 180):

--- a/src/services.py
+++ b/src/services.py
@@ -38,6 +38,7 @@ from mender import MenderClient
 from network_manager import NetworkManager
 from retina_tracker_client import RetinaTrackerClient
 from ssh_keys import SSHKeyManager
+from telemetry_status import TelemetryStatus
 from tracker_capture import TrackerCaptureService
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -72,6 +73,13 @@ RETINA_TRACKER_EVENTS_PATH = os.environ.get('RETINA_TRACKER_EVENTS_PATH',
     os.path.join(PROJECT_ROOT, 'dev_data', 'retina-tracker-events.jsonl') if DEV_MODE
     else '/data/retina-node/retina-tracker/output/events.jsonl'
 )
+# Written by the retina-telemetry container, read-only to us. That service
+# binds no ports, so this file is the only way anything it knows reaches an
+# operator — see telemetry_status.py.
+TELEMETRY_STATUS_PATH = os.environ.get('TELEMETRY_STATUS_PATH',
+    os.path.join(PROJECT_ROOT, 'dev_data', 'telemetry-status.json') if DEV_MODE
+    else '/data/retina-telemetry/status.json'
+)
 
 MENDER_SERVICES = ["mender-authd", "mender-updated", "mender-connect"]
 
@@ -102,6 +110,12 @@ device_state = DeviceState(
     mender_conf_backup_path="/data/mender-cloud-disabled/mender.conf",
     dev_mode=DEV_MODE,
 )
+
+telemetry_status = TelemetryStatus(
+    status_path=TELEMETRY_STATUS_PATH,
+    node_ref_cache_path=os.path.join(DATA_DIR, "telemetry-node-ref"),
+)
+
 
 def config_change_guard():
     """Refuse a config apply while Auto-Calibrate is using the SDR.

--- a/src/telemetry_status.py
+++ b/src/telemetry_status.py
@@ -1,0 +1,170 @@
+"""Reader for the status document retina-telemetry writes.
+
+That service binds no ports and nothing pushes to it, so this file is the only
+channel out of it — its logs are inside a container the owner cannot see, and
+there is no endpoint to ask. We are its only reader.
+
+Its own docstring says the shape deliberately mirrors `mender-update.status`,
+which device_state already handles: a JSON object carrying its own timestamp,
+treated as stale past a timeout. The logic here is the same; it lives in its
+own module because device_state is the *device state machine* and telemetry
+status is not part of it.
+
+## node_ref, and why it is cached
+
+`node_ref` is the owner's public identifier — the thing they need to find their
+node on the server's views. It is assigned by the server and arrives only in a
+registration or heartbeat response, so this document is the sole path by which
+the node ever learns it.
+
+retina-telemetry holds it in memory only: `State.store_token` persists the
+token and nothing else, on the grounds that node_ref is re-obtainable from the
+server without an operator. So for up to one heartbeat interval (60s by
+default) after that container restarts, the document legitimately carries
+`node_ref: null` on a perfectly healthy registered node.
+
+That is why we keep a last-known-good copy on disk. It is *not* for noticing
+rotation — telemetry already does that in `State.apply_levels`, and the file
+always carries the live value, so the file is the source of truth and this
+cache is only consulted when it says null. On disk rather than in memory
+because the case that matters is a node reboot, where both services come back
+at once and an in-memory copy would be empty at exactly the moment the owner is
+looking. It never expires: a node_ref stays valid indefinitely, and blanking it
+when telemetry dies would remove the identifier precisely when someone needs to
+quote it to support.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+# Past this, the document describes a service that is no longer running. It
+# writes every ~10s (STATUS_INTERVAL_S in retina-telemetry's settings), so this
+# is generous enough that an ordinary restart never trips it.
+STALE_AFTER = timedelta(minutes=2)
+
+# States that are normal and will pass on their own. Their `detail` is
+# suppressed so a healthy node has nothing to say for itself.
+#
+# Deliberately an exclusion list rather than a list of states worth showing: a
+# fault state added to retina-telemetry later would be silently hidden by the
+# latter, whereas here anything unrecognised surfaces by default. The only
+# thing this list ever needs to contain is states meaning "this is normal and
+# transient", which is a far more stable set than the faults.
+TRANSIENT_STATES = frozenset({"registering", "awaiting_config", "starting"})
+
+
+def _sentence(detail):
+    """Uppercase the first character and change nothing else.
+
+    retina-telemetry writes these as lowercase fragments meant to follow a
+    state word, which reads as a typo on a card of its own. Only the first
+    character moves: Jinja's `capitalize` lowercases the remainder, which turns
+    "Mender" into "mender" and "MAC-based" into "mac-based" — and these strings
+    are meant to be shown verbatim.
+    """
+    if not detail:
+        return detail
+    return detail[0].upper() + detail[1:]
+
+
+class TelemetryStatus:
+    """Reads retina-telemetry's status document. Never raises.
+
+    An unreadable or absent document is reported as "not installed" rather than
+    as a fault: on a node that has never had the telemetry package, there is no
+    file and nothing is wrong.
+    """
+
+    def __init__(self, status_path, node_ref_cache_path):
+        self.status_path = status_path
+        self.node_ref_cache_path = node_ref_cache_path
+
+    def read(self) -> dict | None:
+        """Return what to show the operator, or None if telemetry isn't installed.
+
+        Keys:
+            state:      the raw state string from the document, or None
+            detail:     prose to show verbatim, or None when there is nothing
+                        worth saying (see TRANSIENT_STATES)
+            node_ref:   live value, falling back to the last known one
+            node_id:    as reported by telemetry, which reads it directly
+            stale:      True when the document is too old to believe, meaning
+                        the container is not running
+            written_at: the raw timestamp, for display alongside `stale`
+        """
+        document = self._load()
+        if document is None:
+            return None
+
+        node_ref = document.get("node_ref")
+        if node_ref:
+            self._remember_node_ref(node_ref)
+        else:
+            node_ref = self._recall_node_ref()
+
+        state = document.get("state")
+        detail = document.get("detail")
+
+        return {
+            "state": state,
+            "detail": None if state in TRANSIENT_STATES else _sentence(detail),
+            "node_ref": node_ref,
+            "node_id": document.get("node_id"),
+            "stale": self._is_stale(document.get("written_at")),
+            "written_at": document.get("written_at"),
+        }
+
+    # ── The document ───────────────────────────────────────────
+
+    def _load(self) -> dict | None:
+        try:
+            with open(self.status_path) as f:
+                document = json.load(f)
+        except (OSError, ValueError):
+            # Absent is the ordinary state on a node without the telemetry
+            # package; malformed is indistinguishable from absent to an
+            # operator, and neither is worth an alarm on the home page.
+            return None
+        return document if isinstance(document, dict) else None
+
+    def _is_stale(self, written_at) -> bool:
+        """Whether the document is too old to describe a running service.
+
+        A document we cannot date is treated as stale: retina-telemetry writes
+        `written_at` on every write, so its absence means this is not a
+        document we understand.
+        """
+        if not written_at:
+            return True
+        try:
+            written = datetime.fromisoformat(written_at)
+        except (TypeError, ValueError):
+            return True
+        if written.tzinfo is None:
+            written = written.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) - written > STALE_AFTER
+
+    # ── The node_ref cache ─────────────────────────────────────
+
+    def _remember_node_ref(self, node_ref):
+        """Store the current node_ref, if it isn't what we already have.
+
+        Best-effort: this is a display convenience, so a failure to write it
+        must not stop the page rendering the value we were given.
+        """
+        if node_ref == self._recall_node_ref():
+            return
+        try:
+            os.makedirs(os.path.dirname(self.node_ref_cache_path), exist_ok=True)
+            with open(self.node_ref_cache_path, "w") as f:
+                f.write(node_ref)
+        except OSError:
+            pass
+
+    def _recall_node_ref(self):
+        try:
+            with open(self.node_ref_cache_path) as f:
+                return f.read().strip() or None
+        except OSError:
+            return None

--- a/src/telemetry_status.py
+++ b/src/telemetry_status.py
@@ -54,6 +54,44 @@ STALE_AFTER = timedelta(minutes=2)
 TRANSIENT_STATES = frozenset({"registering", "awaiting_config", "starting"})
 
 
+def _parse_timestamp(written_at):
+    """Parse retina-telemetry's `written_at`, or None if we cannot.
+
+    It writes RFC 3339 in UTC (`2026-08-16T09:49:52Z`). A naive value would
+    otherwise be read as local time, which on a node in the wrong timezone
+    makes a healthy service look hours stale, so it is assumed to be UTC.
+    """
+    if not written_at:
+        return None
+    try:
+        written = datetime.fromisoformat(written_at)
+    except (TypeError, ValueError):
+        return None
+    return written.replace(tzinfo=timezone.utc) if written.tzinfo is None else written
+
+
+def _in_words(written):
+    """How long ago that was, in prose.
+
+    `2026-08-16T09:49:52Z` is precise and unreadable — it makes the operator do
+    arithmetic to answer the only question the timestamp is there for, which is
+    how long the service has been quiet. Relative phrasing answers it directly
+    and sidesteps timezones entirely, since the node writes UTC and the reader
+    is not necessarily in it.
+    """
+    if written is None:
+        return None
+
+    seconds = max(0, int((datetime.now(timezone.utc) - written).total_seconds()))
+    if seconds < 90:
+        return "less than a minute ago"
+    for amount, unit in ((3600, "minute"), (86400, "hour"), (None, "day")):
+        if amount is None or seconds < amount:
+            divisor = {"minute": 60, "hour": 3600, "day": 86400}[unit]
+            count = seconds // divisor
+            return f"{count} {unit}{'s' if count != 1 else ''} ago"
+
+
 def _sentence(detail):
     """Uppercase the first character and change nothing else.
 
@@ -91,7 +129,8 @@ class TelemetryStatus:
             node_id:    as reported by telemetry, which reads it directly
             stale:      True when the document is too old to believe, meaning
                         the container is not running
-            written_at: the raw timestamp, for display alongside `stale`
+            last_report: how long ago it last wrote, in words, or None if the
+                        timestamp was missing or unreadable
         """
         document = self._load()
         if document is None:
@@ -105,14 +144,18 @@ class TelemetryStatus:
 
         state = document.get("state")
         detail = document.get("detail")
+        written = _parse_timestamp(document.get("written_at"))
 
         return {
             "state": state,
             "detail": None if state in TRANSIENT_STATES else _sentence(detail),
             "node_ref": node_ref,
             "node_id": document.get("node_id"),
-            "stale": self._is_stale(document.get("written_at")),
-            "written_at": document.get("written_at"),
+            # A document we cannot date is stale: retina-telemetry writes
+            # `written_at` on every write, so its absence means this is not a
+            # document we understand.
+            "stale": written is None or datetime.now(timezone.utc) - written > STALE_AFTER,
+            "last_report": _in_words(written),
         }
 
     # ── The document ───────────────────────────────────────────
@@ -127,23 +170,6 @@ class TelemetryStatus:
             # operator, and neither is worth an alarm on the home page.
             return None
         return document if isinstance(document, dict) else None
-
-    def _is_stale(self, written_at) -> bool:
-        """Whether the document is too old to describe a running service.
-
-        A document we cannot date is treated as stale: retina-telemetry writes
-        `written_at` on every write, so its absence means this is not a
-        document we understand.
-        """
-        if not written_at:
-            return True
-        try:
-            written = datetime.fromisoformat(written_at)
-        except (TypeError, ValueError):
-            return True
-        if written.tzinfo is None:
-            written = written.replace(tzinfo=timezone.utc)
-        return datetime.now(timezone.utc) - written > STALE_AFTER
 
     # ── The node_ref cache ─────────────────────────────────────
 

--- a/static/common.css
+++ b/static/common.css
@@ -263,6 +263,10 @@ h1, h2, h3, h4, h5, h6 {
 .tower-info .name { font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
 .tower-info .freq { font-family: var(--font-mono); color: var(--ink-3); font-size: 12.5px; margin-top: 1px; }
 
+/* Telemetry sits between the tower row and the service grid, so it carries the
+   same 20px gap those two use to separate themselves from what follows. */
+.telemetry-section { margin-bottom: 20px; }
+
 /* Section head */
 .section-head h2 {
     font-size: 11.5px;

--- a/static/setup.js
+++ b/static/setup.js
@@ -245,7 +245,18 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         btn.addEventListener('click', function() {
             btn.disabled = true;
             btn.textContent = 'Connecting...';
-            postJSON('/mender/cloud-services', {enabled: true})
+            // Demo mode pre-ticks both boxes, so a consent write here would
+            // record an acceptance nobody gave — the one thing the whole
+            // versioned-record design exists to prevent. Demoing the wizard on
+            // a live node must leave the record untouched.
+            var recordConsent = demoMode
+                ? Promise.resolve()
+                : postJSON('/set-up/consent', {}).then(function(r) { return r.json(); });
+            // Consent is recorded before the Mender toggle because it is the
+            // half that unblocks telemetry: if cloud services fail, the owner
+            // has still accepted and retina-telemetry can register.
+            recordConsent
+            .then(function() { return postJSON('/mender/cloud-services', {enabled: true}); })
             .then(function(r) { return r.json(); })
             .then(function() { advance(); })
             .catch(function() {

--- a/templates/config.html
+++ b/templates/config.html
@@ -247,7 +247,7 @@
                 <div class="cfg-grid">
                     <div style="grid-column:1/-1;" class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Name</label><span class="help">{{ loc.tx_name.description if loc.tx_name else '' }}</span></div>
-                        <div><input type="text" name="location.tx_name" class="ds-input" value="{{ loc.tx_name.value or '' if loc.tx_name else '' }}"></div>
+                        <div><input type="text" name="location.tx_name" class="ds-input" maxlength="32" value="{{ loc.tx_name.value or '' if loc.tx_name else '' }}"></div>
                     </div>
                     {% if loc.tx_latitude %}
                     <div class="cfg-row" style="padding:0;border:0;">
@@ -550,7 +550,7 @@
                 <div class="modal-body">
                     <div class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label for="towerAddCallsign">Name / Callsign</label></div>
-                        <div><input type="text" id="towerAddCallsign" name="callsign" class="ds-input" required></div>
+                        <div><input type="text" id="towerAddCallsign" name="callsign" class="ds-input" maxlength="32" required></div>
                     </div>
                     <div class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label for="towerAddFrequency">Frequency</label><span class="help">MHz</span></div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,6 +52,56 @@
     </div>
     {% endif %}
 
+    {# Absent when the telemetry package isn't installed — not a fault, so no
+       card rather than an empty one. See telemetry_status.py. #}
+    {% if telemetry %}
+    <section class="telemetry-section">
+        <div class="section-head"><h2>Telemetry</h2></div>
+        <div class="svc-card">
+            <div class="svc-head">
+                <div class="svc-icon">
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M12 20v-8"/>
+                        <path d="M8.5 9.5a5 5 0 0 1 7 0" opacity=".6"/>
+                        <path d="M5.5 6.5a9 9 0 0 1 13 0" opacity=".35"/>
+                        <circle cx="12" cy="12" r="1.8" fill="currentColor" stroke="none"/>
+                    </svg>
+                </div>
+                <div class="svc-name">Node identifier</div>
+                {% if telemetry.stale %}
+                <span class="ds-pill">
+                    <span class="ds-pill-dot" style="background:var(--danger);"></span>
+                    Not running
+                </span>
+                {% elif telemetry.state %}
+                <span class="ds-pill">
+                    <span class="ds-pill-dot" style="background:{{ 'var(--accent)' if telemetry.state == 'streaming' else 'var(--ink-3)' }};"></span>
+                    {{ telemetry.state|replace('_', ' ')|capitalize }}
+                </span>
+                {% endif %}
+            </div>
+
+            {% if telemetry.node_ref %}
+            <div class="svc-desc" style="font-weight:600;color:var(--ink);font-family:var(--font-mono);">{{ telemetry.node_ref }}</div>
+            <div class="svc-desc">Use this to find your node's data.</div>
+            {% else %}
+            <div class="svc-desc">This node has no identifier yet — it is assigned once it registers.</div>
+            {% endif %}
+
+            {# Pre-written prose from retina-telemetry, shown verbatim: mapping
+               its states to our own wording would be a second vocabulary to
+               keep in step with a file we don't own. #}
+            {% if telemetry.stale %}
+            <div class="svc-desc">
+                The telemetry service last reported {{ telemetry.last_report or 'at an unknown time' }} and is no longer running, so nothing is reaching the server.
+            </div>
+            {% elif telemetry.detail %}
+            <div class="svc-desc">{{ telemetry.detail }}</div>
+            {% endif %}
+        </div>
+    </section>
+    {% endif %}
+
     {% if mode == 'spectrum' %}
     <section class="spectrum-section">
         <div class="section-head"><h2>Spectrum</h2></div>
@@ -212,55 +262,6 @@
     </section>
     {% endif %}
 
-    {# Absent when the telemetry package isn't installed — not a fault, so no
-       card rather than an empty one. See telemetry_status.py. #}
-    {% if telemetry %}
-    <section>
-        <div class="section-head"><h2>Telemetry</h2></div>
-        <div class="svc-card" style="max-width:480px;">
-            <div class="svc-head">
-                <div class="svc-icon">
-                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M12 20v-8"/>
-                        <path d="M8.5 9.5a5 5 0 0 1 7 0" opacity=".6"/>
-                        <path d="M5.5 6.5a9 9 0 0 1 13 0" opacity=".35"/>
-                        <circle cx="12" cy="12" r="1.8" fill="currentColor" stroke="none"/>
-                    </svg>
-                </div>
-                <div class="svc-name">Node identifier</div>
-                {% if telemetry.stale %}
-                <span class="ds-pill">
-                    <span class="ds-pill-dot" style="background:var(--danger);"></span>
-                    Not running
-                </span>
-                {% elif telemetry.state %}
-                <span class="ds-pill">
-                    <span class="ds-pill-dot" style="background:{{ 'var(--accent)' if telemetry.state == 'streaming' else 'var(--ink-3)' }};"></span>
-                    {{ telemetry.state|replace('_', ' ')|capitalize }}
-                </span>
-                {% endif %}
-            </div>
-
-            {% if telemetry.node_ref %}
-            <div class="svc-desc" style="font-weight:600;color:var(--ink);font-family:var(--font-mono);">{{ telemetry.node_ref }}</div>
-            <div class="svc-desc">Use this to find your node's data.</div>
-            {% else %}
-            <div class="svc-desc">This node has no identifier yet — it is assigned once it registers.</div>
-            {% endif %}
-
-            {# Pre-written prose from retina-telemetry, shown verbatim: mapping
-               its states to our own wording would be a second vocabulary to
-               keep in step with a file we don't own. #}
-            {% if telemetry.stale %}
-            <div class="svc-desc">
-                The telemetry service last reported at {{ telemetry.written_at or 'an unknown time' }} and is no longer running, so nothing is reaching the server.
-            </div>
-            {% elif telemetry.detail %}
-            <div class="svc-desc">{{ telemetry.detail }}</div>
-            {% endif %}
-        </div>
-    </section>
-    {% endif %}
 
 </main>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -212,6 +212,56 @@
     </section>
     {% endif %}
 
+    {# Absent when the telemetry package isn't installed — not a fault, so no
+       card rather than an empty one. See telemetry_status.py. #}
+    {% if telemetry %}
+    <section>
+        <div class="section-head"><h2>Telemetry</h2></div>
+        <div class="svc-card" style="max-width:480px;">
+            <div class="svc-head">
+                <div class="svc-icon">
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M12 20v-8"/>
+                        <path d="M8.5 9.5a5 5 0 0 1 7 0" opacity=".6"/>
+                        <path d="M5.5 6.5a9 9 0 0 1 13 0" opacity=".35"/>
+                        <circle cx="12" cy="12" r="1.8" fill="currentColor" stroke="none"/>
+                    </svg>
+                </div>
+                <div class="svc-name">Node identifier</div>
+                {% if telemetry.stale %}
+                <span class="ds-pill">
+                    <span class="ds-pill-dot" style="background:var(--danger);"></span>
+                    Not running
+                </span>
+                {% elif telemetry.state %}
+                <span class="ds-pill">
+                    <span class="ds-pill-dot" style="background:{{ 'var(--accent)' if telemetry.state == 'streaming' else 'var(--ink-3)' }};"></span>
+                    {{ telemetry.state|replace('_', ' ')|capitalize }}
+                </span>
+                {% endif %}
+            </div>
+
+            {% if telemetry.node_ref %}
+            <div class="svc-desc" style="font-weight:600;color:var(--ink);font-family:var(--font-mono);">{{ telemetry.node_ref }}</div>
+            <div class="svc-desc">Use this to find your node's data.</div>
+            {% else %}
+            <div class="svc-desc">This node has no identifier yet — it is assigned once it registers.</div>
+            {% endif %}
+
+            {# Pre-written prose from retina-telemetry, shown verbatim: mapping
+               its states to our own wording would be a second vocabulary to
+               keep in step with a file we don't own. #}
+            {% if telemetry.stale %}
+            <div class="svc-desc">
+                The telemetry service last reported at {{ telemetry.written_at or 'an unknown time' }} and is no longer running, so nothing is reaching the server.
+            </div>
+            {% elif telemetry.detail %}
+            <div class="svc-desc">{{ telemetry.detail }}</div>
+            {% endif %}
+        </div>
+    </section>
+    {% endif %}
+
 </main>
 {% endblock %}
 

--- a/templates/setup/_agreements.html
+++ b/templates/setup/_agreements.html
@@ -12,11 +12,15 @@
             </div>
         </label>
 
+        {# The publication disclosure lives here rather than in the EULA, so
+           this wording is part of what TELEMETRY_CONSENT_VERSION identifies —
+           changing it must bump that constant (see device_state.py). Recording
+           publication as "public" is only honest while this text says so. #}
         <label class="step-check">
             <input type="checkbox" id="cloudCheck">
             <div>
-                <div class="step-check-text">Enable cloud services</div>
-                <div class="step-check-help">Required for automatic updates. Can be disabled later in Settings.</div>
+                <div class="step-check-text">Enable cloud services and data publication</div>
+                <div class="step-check-help">Required for automatic updates, and can be disabled later in Settings. Your radar detections are sent to Offworld Labs and published in a public archive, including the location of this receiver. Published data cannot be recalled once it has been copied.</div>
             </div>
         </label>
     </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1154,3 +1154,37 @@ class TestSetupWizardStepRoutes:
         response = app_client.post('/set-up/complete')
         data = json.loads(response.data)
         assert data['success'] is True
+
+
+class TestTelemetryConsentRoute:
+    """Test POST /set-up/consent.
+
+    Until this writes, no node in the fleet can register with
+    retina-telemetry — it refuses without all three records and will never
+    synthesise one.
+    """
+
+    def test_consent_writes_the_records(self, app_client):
+        import app as app_module
+        assert app_module.device_state.get_telemetry_consent() is None
+
+        response = app_client.post('/set-up/consent',
+                                   data=json.dumps({}),
+                                   content_type='application/json')
+
+        assert json.loads(response.data)['success'] is True
+        consent = app_module.device_state.get_telemetry_consent()
+        assert set(consent) == {"licence", "remote_management", "publication"}
+        assert consent['publication']['choice'] == 'public'
+
+    def test_consent_is_independent_of_wizard_completion(self, app_client):
+        """The re-consent path for the deployed fleet: a node that has already
+        finished setup re-runs /set-up, ticks, continues, and abandons. Nothing
+        about completing the wizard may be required for the record to land."""
+        import app as app_module
+        app_module.device_state.mark_setup_wizard_completed()
+
+        app_client.post('/set-up/consent', data=json.dumps({}),
+                        content_type='application/json')
+
+        assert app_module.device_state.get_telemetry_consent() is not None

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -161,6 +161,24 @@ class TestLocationFormConfig:
         assert config.rx_latitude == 37.7644
         assert config.tx_name == 'KSCZ-LD'
 
+    def test_tx_name_length_cap(self):
+        """tx_name is capped at 32 — retina-telemetry's tx_callsign limit.
+
+        A longer name means it cannot build a NodeConfig at all, so the node
+        never registers. Rejecting it here covers both writers: the config form
+        and the wizard's /towers/set-location.
+        """
+        def location(tx_name):
+            return LocationFormConfig(
+                rx_latitude=0, rx_longitude=0, rx_altitude=0, rx_name='Test',
+                tx_latitude=0, tx_longitude=0, tx_altitude=0, tx_name=tx_name
+            )
+
+        assert location('x' * 32).tx_name == 'x' * 32
+
+        with pytest.raises(ValidationError):
+            location('x' * 33)
+
     def test_latitude_bounds(self):
         """Latitude must be -90 to 90."""
         # Invalid: > 90

--- a/tests/test_device_state.py
+++ b/tests/test_device_state.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from device_state import INSTALL_LOCK_TIMEOUT, MENDER_STATUS_TIMEOUT, SETUP_WIZARD_TIMEOUT, DeviceState
+from device_state import (
+    INSTALL_LOCK_TIMEOUT,
+    MENDER_STATUS_TIMEOUT,
+    SETUP_WIZARD_TIMEOUT,
+    TELEMETRY_CONSENT_VERSION,
+    DeviceState,
+)
 
 
 @pytest.fixture
@@ -424,3 +430,84 @@ class TestTowersCache:
         with open(ds.towers_cache_file, "w") as f:
             f.write("not json")
         assert ds.get_towers_cache() is None
+
+
+class TestTelemetryConsent:
+    """Test the consent records retina-telemetry refuses to register without.
+
+    The shape is a cross-repo contract with retina-telemetry's
+    `collect/consent.py`, which fails closed on anything it does not recognise
+    — so these assert the exact keys rather than round-tripping our own writer.
+    """
+
+    def test_no_consent_by_default(self, ds):
+        """The state of every node that has not been through the wizard."""
+        assert ds.get_telemetry_consent() is None
+
+    def test_writes_all_three_records(self, ds):
+        ds.save_telemetry_consent()
+        consent = ds.get_telemetry_consent()
+
+        assert set(consent) == {"licence", "remote_management", "publication"}
+        for name in ("licence", "remote_management", "publication"):
+            assert consent[name]["version"] == TELEMETRY_CONSENT_VERSION
+            assert consent[name]["accepted_at"]
+
+    def test_publication_records_a_choice(self, ds):
+        """retina-telemetry discards the record unless choice is exactly
+        "public" or "private"; anything else is treated as no consent at all."""
+        ds.save_telemetry_consent()
+        assert ds.get_telemetry_consent()["publication"]["choice"] == "public"
+
+    def test_accepted_at_is_timezone_aware(self, ds):
+        """The wire types this AwareDatetime, so a naive timestamp is rejected
+        at the boundary and the node silently never registers."""
+        ds.save_telemetry_consent()
+        stamp = ds.get_telemetry_consent()["licence"]["accepted_at"]
+
+        assert datetime.fromisoformat(stamp).tzinfo is not None
+
+    def test_all_three_share_one_timestamp(self, ds):
+        """One checkbox, one moment of agreement."""
+        ds.save_telemetry_consent()
+        consent = ds.get_telemetry_consent()
+
+        stamps = {consent[n]["accepted_at"] for n in consent}
+        assert len(stamps) == 1
+
+    def test_reaccepting_same_version_preserves_the_original_date(self, ds):
+        """A wizard re-run showing unchanged wording is not a new agreement,
+        and overwriting would destroy when they first agreed."""
+        ds.save_telemetry_consent()
+        first = ds.get_telemetry_consent()["licence"]["accepted_at"]
+
+        ds.save_telemetry_consent()
+        assert ds.get_telemetry_consent()["licence"]["accepted_at"] == first
+
+    def test_new_version_redates_every_record(self, ds):
+        """Changed wording is a genuine re-acceptance."""
+        ds.save_telemetry_consent(version="2020-01-01")
+        with open(ds.telemetry_consent_file) as f:
+            stale = json.load(f)
+        stale["licence"]["accepted_at"] = "2020-01-01T00:00:00Z"
+        stale["publication"]["accepted_at"] = "2020-01-01T00:00:00Z"
+        with open(ds.telemetry_consent_file, "w") as f:
+            json.dump(stale, f)
+
+        ds.save_telemetry_consent(version="2026-12-25")
+        consent = ds.get_telemetry_consent()
+
+        assert consent["licence"]["version"] == "2026-12-25"
+        assert consent["licence"]["accepted_at"] != "2020-01-01T00:00:00Z"
+        assert consent["publication"]["accepted_at"] != "2020-01-01T00:00:00Z"
+
+    def test_malformed_file_reads_as_no_consent(self, ds):
+        """Fail closed, matching retina-telemetry's own posture: a record we
+        cannot read is not a record."""
+        with open(ds.telemetry_consent_file, "w") as f:
+            f.write("{not json")
+        assert ds.get_telemetry_consent() is None
+
+    def test_write_leaves_no_temp_file_behind(self, ds):
+        ds.save_telemetry_consent()
+        assert not os.path.exists(ds.telemetry_consent_file + ".tmp")

--- a/tests/test_telemetry_status.py
+++ b/tests/test_telemetry_status.py
@@ -1,0 +1,224 @@
+"""Tests for the retina-telemetry status document reader.
+
+The document is written by another container and is the only channel out of a
+service that binds no ports, so the cases that matter here are the ones where
+it is absent, stale, or half-understood — none of which may raise.
+"""
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from telemetry_status import TelemetryStatus
+
+
+def written_at(age=timedelta(0)):
+    """A timestamp in the format retina-telemetry actually writes."""
+    return (datetime.now(timezone.utc) - age).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@pytest.fixture
+def reader(temp_dir):
+    return TelemetryStatus(
+        status_path=os.path.join(temp_dir, "status.json"),
+        node_ref_cache_path=os.path.join(temp_dir, "telemetry-node-ref"),
+    )
+
+
+def write_status(reader, **fields):
+    document = {"schema": 1, "written_at": written_at(), **fields}
+    with open(reader.status_path, "w") as f:
+        json.dump(document, f)
+
+
+class TestMissingOrUnreadable:
+    """Absent means the telemetry package isn't installed — not a fault."""
+
+    def test_absent_file_reads_as_none(self, reader):
+        assert reader.read() is None
+
+    def test_malformed_json_reads_as_none(self, reader):
+        with open(reader.status_path, "w") as f:
+            f.write("{not json")
+        assert reader.read() is None
+
+    def test_non_object_document_reads_as_none(self, reader):
+        with open(reader.status_path, "w") as f:
+            json.dump(["not", "an", "object"], f)
+        assert reader.read() is None
+
+
+class TestDetailSuppression:
+    """Prose is hidden for normal transients and shown for everything else.
+
+    The list is deliberately of transients rather than of faults, so a state
+    added to retina-telemetry later surfaces instead of being silently hidden.
+    """
+
+    @pytest.mark.parametrize("state", ["registering", "awaiting_config", "starting"])
+    def test_transient_states_suppress_detail(self, reader, state):
+        write_status(reader, state=state, detail="this is normal and will pass")
+        assert reader.read()["detail"] is None
+
+    @pytest.mark.parametrize("state", ["no_identity", "no_agreement", "revoked", "no_detections"])
+    def test_actionable_states_show_detail(self, reader, state):
+        write_status(reader, state=state, detail="something needs doing")
+        assert reader.read()["detail"] == "Something needs doing"
+
+    def test_unrecognised_state_shows_detail(self, reader):
+        """A state we've never heard of must surface, not hide.
+
+        This is the whole reason the list is of transients: a fault added
+        upstream reaches the operator without retina-gui being changed first.
+        """
+        write_status(reader, state="some_future_fault", detail="a new way to fail")
+        assert reader.read()["detail"] == "A new way to fail"
+
+    def test_state_is_passed_through_unmapped(self, reader):
+        write_status(reader, state="streaming", detail=None)
+        assert reader.read()["state"] == "streaming"
+
+    def test_detail_casing_is_otherwise_untouched(self, reader):
+        """Only the first character moves.
+
+        These strings are shown verbatim, and they carry casing that matters —
+        "Mender", "MAC-based", "blah2-api". Jinja's `capitalize` would lowercase
+        all of it, which is why this happens in Python instead.
+        """
+        write_status(
+            reader, state="no_identity",
+            detail="/data/mender/node_id is missing. It has not enrolled with "
+                   "Mender, or has fallen back to a MAC-based one.",
+        )
+        assert reader.read()["detail"] == (
+            "/data/mender/node_id is missing. It has not enrolled with "
+            "Mender, or has fallen back to a MAC-based one."
+        )
+
+    def test_lowercase_detail_gets_a_capital(self, reader):
+        write_status(reader, state="revoked", detail="the server rejected this node's token.")
+        assert reader.read()["detail"].startswith("The server rejected")
+
+
+class TestStaleness:
+    """A stale document means the container died; no state value can say so."""
+
+    def test_fresh_document_is_not_stale(self, reader):
+        write_status(reader, state="streaming")
+        assert reader.read()["stale"] is False
+
+    def test_old_document_is_stale(self, reader):
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming", "written_at": written_at(timedelta(minutes=10))}, f)
+        assert reader.read()["stale"] is True
+
+    def test_missing_written_at_is_stale(self, reader):
+        """retina-telemetry writes it on every write, so its absence means
+        this is not a document we understand."""
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming"}, f)
+        assert reader.read()["stale"] is True
+
+    def test_unparseable_written_at_is_stale(self, reader):
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming", "written_at": "not a timestamp"}, f)
+        assert reader.read()["stale"] is True
+
+    def test_naive_written_at_is_treated_as_utc(self, reader):
+        """Defensive: the writer always emits Z, but a naive timestamp read as
+        local time could look hours stale on a node in the wrong timezone."""
+        naive = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming", "written_at": naive}, f)
+        assert reader.read()["stale"] is False
+
+
+class TestNodeRefCache:
+    """node_ref is null for up to a heartbeat interval after a restart.
+
+    The cache exists only to cover that window — telemetry itself is the source
+    of truth and already handles rotation.
+    """
+
+    def test_live_value_is_returned_and_remembered(self, reader):
+        write_status(reader, state="streaming", node_ref="nde4f2k9xq7m3b8")
+        assert reader.read()["node_ref"] == "nde4f2k9xq7m3b8"
+        with open(reader.node_ref_cache_path) as f:
+            assert f.read().strip() == "nde4f2k9xq7m3b8"
+
+    def test_null_falls_back_to_last_known_good(self, reader):
+        write_status(reader, state="streaming", node_ref="nde4f2k9xq7m3b8")
+        reader.read()
+
+        # What the document looks like for ~60s after telemetry restarts.
+        write_status(reader, state="awaiting_config", node_ref=None)
+        assert reader.read()["node_ref"] == "nde4f2k9xq7m3b8"
+
+    def test_null_with_no_cache_returns_none(self, reader):
+        write_status(reader, state="unregistered", node_ref=None)
+        assert reader.read()["node_ref"] is None
+
+    def test_rotation_replaces_the_cached_value(self, reader):
+        write_status(reader, state="streaming", node_ref="nde4f2k9xq7m3b8")
+        reader.read()
+
+        write_status(reader, state="streaming", node_ref="ndeaaaaaaaaaaaa")
+        assert reader.read()["node_ref"] == "ndeaaaaaaaaaaaa"
+
+        write_status(reader, state="streaming", node_ref=None)
+        assert reader.read()["node_ref"] == "ndeaaaaaaaaaaaa"
+
+    def test_unwritable_cache_does_not_break_the_read(self, reader):
+        """The cache is a display convenience; losing it must not cost us the
+        value we were just handed."""
+        reader.node_ref_cache_path = "/proc/nonexistent/telemetry-node-ref"
+        write_status(reader, state="streaming", node_ref="nde4f2k9xq7m3b8")
+        assert reader.read()["node_ref"] == "nde4f2k9xq7m3b8"
+
+
+class TestHomePageCard:
+    """The card is rendered server-side on page load."""
+
+    def _point_at(self, app_module, temp_dir):
+        reader = TelemetryStatus(
+            status_path=os.path.join(temp_dir, "status.json"),
+            node_ref_cache_path=os.path.join(temp_dir, "telemetry-node-ref"),
+        )
+        app_module.telemetry_status = reader
+        return reader
+
+    def test_no_card_when_telemetry_is_not_installed(self, app_client, temp_dir):
+        import app as app_module
+        self._point_at(app_module, temp_dir)
+
+        assert b"Node identifier" not in app_client.get("/").data
+
+    def test_node_ref_is_shown(self, app_client, temp_dir):
+        import app as app_module
+        reader = self._point_at(app_module, temp_dir)
+        write_status(reader, state="streaming", node_ref="nde4f2k9xq7m3b8", detail=None)
+
+        body = app_client.get("/").data
+        assert b"nde4f2k9xq7m3b8" in body
+
+    def test_actionable_detail_reaches_the_page(self, app_client, temp_dir):
+        import app as app_module
+        reader = self._point_at(app_module, temp_dir)
+        write_status(reader, state="no_agreement", node_ref=None,
+                     detail="no record of the terms being accepted")
+
+        assert b"No record of the terms being accepted" in app_client.get("/").data
+
+    def test_stale_document_reports_the_service_as_down(self, app_client, temp_dir):
+        import app as app_module
+        reader = self._point_at(app_module, temp_dir)
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming", "node_ref": "nde4f2k9xq7m3b8",
+                       "written_at": written_at(timedelta(hours=1))}, f)
+
+        body = app_client.get("/").data
+        assert b"Not running" in body
+        # The identifier still shows: it stays valid, and someone contacting
+        # support about a dead service is exactly who needs to quote it.
+        assert b"nde4f2k9xq7m3b8" in body

--- a/tests/test_telemetry_status.py
+++ b/tests/test_telemetry_status.py
@@ -134,6 +134,43 @@ class TestStaleness:
         assert reader.read()["stale"] is False
 
 
+class TestLastReportInWords:
+    """`2026-08-16T09:49:52Z` makes the operator do arithmetic to answer the
+    only question it is there for — how long the service has been quiet."""
+
+    @pytest.mark.parametrize("age,expected", [
+        (timedelta(seconds=5), "less than a minute ago"),
+        (timedelta(seconds=89), "less than a minute ago"),
+        (timedelta(seconds=90), "1 minute ago"),
+        (timedelta(minutes=5), "5 minutes ago"),
+        (timedelta(hours=1), "1 hour ago"),
+        (timedelta(hours=6), "6 hours ago"),
+        (timedelta(days=1), "1 day ago"),
+        (timedelta(days=9), "9 days ago"),
+    ])
+    def test_ages_read_as_prose(self, reader, age, expected):
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming", "written_at": written_at(age)}, f)
+        assert reader.read()["last_report"] == expected
+
+    def test_no_timestamp_has_no_words(self, reader):
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming"}, f)
+        assert reader.read()["last_report"] is None
+
+    def test_unparseable_timestamp_has_no_words(self, reader):
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming", "written_at": "not a timestamp"}, f)
+        assert reader.read()["last_report"] is None
+
+    def test_a_clock_skewed_future_stamp_does_not_go_negative(self, reader):
+        """Node and container clocks need not agree to the second."""
+        future = (datetime.now(timezone.utc) + timedelta(seconds=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with open(reader.status_path, "w") as f:
+            json.dump({"state": "streaming", "written_at": future}, f)
+        assert reader.read()["last_report"] == "less than a minute ago"
+
+
 class TestNodeRefCache:
     """node_ref is null for up to a heartbeat interval after a restart.
 
@@ -222,3 +259,6 @@ class TestHomePageCard:
         # The identifier still shows: it stays valid, and someone contacting
         # support about a dead service is exactly who needs to quote it.
         assert b"nde4f2k9xq7m3b8" in body
+        # Prose, not an RFC 3339 stamp the reader has to decode.
+        assert b"last reported 1 hour ago" in body
+        assert b"T09:" not in body

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -210,6 +210,22 @@ class TestTowerCacheAdd:
         assert resp.status_code == 400
         assert resp.get_json()['success'] is False
 
+    def test_add_rejects_overlong_callsign(self, app_client):
+        """32 is retina-telemetry's tx_callsign cap; a longer one would be
+        accepted into the cache here and only fail later, when the tower is
+        selected and the whole location block stops validating."""
+        resp = app_client.post('/towers/cache/add', json={
+            'callsign': 'x' * 33, 'frequency_mhz': 95.5, 'latitude': -33.9, 'longitude': 151.2,
+        })
+        assert resp.status_code == 400
+        assert '32 characters' in resp.get_json()['error']
+
+    def test_add_accepts_callsign_at_the_cap(self, app_client):
+        resp = app_client.post('/towers/cache/add', json={
+            'callsign': 'x' * 32, 'frequency_mhz': 95.5, 'latitude': -33.9, 'longitude': 151.2,
+        })
+        assert resp.status_code == 200
+
     def test_add_rejects_out_of_range_latitude(self, app_client):
         resp = app_client.post('/towers/cache/add', json={
             'callsign': 'Bad', 'frequency_mhz': 95.5, 'latitude': 999, 'longitude': 151.2,


### PR DESCRIPTION
Everything `retina-telemetry` needs from this repo. That service is built and
spec-compliant, and **cannot register a single node until the first item here
exists** — it refuses without the consent records and will never write a
default of its own.

Three items, from a handoff written against `retina-telemetry`. The fourth in
that handoff — antenna geometry — is explicitly out of scope: spec v1.1.1 made
those fields required-and-nullable, so every node sends two explicit `null`s and
registers fine.

## 1. Consent records — the blocking one

Writes `/data/retina-gui/telemetry-consent.json` with the three records the
wire's `Agreements` object requires. The shape mirrors it one-for-one, so there
is no translation to get wrong between what the owner saw and what the server
is told.

The wire wants three separately-versioned records because they are withdrawn
separately. The screen does not, because two of them are not choices: you cannot
proceed without the licence, and publication is a condition of taking part
rather than a preference. So the EULA keeps its own line — a distinct document
with its own link — and the second checkbox carries remote management and
publication together.

Publication is recorded as `"public"` for every node. That is only honest
because the checkbox says so in as many words, which is why the disclosure is in
the label rather than a tooltip: the `version` field exists to answer, later,
what a given owner actually saw. Making publication separately optional is a UI
change and nothing else — the wire has carried `"private"` all along.

**Written on the Continue click, not at wizard completion.** Every deployed node
has already finished setup and will never see the agreements step again, so
re-running `/set-up` is the re-consent path for the whole fleet — and writing
early means an owner can tick, continue, and close the tab without the location
step, the tower search, or the docker work `/set-up/complete` triggers on a node
that is already running. `retina-telemetry` re-reads the file on every state
derivation rather than caching at startup, so it takes effect in seconds with no
restart and no ordering between the two services.

Details that would otherwise have failed silently:

- `accepted_at` is timezone-aware. The wire types it `AwareDatetime`, so a naive
  stamp is refused at the boundary and the node simply never registers — and
  every other timestamp in `device_state` uses a naive `datetime.now()`, which
  makes copying the surrounding idiom the natural way to break it. Verified by
  building the real wire `Agreements` model from what this writes.
- Demo mode writes nothing. `?demo=1` works on a live node and pre-ticks both
  boxes, so hanging the write off that handler would manufacture an acceptance
  nobody gave.
- The write is atomic. A half-written file reads as "not accepted", which looks
  like a telemetry bug rather than an interrupted write.
- Re-accepting an unchanged version keeps the original `accepted_at`. A re-run
  showing the same wording has not produced a new agreement.

## 2. Transmitter name capped at 32

`location.tx_name` reaches the server as `tx_callsign`, which the spec caps at
32. Over that, `retina-telemetry` cannot build a `NodeConfig` at all, so
registration and every config resend fail — visible only as a rejected
configuration in a status document nobody was reading.

Tower-Finder never returns anything close: its callsigns are FCC-shaped
(`WMFP`, `WPRI-TV`), and the longest entry in owl's live cache is 14 characters.
The only way to exceed it is a hand-typed name, so both places that accept one
now check. `LocationFormConfig` is the chokepoint — `/config/save` and the
wizard's `/towers/set-location` both validate through it — so a direct API post
cannot avoid it. `/towers/cache/add` checks separately so the rejection lands on
the field being typed into, rather than later when the tower is picked and the
whole location block stops validating.

## 3. The status document

`retina-telemetry` binds no ports and nothing pushes to it. Its logs are inside
a container the owner cannot see, and there is no endpoint to ask, so
`status.json` is the only channel out of it and this repo is its only reader.
Three failures reach an operator through it or not at all: no identity, a
revoked token, and a configuration the server rejected.

It also carries `node_ref`, the owner's public identifier, assigned by the
server and arriving only in a registration or heartbeat response — so this is
the sole path by which the node ever learns it. Hence a permanent card rather
than one that appears only on failure.

- `detail` is pre-written prose, shown verbatim. Mapping states to our own
  wording would mean maintaining a second vocabulary in step with a file we do
  not own. It is suppressed for the three states that are normal and transient —
  deliberately an exclusion list, so a fault state added upstream surfaces on its
  own instead of being hidden by a list of faults we forgot to extend.
- `node_ref` is cached on disk, but not to notice rotation — telemetry does that
  itself and the file always carries the live value. It is cached because
  telemetry holds it in memory only, so the document legitimately reads `null`
  for up to a heartbeat interval after that container restarts. In memory the
  cache would be empty on a node reboot, which is exactly when someone is
  looking. It never expires.
- An absent document means the package is not installed — not a fault, and no
  card. A stale one means the container died, which is, and says so while still
  showing the identifier: someone contacting support about a dead service is
  precisely who needs to quote it.
- The timestamp is not shown raw. `2026-08-16T09:49:52Z` makes the reader do
  arithmetic to answer the only question it is there for, so it reads "last
  reported 6 hours ago" — which also sidesteps timezones, since the node writes
  UTC and whoever is looking need not be in it.

## Verification

Beyond the 53 new tests, the output was checked against `retina-telemetry`
itself rather than against my reading of the spec — its own `read_consent()`
returns `complete: True, missing: []`, and its strict wire `Agreements` model
builds with the timestamp parsed as tz-aware UTC.

All three deployed to owl and exercised live: the service restarts clean, a
33-character callsign is refused over the API with the browser bypassed
entirely, the consent route writes the right shape and preserves `accepted_at`
on re-acceptance, and the card renders in both its healthy and stale states.

## Known gaps, deliberate

- **`/eula` is still the placeholder text.** It is now linked directly above a
  checkbox making specific claims about publishing the receiver's location. The
  disclosure is genuinely present in the checkbox wording, so the record is
  truthful, but the linked agreement should be written before this reaches real
  owners.
- **Nothing re-prompts on a version bump.** `TELEMETRY_CONSENT_VERSION` is
  frozen at `2026-08-15` and moves only when the agreement wording does; today a
  node holding an older version is not asked again. Deferred by decision, noted
  in the constant's comment.
- **Publication is not separately optional.** Deferred by decision; the file
  shape already supports `"private"`, so it is a UI change if that ever changes.

## Note on local test runs

Two `test_restart_lock.py` tests fail on Python 3.14 and pass on the 3.12 CI
uses. Not related to this PR — 3.14 changed the default multiprocessing start
method from `fork` to `forkserver`, which sets up its IPC over a Unix domain
socket, and the `#62` network guard treats any string address as a hostname. A
fix belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
