### PR TITLE
Accept an empty ADS-B source when adsb.lol fallback is on

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -194,10 +194,18 @@ class Tar1090Config(BaseModel):
 
     Note: adsb_source is stored as comma-separated string in YAML
     but split into 3 fields for the form.
+
+    The three source fields are optional here so that a node with no local
+    beast feed can be described at all: one fed from adsb.lol via the tar1090
+    proxy has nothing to point them at, and blanking adsb_source is how that
+    is expressed. Optional does not mean free-standing, though. When they may
+    actually be left empty depends on adsblol_fallback, and a partial set is
+    never valid, so both rules are enforced on save in routes/config.py, where
+    each complaint can be attached to the box it concerns.
     """
-    adsb_source_host: str = Field(title="ADS-B Host", description="IP or hostname")
-    adsb_source_port: int = Field(ge=1, le=65535, title="ADS-B Port")
-    adsb_source_protocol: str = Field(title="Protocol", description="e.g. beast_in")
+    adsb_source_host: str | None = Field(None, title="ADS-B Host", description="IP or hostname")
+    adsb_source_port: int | None = Field(None, ge=1, le=65535, title="ADS-B Port")
+    adsb_source_protocol: str | None = Field(None, title="Protocol", description="e.g. beast_in")
     adsblol_fallback: bool = Field(title="adsb.lol Fallback")
     adsblol_radius: int = Field(ge=1, le=500, title="adsb.lol Radius", description="nautical miles")
 

--- a/src/form_utils.py
+++ b/src/form_utils.py
@@ -3,6 +3,7 @@ Utilities for converting Pydantic schemas to form field dicts for Jinja renderin
 
 Compatible with both Pydantic v1 (Debian Bookworm apt) and v2.
 """
+import types
 from typing import Literal, Union, get_args, get_origin
 
 # Detect Pydantic version
@@ -52,10 +53,19 @@ def get_field_readonly(field_info):
     return False
 
 
+# Optional[X] and X | None describe the same type but are not the same object:
+# get_origin returns typing.Union for the first and types.UnionType for the
+# second. Matching only the first makes a PEP 604 field quietly lose its input
+# type and render a port as a text box instead of a number one, so both forms
+# are accepted here. The repo's ruff config enforces X | None (UP045), which
+# would otherwise be the failing style.
+_UNION_ORIGINS = (Union, types.UnionType)
+
+
 def _unwrap_optional(annotation):
-    """Strip Optional[X] down to X."""
+    """Strip Optional[X] / X | None down to X."""
     origin = get_origin(annotation)
-    if origin is Union:
+    if origin in _UNION_ORIGINS:
         args = get_args(annotation)
         non_none = [a for a in args if a is not type(None)]
         if non_none:

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -98,6 +98,39 @@ def delete_key():
     return redirect(url_for("config.config_page"))
 
 
+# The three ADS-B source boxes are one YAML value (host,port,protocol), so they
+# only mean anything as a set: complete, or empty because adsb.lol is feeding
+# tar1090 instead. Neither of those is what the form produces on its own, hence
+# both checks here.
+#
+# Checked here rather than in the schema so each complaint lands on the box it
+# belongs to. Pydantic can see adsblol_fallback perfectly well - it is a field
+# of the same model - but a model-level error carries no field name, so the
+# page would raise its banner with nothing highlighted, which is the failure
+# this whole change exists to remove.
+_ADSB_SOURCE_FIELDS = ("adsb_source_host", "adsb_source_port", "adsb_source_protocol")
+
+
+def _adsb_source_errors(tar1090_data):
+    """Per-field errors for a source that is neither complete nor legitimately empty."""
+    missing = [f for f in _ADSB_SOURCE_FIELDS if tar1090_data.get(f) in (None, "")]
+    if not missing:
+        return {}
+
+    if len(missing) == len(_ADSB_SOURCE_FIELDS):
+        # Nothing to point at is fine only when adsb.lol is covering for it.
+        if tar1090_data.get("adsblol_fallback"):
+            return {}
+        reason = "an ADS-B source is required unless adsb.lol fallback is turned on"
+    else:
+        # A partial set joins into a malformed "host,," that tar1090 accepts
+        # and then quietly never connects on.
+        reason = ("required when an ADS-B source is set "
+                  "(clear all three to feed tar1090 from adsb.lol instead)")
+
+    return {f"tar1090.{f}": reason for f in missing}
+
+
 @bp.route("/config/save", methods=["POST"])
 def save_config():
     """Save config form data to user.yml."""
