### PR TITLE
Stop the wizard's tower step polling a redirect forever

### DIFF
--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -14,10 +14,24 @@ from form_utils import schema_to_form_fields
 bp = Blueprint('config', __name__)
 
 
+# The wizard's tower step polls /config/apply/status to know when the restart
+# it queued has finished. Redirecting that hands fetch() an HTML page rather
+# than an error: the request succeeds, .json() rejects, and the step re-polls
+# a redirect forever with its spinner still up and its skip button hidden.
+# Same rule as _CALIBRATION_ALLOWED_PREFIXES in app.py — never redirect the
+# status endpoint the watching window depends on.
+#
+# Matched exactly, not by prefix: this route only reads status, while
+# /config/apply and /config/save mutate and must stay blocked mid-wizard.
+_WIZARD_ALLOWED_PATHS = ('/config/apply/status',)
+
+
 @bp.before_request
 def _check_wizard_not_active():
     """Block config access while the setup wizard is in progress."""
     from app import device_state
+    if request.path in _WIZARD_ALLOWED_PATHS:
+        return None
     if device_state.is_setup_wizard_in_progress():
         return redirect('/set-up')
 

--- a/static/setup.js
+++ b/static/setup.js
@@ -1072,10 +1072,13 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                     frequency_mhz: selectedTower.frequency_mhz
                 };
 
