### PR TITLE
Let a no-track calibration run persist its tuning

### DIFF
--- a/src/calibrator.py
+++ b/src/calibrator.py
@@ -418,6 +418,14 @@ class Calibrator:
             "rf": {"overload_a": None, "overload_b": None},
             "best_attempt": None,
             "result": None,
+            # The operating point a no-track run settled on and left the
+            # device running (see _apply_top_tower_fallback). Persistable by
+            # /calibrate/apply exactly like "result": a run that never
+            # confirmed a track still resolved tuning this device's own
+            # descent proved it tolerates, which is worth keeping. Stays
+            # None for a cancelled run — cancel restores the original
+            # tuning, so there is deliberately nothing to offer.
+            "fallback": None,
             "error": None,
             "original": None,
             # None until the preflight has something to report. Only set when
@@ -1474,6 +1482,20 @@ class Calibrator:
         config.yml).
         """
         self._update(phase="restoring")
+        # Recorded ahead of the retune and kept whether or not it lands: this
+        # is the tuning /calibrate/apply persists for a no-track run, and it
+        # is the right thing to write to config either way. A blah2 that
+        # missed the retune re-reads config.yml on its next restart
+        # (restart: always), so persisting is what actually makes this stick
+        # — dropping the record because the live apply failed would discard
+        # the run's only durable output at the moment it matters most.
+        self._update(fallback={
+            "tower_name": top_tower.get("name"),
+            "fc": top_fc,
+            "gain_a": gain_a,
+            "gain_b": gain_b,
+            "lna_state": lna_state,
+        })
         try:
             self._apply(top_fc, gain_a, gain_b, lna_state, ignore_cancel=True)
             self._set_current(tower_index=0, tower_name=top_tower.get("name"),

--- a/src/routes/calibrate.py
+++ b/src/routes/calibrate.py
@@ -210,8 +210,11 @@ def cancel():
 
 @bp.route("/apply", methods=["POST"])
 def apply():
-    """Persist a successful calibration result: write user.yml, then queue the
+    """Persist a calibration run's tuning: write user.yml, then queue the
     config-merger + service restart (mirrors /towers/select).
+
+    Takes a confirmed-track result when there is one, and otherwise the
+    operating point a no-track run settled on (see calibrator's "fallback").
 
     can_start_calibration() below already covers a Mender install in progress,
     which is why this route needs no separate update guard.
@@ -220,9 +223,21 @@ def apply():
 
     run_status = calibrator.get_status()
     result = run_status.get("result")
-    if run_status.get("state") != "done" or not result:
+    # A run that confirmed no track still resolved an operating point this
+    # device's own descent proved it tolerates, and _apply_top_tower_fallback
+    # has already left blah2 running on it. That tuning is live-only until
+    # something writes it to config: the next stack restart re-reads
+    # config.yml and silently discards it. In the setup wizard that restart
+    # is seconds away (/set-up/complete force-recreates the stack), so
+    # without this the run's only durable output is lost every single time.
+    # It is the same write as a success, from values proven the same way.
+    # Cancelled runs never arrive here with a fallback — cancel restores the
+    # original tuning, and _run's _check_cancel fires before the fallback is
+    # ever recorded — so cancelling still means "put it back".
+    tuning = result if run_status.get("state") == "done" and result else run_status.get("fallback")
+    if not tuning:
         return jsonify({"success": False,
-                        "error": "No successful calibration result to apply"}), 409
+                        "error": "No calibration tuning to apply"}), 409
 
     ok, reason = device_state.can_start_calibration()
     if not ok:
@@ -230,10 +245,10 @@ def apply():
 
     user_config = dict(config_mgr.load_user_config())
     capture = dict(user_config.get('capture', {}) or {})
-    capture['fc'] = int(result['fc'])
+    capture['fc'] = int(tuning['fc'])
     device = dict(capture.get('device', {}) or {})
-    device['gainReduction'] = [int(result['gain_a']), int(result['gain_b'])]
-    device['lnaState'] = int(result['lna_state'])
+    device['gainReduction'] = [int(tuning['gain_a']), int(tuning['gain_b'])]
+    device['lnaState'] = int(tuning['lna_state'])
     # Always assert AGC off: a calibration result is by definition a manual
     # gain/LNA operating point (the AGC guard above refuses to run against
     # hardware AGC), so persisting one must never inherit a stale AGC-on

--- a/templates/config.html
+++ b/templates/config.html
@@ -1569,6 +1569,25 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
                     + ': ' + status.best_attempt.reason
                     + '.<br>Try entering these in the Capture fields below as a starting point.';
             }
+            // A run that found no track still resolved an operating point the
+            // descent proved this device tolerates, and the radar is on it
+            // right now — but only live, until it is written to config. Offer
+            // the same persist the success path offers, or the next restart
+            // throws the whole run away. Distinct from "Closest attempt"
+            // above, which is informational and may name a different tower:
+            // this is what the radar is actually running.
+            if (status.fallback) {
+                resultEl.style.display = '';
+                resultEl.innerHTML = 'The radar is running on <strong>'
+                    + escapeHtml(status.fallback.tower_name || 'Tower') + '</strong> at '
+                    + mhz(status.fallback.fc) + ', gain reduction A ' + status.fallback.gain_a
+                    + ' dB / B ' + status.fallback.gain_b + ' dB, LNA state '
+                    + status.fallback.lna_state
+                    + ' - the best operating point this run proved the device tolerates.'
+                    + '<br>This is not saved yet: a restart would go back to the previous tuning. '
+                    + 'Persist it to keep it.';
+                applyBtn.style.display = '';
+            }
         }
     }
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1099,6 +1099,73 @@ class TestNoTrackFallback:
         assert client.current["gain_b"] == 39
         assert client.current["lna_state"] == LNA_STATE_MIN
 
+    def test_fallback_tuning_is_recorded_for_persistence(self, fast):
+        """The fallback is applied live, but live-only tuning dies at the
+        next stack restart — which in the setup wizard is seconds later
+        (/set-up/complete force-recreates the stack). Recording it in status
+        is what lets /calibrate/apply write it to config, so the run's only
+        durable output survives."""
+        client = FakeBlah2Client(
+            overload_rule=lambda fc, ga, gb, lna: (False, gb < 37))
+        status = run_to_completion(Calibrator(client, FakeRetinaTrackerClient()), [TOWER])
+        assert status["state"] == "failed"
+        assert status["result"] is None
+        fallback = status["fallback"]
+        assert fallback is not None
+        # Exactly what the device was left running, so persisting it is a
+        # no-op against live state rather than a fresh, unproven tuning.
+        assert fallback["fc"] == TOWER["fc"] == client.current["fc"]
+        assert fallback["gain_a"] == client.current["gain_a"]
+        assert fallback["gain_b"] == client.current["gain_b"] == 39
+        assert fallback["lna_state"] == client.current["lna_state"]
+        assert fallback["tower_name"] == TOWER["name"]
+
+    def test_fallback_names_the_top_tower_not_the_last_tried(self, fast):
+        """fc must stay on the top-ranked tower — in the setup wizard that
+        is the tower the user just chose, and persisting a different one
+        would silently overrule that choice."""
+        client = FakeBlah2Client()
+        status = run_to_completion(Calibrator(client, FakeRetinaTrackerClient()),
+                                   [TOWER, TOWER_TWO])
+        assert status["fallback"]["fc"] == TOWER["fc"]
+        assert status["fallback"]["fc"] != TOWER_TWO["fc"]
+
+    def test_cancelled_run_records_no_fallback(self, fast):
+        """Cancel restores the original tuning, so there must be nothing for
+        /calibrate/apply to persist — cancelling has to keep meaning "put it
+        back", not "keep whatever it had reached"."""
+        import time
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=30,
+                               dwell_seconds=30)
+        assert started
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if cal.get_status()["phase"] == "dwelling":
+                break
+            time.sleep(0.01)
+        cal.cancel()
+        cal._thread.join(timeout=10)
+        status = cal.get_status()
+        assert status["state"] == "cancelled"
+        assert status["fallback"] is None
+
+    def test_a_new_run_clears_the_previous_run_fallback(self, fast):
+        """Otherwise a stale fallback from an earlier run stays persistable
+        while a fresh run is still going."""
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        assert run_to_completion(cal, [TOWER])["fallback"] is not None
+        started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=30,
+                               dwell_seconds=30)
+        assert started
+        try:
+            assert cal.get_status()["fallback"] is None
+        finally:
+            cal.cancel()
+            cal._thread.join(timeout=10)
+
 
 class TestTrackerSidecarIntegration:
     """Directly exercises the shared-sidecar-specific mechanics that don't
@@ -1782,6 +1849,74 @@ class TestRoutes:
                           return_value={"state": "idle", "result": None}):
             resp = app_client.post('/calibrate/apply')
         assert resp.status_code == 409
+
+    def test_apply_of_a_cancelled_run_is_rejected(self, app_client):
+        """Cancel restores the original tuning and never records a fallback,
+        so there is nothing to keep — the route must not invent one."""
+        import app as app_module
+        cancelled = {"state": "cancelled", "result": None, "fallback": None}
+        with patch.object(app_module.calibrator, 'get_status', return_value=cancelled):
+            resp = app_client.post('/calibrate/apply')
+        assert resp.status_code == 409
+
+    def test_apply_persists_a_no_track_fallback(self, app_client, config_files):
+        """The blocker this route change exists for: a run that confirmed no
+        track still resolved an operating point the descent proved the device
+        tolerates, and it is applied live only. The next stack restart
+        re-reads config.yml and discards it — seconds later, in the setup
+        wizard's case — so it has to be writable to config just like a
+        success."""
+        import app as app_module
+        no_track = {
+            "state": "failed",
+            "started_at": "2026-08-24T00:00:00+00:00",
+            "result": None,
+            "error": "No confirmed track found within the time budget.",
+            "fallback": {"tower_name": "Tower One", "fc": 213_000_000,
+                         "gain_a": 49, "gain_b": 39, "lna_state": 7},
+        }
+        with patch.object(app_module.calibrator, 'get_status', return_value=no_track), \
+             patch.object(app_module.apply_service, 'request',
+                          return_value={"state": "running"}) as queued:
+            resp = app_client.post('/calibrate/apply')
+        assert resp.status_code == 202
+        assert resp.get_json()["success"] is True
+        queued.assert_called_once_with()
+
+        user_path, _ = config_files
+        with open(user_path) as f:
+            user = yaml.safe_load(f)
+        assert user['capture']['fc'] == 213_000_000
+        assert user['capture']['device']['gainReduction'] == [49, 39]
+        assert user['capture']['device']['lnaState'] == 7
+        # AGC stays off on this path too: the fallback is a manual operating
+        # point exactly like a confirmed result.
+        assert user['capture']['device']['bandwidthNumber'] == 0
+
+    def test_apply_prefers_a_confirmed_result_over_a_fallback(self, app_client, config_files):
+        """Defensive: the two are mutually exclusive in the engine today
+        (the fallback only runs when result is None). If that ever changes,
+        a confirmed track must still win over a consolation tuning."""
+        import app as app_module
+        both = {
+            "state": "done",
+            "result": {"tower_name": "Real", "fc": 105_100_000,
+                       "gain_a": 30, "gain_b": 45, "lna_state": 6,
+                       "track_id": "0A3F"},
+            "fallback": {"tower_name": "Consolation", "fc": 213_000_000,
+                         "gain_a": 59, "gain_b": 59, "lna_state": 9},
+        }
+        with patch.object(app_module.calibrator, 'get_status', return_value=both), \
+             patch.object(app_module.apply_service, 'request',
+                          return_value={"state": "running"}):
+            resp = app_client.post('/calibrate/apply')
+        assert resp.status_code == 202
+
+        user_path, _ = config_files
+        with open(user_path) as f:
+            user = yaml.safe_load(f)
+        assert user['capture']['fc'] == 105_100_000
+        assert user['capture']['device']['gainReduction'] == [30, 45]
 
     def test_apply_is_not_blocked_by_the_config_change_guard(self, app_client):
         """The guard that refuses config changes mid-run must not refuse the