@@ -142,6 +175,7 @@ def save_config():
             Tar1090Config(**tar1090_data)
         except ValidationError as e:
             all_errors.update(ConfigManager.format_validation_errors(e, 'tar1090'))
+        all_errors.update(_adsb_source_errors(tar1090_data))
 
     if retina_tracker_data:
         try:
@@ -170,8 +204,13 @@ def save_config():
         host = tar1090_data.pop('adsb_source_host', '')
         port = tar1090_data.pop('adsb_source_port', '')
         protocol = tar1090_data.pop('adsb_source_protocol', '')
-        if host or port or protocol:
-            tar1090_nested['adsb_source'] = f"{host},{port},{protocol}"
+        # An emptied source is written as "" rather than omitted. default.yml
+        # ships a source of its own, so dropping the key here would leave the
+        # merge free to put that default straight back and silently undo the
+        # clearing. compute_user_overrides still discards the "" when it
+        # matches what is already merged, so nothing is pinned needlessly.
+        tar1090_nested['adsb_source'] = (f"{host},{port},{protocol}"
+                                         if host or port or protocol else "")
         tar1090_nested.update(tar1090_data)
 
     merged_config = config_mgr.load_merged_config()

--- a/templates/config.html
+++ b/templates/config.html
@@ -336,9 +336,15 @@
                 <div class="cfg-grid three">
                     {% for fname in ['adsb_source_host', 'adsb_source_port', 'adsb_source_protocol'] %}
                     {% if fname in t %}
+                    {# This section is hand-built rather than rendered through
+                       render_field, so it has to look config_errors up itself.
+                       Without this the banner above claims fields are
+                       highlighted and none of them are. #}
+                    {% set t_err = config_errors.get('tar1090.' ~ fname) if config_errors else none %}
                     <div>
                         <div class="ds-label-micro" style="margin-bottom:6px;">{{ t[fname].title }}</div>
-                        <input type="{{ t[fname].type }}" name="tar1090.{{ fname }}" class="ds-input mono" value="{{ t[fname].value if t[fname].value is not none else '' }}">
+                        <input type="{{ t[fname].type }}" name="tar1090.{{ fname }}" class="ds-input mono{% if t_err %} is-invalid{% endif %}" value="{{ t[fname].value if t[fname].value is not none else '' }}">
+                        {% if t_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ t_err }}</div>{% endif %}
                     </div>
                     {% endif %}
                     {% endfor %}
@@ -355,10 +361,12 @@
                         <div class="desc">Use the public adsb.lol feed if no local ADS-B receiver is reachable.</div>
                     </div>
                     {% if 'adsblol_radius' in t %}
+                    {% set radius_err = config_errors.get('tar1090.adsblol_radius') if config_errors else none %}
                     <div class="cfg-input-row" style="width:180px;flex-shrink:0;">
-                        <input type="number" name="tar1090.adsblol_radius" class="ds-input mono" min="1" max="500" value="{{ t['adsblol_radius'].value if t['adsblol_radius'].value is not none else '' }}">
+                        <input type="number" name="tar1090.adsblol_radius" class="ds-input mono{% if radius_err %} is-invalid{% endif %}" min="1" max="500" value="{{ t['adsblol_radius'].value if t['adsblol_radius'].value is not none else '' }}">
                         <span class="unit">nm</span>
                     </div>