+                var pollFailures = 0;
+
                 function pollApply() {
                     fetch('/config/apply/status')
                     .then(function(r) { return r.json(); })
                     .then(function(s) {
+                        pollFailures = 0;
                         if (s.state === 'running') {
                             var label = s.phase_label || 'Applying configuration';
                             if (s.phase === 'settling' && s.settle_remaining) {
@@ -1094,7 +1097,23 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                             setTimeout(advance, 1500);
                         }
                     })
-                    .catch(function() { setTimeout(pollApply, 2000); });  // transient: keep watching
+                    .catch(function() {
+                        // A miss or two is transient — the GUI can blink out
+                        // while the stack restarts under us. A run of them is
+                        // not, and re-polling forever without saying so leaves
+                        // this step frozen on its spinner with the skip button
+                        // hidden and nothing to click. Surface it instead, and
+                        // give back the way past.
+                        if (++pollFailures >= 5) {
+                            statusEl.innerHTML = '<span class="text-warning">Configuration saved, but progress could not be read.</span>';
+                            saveBtn.disabled = false;
+                            saveBtn.textContent = 'Retry';
+                            skipBtn.style.display = '';
+                            skipBtn.textContent = 'Continue anyway \u2192';
+                            return;
+                        }
+                        setTimeout(pollApply, 2000);
+                    });
                 }
 
                 postJSON('/towers/select', payload)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -691,6 +691,74 @@ class TestNavigationLockedToConfigDuringCalibration:
             assert app_client.get('/').status_code == 200
 
 
+class TestWizardRedirectDoesNotStrandTheWizard:
+    """The wizard guard on the config blueprint is a page guard, but
+    @bp.before_request applies it to every route in that blueprint —
+    including /config/apply/status, which the wizard's own tower step polls.
+
+    Observed on jonathan-node-1: the tower step saved WGBY-TV correctly and
+    the queued apply finished in 0.74s, but every poll was answered with a
+    302 to /set-up. fetch() follows redirects, so the browser got the setup
+    page as a 200 of text/html, .json() rejected, and the step's catch-all
+    re-polled forever — leaving "Saving configuration..." on screen for 53
+    minutes with the skip button hidden.
+
+    Same rule the calibration guard already follows above: never redirect the
+    status endpoint the watching window depends on.
+    """
+
+    @staticmethod
+    def _in_wizard(client):
+        client.post('/set-up/save-step', json={'step': 'towers'})
+
+    def test_the_wizards_own_poll_endpoint_keeps_working(self, app_client):
+        self._in_wizard(app_client)
+        response = app_client.get('/config/apply/status')
+        assert response.status_code == 200
+        assert response.headers['Content-Type'].startswith('application/json')
+        json.loads(response.data)  # must parse — this is what fetch().json() does
+
+    def test_the_config_page_is_still_blocked(self, app_client):
+        """The exemption is one exact path, not a /config prefix. Widening it
+        would quietly disable the guard this class is built around."""
+        self._in_wizard(app_client)
+        response = app_client.get('/config')
+        assert response.status_code == 302
+        assert response.headers['Location'].endswith('/set-up')
+
+    def test_mutating_config_routes_are_still_blocked(self, app_client):
+        self._in_wizard(app_client)
+        for path in ('/config/save', '/config/apply'):
+            response = app_client.post(path, data={})
+            assert response.status_code == 302, path
+
+    def test_the_tower_step_can_read_its_own_progress(self, app_client):
+        """End to end: save a tower mid-wizard, then poll as setup.js does.
+
+        Deliberately asserts the poll stays readable rather than that the
+        apply reaches a terminal state — the work is a real docker restart
+        that a unit test cannot drive to completion. Readability is the whole
+        bug: before the fix every one of these polls raised JSONDecodeError
+        on the setup page's HTML, and the step had no state to act on.
+        """
+        self._in_wizard(app_client)
+        saved = app_client.post('/towers/select', json={
+            'rx_latitude': 42.2371916, 'rx_longitude': -72.6835149,
+            'rx_altitude': 16, 'tx_latitude': 42.241528,
+            'tx_longitude': -72.648361, 'tx_altitude': 619.2,
+            'tx_callsign': 'WGBY-TV', 'frequency_mhz': 213.0,
+        })
+        assert saved.status_code == 202
+
+        for _ in range(5):
+            response = app_client.get('/config/apply/status')
+            assert response.status_code == 200
+            status = json.loads(response.data)  # raised JSONDecodeError before
+            assert status['state'] in ('queued', 'running', 'done', 'failed'), status
+            if status['state'] != 'running':
+                break
+
+
 class TestConfigChangesDuringCalibration:
     """A config apply restarts the whole stack, which pulls the SDR out from
     under an Auto-Calibrate run.


### PR DESCRIPTION
Reported from the field: *"Reran configuration and got blocked from completing configuration (stuck in an infinite loop at the choose a tower screen)."* Reproduced and confirmed on two nodes.

The tower step saves correctly, the queued apply finishes, and the screen sits on "Saving configuration…" until the tab is closed — 53 minutes in the reported case.

## Cause

`config.py` has carried `@bp.before_request` since f037945 (June), redirecting the whole blueprint into `/set-up` while the wizard runs. That was correct when the blueprint held only page routes.

242b6af then added `/config/apply/status` to that blueprint, and 22534b3 — 91 minutes later the same afternoon — made the wizard's tower step poll it. A caller *inside* the wizard was now polling a route guarded *against* the wizard.

## Why it looks like a frozen spinner rather than an error

The guard answers `302`. `fetch()` follows redirects by default, so the browser receives the setup page: **HTTP 200, `text/html`** — a successful request as far as the network is concerned. Only `.json()` fails, and the handler was:

```js
.catch(function() { setTimeout(pollApply, 2000); });  // transient
```

It re-polls without touching the status line, so the UI keeps showing the string set *before* the fetch, forever. Nothing goes red; the network tab shows a wall of 200s. The click handler has already hidden the skip button and only restores it on branches that can no longer be reached — so the one control that would let the user past is removed by the same path that strands them.

**The server was never wrong.** The apply finished in 0.74s on jonathan-node-1 and 50.0s on owl. Both browsers were still polling minutes later.

## Fix

Exempt the one path the wizard depends on — matched **exactly**, not by prefix, since `/config/apply` and `/config/save` mutate and must stay blocked mid-wizard.

This rule already existed in this repo for the *other* redirect guard: `app.py` exempts `_CALIBRATION_ALLOWED_PREFIXES`, and the suite asserts it under *"Redirecting these would break the very window doing the watching and cancelling"* — naming `/config/apply/status` specifically. The lesson was learned once and applied to only one of the two guards.

Also bounds the catch-all retry: after five consecutive failures the step says so and restores **Retry** and **Continue anyway →**, so the next bug of this shape is visible in ten seconds instead of invisible forever.

## Verification

Reproduced against the real app, fixed, then confirmed on hardware. Same node (`owl`), one hour apart:

| | Polls | Result |
|---|---|---|
| Before | 70 consecutive `302`s at 2s intervals | never terminated |
| After | 49 polls, all `200`, **0** redirects | advanced on its own |

The cadence is independent proof: **2s** is the catch-retry path, **1s** is the running-state path. The poll did not merely stop failing — it moved onto the success branch and exited.

End-to-end run confirmed by the reporter on real hardware.

## Tests

Four regression tests. Two fail without the exemption (`assert 302 == 200`); the other two assert `/config` and the mutating routes still redirect, so a future "fix" cannot widen this to a `/config` prefix and quietly disable the guard.

Full suite: **542 passed**.

## Not included

- The wizard's **exit button** navigates to `/`, which redirects straight back into the wizard — independent issue, and what made this one inescapable rather than merely annoying.
- Outbound `requests` calls use a per-address timeout, so a host with one dead address family costs 2× the configured timeout. Surfaced while debugging this; unrelated fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)