### PR DESCRIPTION
## What

A calibration run that confirms no track still resolves an operating point the descent proved the device tolerates, and `_apply_top_tower_fallback` already leaves blah2 running on it. That was **live-only**: `/calibrate/apply` refused anything that wasn't `state == "done"` with a result, so the next stack restart re-read `config.yml` and silently discarded the entire run.

- Calibrator records that tuning in status as `fallback`, ahead of the retune and regardless of whether it lands (a blah2 that missed the retune re-reads `config.yml` on its next restart, so persisting is precisely what makes it stick).
- `/calibrate/apply` takes a confirmed result when there is one and the fallback otherwise. Same write, same proven values, AGC still forced off on both paths.
- The modal offers the same "Persist to config" button on a no-track outcome.

## Why now

Blocking for adding Auto-Calibrate to the setup wizard (ClickUp 86cb71r91), where the next restart is seconds away — `/set-up/complete` force-recreates the stack — so the run's only durable output was lost every single time. Worth having on its own for the Configuration page too, where it was merely lost later rather than immediately.

## Design decisions

- **Cancel still means put it back.** `_check_cancel` fires before the fallback is recorded, so a cancelled run has nothing to persist and the route rejects it. Tested.
- **`fc` stays on the top-ranked tower.** `best_attempt` can name a different tower and stays informational — persisting it would silently overrule the configured/chosen tower. This was validated live: see below.
- **Offered, not automatic.** Matches the existing persist-on-success UX and avoids restarting the stack under someone who didn't ask. The wizard will call the route directly.