+                    {% if radius_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ radius_err }}</div>{% endif %}
                     {% endif %}
                 </div>
                 {% endif %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -449,6 +449,70 @@ class TestTar1090Save:
         # adsblol_fallback=True is same as merged config, might not be saved
         # (only values that differ are saved)
 
+    def test_blank_adsb_source_saved_as_explicit_blank(self, app_client, user_config_file):
+        """Clearing all three boxes must save, and must stay cleared."""
+        response = app_client.post('/config/save', data={
+            'tar1090.adsb_source_host': '',
+            'tar1090.adsb_source_port': '',
+            'tar1090.adsb_source_protocol': '',
+            'tar1090.adsblol_fallback': 'on',
+            'tar1090.adsblol_radius': '50',
+        }, follow_redirects=False)
+
+        assert response.status_code == 302
+
+        with open(user_config_file) as f:
+            saved = yaml.safe_load(f)
+        # Written as "" rather than left out: default.yml ships a source of its
+        # own, so an omitted key would merge that default straight back in.
+        assert saved['tar1090']['adsb_source'] == ''
+
+    def test_complete_adsb_source_saves_with_fallback_off(self, app_client, user_config_file):
+        """adsb.lol only excuses an empty source; a full one never needed it."""
+        response = app_client.post('/config/save', data={
+            'tar1090.adsb_source_host': '10.0.0.1',
+            'tar1090.adsb_source_port': '30006',
+            'tar1090.adsb_source_protocol': 'raw_in',
+            # adsblol_fallback unchecked, so the browser does not post it
+            'tar1090.adsblol_radius': '50',
+        }, follow_redirects=False)
+
+        assert response.status_code == 302
+
+        with open(user_config_file) as f:
+            saved = yaml.safe_load(f)
+        assert saved['tar1090']['adsb_source'] == '10.0.0.1,30006,raw_in'
+        assert saved['tar1090']['adsblol_fallback'] is False
+
+    def test_blank_adsb_source_rejected_without_fallback(self, app_client):
+        """With adsb.lol off too, an empty source leaves the node no ADS-B at all."""
+        response = app_client.post('/config/save', data={
+            'tar1090.adsb_source_host': '',
+            'tar1090.adsb_source_port': '',
+            'tar1090.adsb_source_protocol': '',
+            # adsblol_fallback unchecked, so the browser does not post it
+            'tar1090.adsblol_radius': '50',
+        })
+
+        assert response.status_code == 200
+        assert b'an ADS-B source is required unless adsb.lol fallback' in response.data
+
+    def test_partial_adsb_source_rejected(self, app_client):
+        """A host with no port or protocol would join into a broken "host,,"."""
+        response = app_client.post('/config/save', data={
+            'tar1090.adsb_source_host': '10.0.0.1',
+            'tar1090.adsb_source_port': '',
+            'tar1090.adsb_source_protocol': '',
+            'tar1090.adsblol_fallback': 'on',
+            'tar1090.adsblol_radius': '50',
+        })
+
+        assert response.status_code == 200
+        assert b'Please fix the highlighted fields below' in response.data
+        # The complaint has to reach the empty boxes. A banner with nothing
+        # highlighted is what made the original bug so hard to place.
+        assert b'required when an ADS-B source is set' in response.data
+
     def test_invalid_port(self, app_client):
         """Port > 65535 should show error banner."""
         response = app_client.post('/config/save', data={

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -275,6 +275,23 @@ class TestTar1090Config:
         )
         assert config.adsb_source_port == 30005
 
+    def test_blank_adsb_source(self):
+        """No local beast feed must be describable at all.
+
+        A node fed from adsb.lol through the tar1090 proxy has nothing to
+        point these at, and a blank adsb_source is how that is expressed.
+        While all three were required, blanking it made the whole config
+        page unsaveable - every field on it, not just this section.
+
+        Whether a blank source is allowed on a given save depends on
+        adsblol_fallback; that rule lives in routes/config.py, so the model
+        on its own accepts the absence.
+        """
+        config = Tar1090Config(adsblol_fallback=True, adsblol_radius=120)
+        assert config.adsb_source_host is None
+        assert config.adsb_source_port is None
+        assert config.adsb_source_protocol is None
+
     def test_port_bounds(self):
         """Port must be 1-65535."""
         with pytest.raises(ValidationError):

--- a/tests/test_form_utils.py
+++ b/tests/test_form_utils.py
@@ -3,7 +3,7 @@
 Tests the form field generation from flat Pydantic schemas.
 """
 
-from config_schema import AdsbTruthConfig, CaptureFormConfig, LocationFormConfig
+from config_schema import AdsbTruthConfig, CaptureFormConfig, LocationFormConfig, Tar1090Config
 from form_utils import get_field_constraints, get_field_input_type, schema_to_form_fields
 
 
@@ -24,6 +24,17 @@ class TestGetFieldInputType:
         """String fields should map to text."""
         field_info = CaptureFormConfig.model_fields['device_type']
         assert get_field_input_type(field_info) == 'text'
+
+    def test_optional_int_to_number(self):
+        """`X | None` must map the same as `X`.
+
+        get_origin returns types.UnionType for a PEP 604 union but
+        typing.Union for Optional[X]. Recognising only the latter renders an
+        optional port as a plain text box with no spinner or browser-side
+        range check, which is easy to miss because nothing errors.
+        """
+        field_info = Tar1090Config.model_fields['adsb_source_port']
+        assert get_field_input_type(field_info) == 'number'
 
     def test_float_to_number(self):
         """Float fields should map to number."""
@@ -52,6 +63,12 @@ class TestGetFieldConstraints:
         constraints = get_field_constraints(field_info)
         assert constraints.get('max') == 0
         assert 'min' not in constraints
+
+    def test_optional_int_keeps_constraints(self):
+        """Bounds on a `X | None` field must survive the unwrap."""
+        constraints = get_field_constraints(Tar1090Config.model_fields['adsb_source_port'])
+        assert constraints['min'] == 1
+        assert constraints['max'] == 65535
 
     def test_no_constraints(self):
         """Field with no constraints."""


### PR DESCRIPTION
A node fed from adsb.lol through the tar1090 proxy has no local beast feed to name, and blanking `tar1090.adsb_source` is how that is expressed. jonathan-node-1 is configured that way.

The Configuration page then refused **every** save on that node, whatever field was being edited. The form renders the three source boxes empty, `parse_flat_form_data` drops empty values on submit, and `Tar1090Config` required all three, so the page came back complaining about three fields nobody had touched.

Nothing was highlighted either. The tar1090 section is hand-built markup rather than the `render_field` macro, so it never consulted `config_errors`. The banner named fields it had no way to point at, which is what made the failure so hard to place.

## The rule

An empty source is accepted when `adsblol_fallback` is on, and only then. With the fallback off as well the node would have no ADS-B truth at all, so that combination is still refused.

| Source | adsb.lol fallback | Result |
| --- | --- | --- |
| all three empty | on | saves |
| all three empty | off | refused: "an ADS-B source is required unless adsb.lol fallback is turned on" |
| partially filled | either | refused, on the empty boxes |
| all three filled | either | saves, unchanged |

## Changes

- `Tar1090Config`: the three source fields are optional, so the absence is expressible at all.
- Both rules live in `save_config`, keyed per empty field. A partial set is never valid since it joins into a malformed `"host,,"` that tar1090 accepts and then quietly never connects on. Pydantic can see `adsblol_fallback` perfectly well, but a model-level error carries no field name and would reproduce the invisible banner this change exists to remove.
- A cleared source writes `adsb_source: ""` rather than dropping the key. The config-merger's `default.yml` ships a source of its own, so an omitted key would let the merge put that default straight back and undo the clearing.
- The tar1090 inputs render their errors.
- `_unwrap_optional` only recognised `typing.Union`, so the `X | None` spelling ruff requires (UP045) would have rendered the port as a text box with no spinner and no browser-side range check. It now accepts `types.UnionType` too, which is what `get_origin` returns for a PEP 604 union.

## Verification

- 556 tests pass; ruff and the dead-code gate are clean.
- Checked against pydantic 1.10.4 on a node as well as 2.13.4 in CI: form field types and bounds come out identical to before the change on both.
- Deployed to jonathan-node-1 and replayed a save of its live config: previously refused, now accepted, and still refused when the fallback is flipped off.

## Known gap, not fixed here

The same invisible-banner defect exists in the location section, which is also hand-built without a `config_errors` lookup. It is easier to hit than the tar1090 one: the form is `novalidate`, so a mistyped latitude reaches the server, is correctly rejected, and highlights nothing. Filed as [86cb9dnfq](https://app.clickup.com/t/86cb9dnfq) to keep this change about the ADS-B source rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