## Testing

549 tests pass on this base, ruff clean. 7 new tests: four drive a real `Calibrator` through `run_to_completion` (fallback recorded, top-tower `fc`, cancel records nothing, new run clears the previous fallback); three cover the route (persists a no-track fallback, rejects a cancelled run, prefers a confirmed result).

**Live-verified on owl (192.168.0.144), real SDRplay hardware.**

Success path — unforced run confirmed a real track, and `fallback` correctly stayed `null`:
```
state: done   result: track_id 260824-00005A, WGBY-TV @ 213MHz, gain (20, 39), LNA 1
```

No-track path — forced by raising the tracker's `min_snr` out of reach. All three towers tried, budget exhausted at 897/900:
```
state:        failed
result:       None
fallback:     WGBY-TV @ 213000000, gain (20, 39), LNA 1   <- towers[0]
best_attempt: WVER    @ 195000000                          <- a DIFFERENT tower
```
`POST /calibrate/apply` returned **202** (it returns **409** on this status without this change), wrote `user.yml`, applied in ~48s, stack healthy afterwards with blah2 reporting the gains live.

That `best_attempt` landed on a different tower is the concrete justification for the `fc`-pinning decision — persisting it would have moved the node off WGBY-TV onto WVER.

## Reviewer caveats

1. **The JavaScript has not executed.** Everything above was driven through the API. The `status.fallback` render branch in `templates/config.html` is inspection-only — if it has a bug, the backend works but the button never appears. This is the part most worth a careful read.
2. **The persist offer is transient (pre-existing, not introduced here).** The modal's reattach only re-renders when `status.state === 'running'`, so closing the modal or refreshing after a no-track run loses the button even though the status still holds the fallback and the route would still accept it. Identical for the success path today, but it matters more now that no-track is the common case. Suggested follow-up rather than a change here.
3. **Expect CI noise.** `test_tracker_capture.py::test_refresh_failure_does_not_kill_capture_loop` is a 2.0s timing assertion that flaked on a loaded runner and passes locally, in a file this change does not touch.
4. **Untested in anger:** the `(59, 59, 9)` still-overloading case, where "best proven" means "safest reachable" rather than proven clean. owl never overloaded at any step, so that path did not run. It is still strictly safer than the shipped default, which overloads worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)