### PR TITLE
Add Auto-Calibrate as a setup wizard step

### DIFF
--- a/src/calibrator.py
+++ b/src/calibrator.py
@@ -289,6 +289,18 @@ DWELL_POLL_SECONDS = 1.0
 # the dwell catches what one probe cannot.
 DWELL_OVERLOAD_CHECK_SECONDS = 5.0
 
+# How long a skip-confirmation run watches its resolved operating point before
+# accepting it. Descent proves a candidate only over OVERLOAD_SETTLE_SECONDS —
+# a single second — and the whole reason DWELL_OVERLOAD_CHECK_SECONDS exists is
+# that one probe cannot tell a clean point from one that clips intermittently.
+# Skipping the dwell entirely would therefore persist a one-second verdict, and
+# the documented failure above (device cycling Overload_Detected/Corrected until
+# the SDRplay API stopped answering) is exactly what that misses. So the track
+# wait goes, the overload watch stays: ~9 checks at 5s apart, enough to absorb
+# MAX_DWELL_BACKOFFS retreats and still leave several clean readings at the
+# point we finally keep.
+SOAK_SECONDS = 45.0
+
 # How many times a dwell retreats before giving up on the tower. Each backoff
 # costs part of the dwell window, and a point needing several is not one worth
 # dwelling on.
@@ -426,11 +438,11 @@ class Calibrator:
             # None for a cancelled run — cancel restores the original
             # tuning, so there is deliberately nothing to offer.
             "fallback": None,
-            # True when the caller asked for a descent-only run (setup wizard).
-            # Consumers need it to tell "we deliberately never looked for a
-            # track" from "we looked and found nothing" — the two have very
-            # different things to say to a user. See _run.
-            "descent_only": False,
+            # True when the caller asked to skip track confirmation (setup
+            # wizard). Consumers need it to tell "we deliberately never looked
+            # for a track" from "we looked and found nothing" — the two have
+            # very different things to say to a user. See _run.
+            "skip_confirmation": False,
             "error": None,
             "original": None,
             # None until the preflight has something to report. Only set when
@@ -456,7 +468,7 @@ class Calibrator:
         return status
 
     def start(self, towers, original, budget_seconds=TOTAL_BUDGET_SECONDS,
-              dwell_seconds=None, mode=MODE_TRACK, descent_only=False):
+              dwell_seconds=None, mode=MODE_TRACK, skip_confirmation=False):
         """Start a run. Returns (started, error).
 
         towers: list of {"name": str, "fc": int Hz} — first entry is dwelt on
@@ -468,15 +480,19 @@ class Calibrator:
         time remains after each tower's descent evenly across the towers
         still to go. Descent is never taken out of this — it runs under its
         own DESCENT_BACKSTOP_SECONDS ceiling.
-        descent_only: resolve each tower's operating point and stop, never
-        dwelling for a confirmed track. Built for the setup wizard, which
-        wants a non-overloading tuning rather than a confirmation: it turns a
-        ~15 minute run into roughly the descent's own ~200s, and since no
+        skip_confirmation: resolve each tower's operating point, soak it for
+        SOAK_SECONDS to prove it holds, and stop — never waiting for a
+        confirmed track. Built for the setup wizard, which wants a stable
+        non-overloading tuning rather than a confirmation: it turns a ~15
+        minute run into roughly the descent plus the soak, and since no
         confirmation is attempted, none can be spurious — which matters while
         _on_track_event still accepts tracks the sidecar itself flags as
         implausible. The run ends with no result, so the no-track fallback
         persists the resolved tuning exactly as it would otherwise.
-        Deliberately NOT expressed as dwell_seconds=0: that lands in the
+        It does NOT skip overload watching: descent proves a candidate over
+        one second, and a point that clips intermittently only shows up when
+        it is sat on (see SOAK_SECONDS and DWELL_OVERLOAD_CHECK_SECONDS).
+        Also deliberately NOT expressed as dwell_seconds=0: that lands in the
         "budget genuinely exhausted" branch and reports skipped_no_time,
         which would be a false explanation here.
         mode: MODE_TRACK (any confirmed track) or MODE_ADSB (confirmed track
@@ -502,7 +518,7 @@ class Calibrator:
             self._status.update({
                 "state": "running",
                 "mode": mode,
-                "descent_only": bool(descent_only),
+                "skip_confirmation": bool(skip_confirmation),
                 "started_at": _utcnow(),
                 "original": dict(original),
                 "_started_monotonic": time.monotonic(),
@@ -519,7 +535,7 @@ class Calibrator:
         self._thread = threading.Thread(
             target=self._run, args=(list(towers), dict(original),
                                     budget_seconds, dwell_seconds, mode,
-                                    bool(descent_only)),
+                                    bool(skip_confirmation)),
             daemon=True)
         self._thread.start()
         return True, None
@@ -1148,7 +1164,7 @@ class Calibrator:
         return gain_a, gain_b, lna_state, applied_at
 
     def _dwell(self, tower, fc, gain_a, gain_b, lna_state, applied_at, dwell_deadline,
-               tower_entry):
+               tower_entry, watch_only=False):
         """MODE_TRACK's dwell: push live detections to the shared
         retina-tracker sidecar (see module docstring for why — blah2's own
         tracker is not trusted here) and wait for it to emit a confirmed
@@ -1157,8 +1173,11 @@ class Calibrator:
         _dwell_adsb instead — see the module docstring.)
         """
         self._update(phase="dwelling")
-        # Start from a genuinely empty tracker — see _reset_tracker.
-        self._reset_tracker()
+        # Start from a genuinely empty tracker — see _reset_tracker. Skipped
+        # for a watch_only soak: it never reads the tracker, so resetting it
+        # would only disturb tracker_capture's always-on feed for no gain.
+        if not watch_only:
+            self._reset_tracker()
         max_evidence = EVIDENCE_NONE
         max_detections = 0
         last_timestamp = None
@@ -1183,6 +1202,15 @@ class Calibrator:
                         tower_entry["outcome"] = "unstable_overload"
                         tower_entry["max_evidence"] = max_evidence
                         tower_entry["max_detections"] = max_detections
+                        # As on the other two exits: record where the backoffs
+                        # actually left the device. Without this the entry
+                        # keeps descent's pre-retreat values, and the no-track
+                        # fallback then persists the very tuning this branch
+                        # just proved unstable — undoing the retreat
+                        # _dwell_backoff already applied to the hardware.
+                        tower_entry["final_gain_a"] = gain_a
+                        tower_entry["final_gain_b"] = gain_b
+                        tower_entry["final_lna_state"] = lna_state
                         return None
                     backoffs += 1
                     gain_a, gain_b, lna_state, applied_at = self._dwell_backoff(
@@ -1195,6 +1223,13 @@ class Calibrator:
                     self._reset_tracker()
                     last_timestamp = None
                     overload_baseline = self._overload_reading()
+
+            if watch_only:
+                # The soak's entire job is the overload check above. No
+                # detections are fed and no confirmation is looked for, so
+                # there is nothing here that could be falsely confirmed.
+                self._sleep(TRACKER_FEED_POLL_SECONDS)
+                continue
 
             detection = self._client.get_detection()
             timestamp = detection.get("timestamp") if detection else None
@@ -1230,7 +1265,10 @@ class Calibrator:
                                             max_evidence, max_detections)
             self._sleep(TRACKER_FEED_POLL_SECONDS)
 
-        tower_entry["outcome"] = "no_confirmed_track"
+        # A soak that reached its deadline without the overload watch giving
+        # up has done its job: the point held. "no_confirmed_track" would be
+        # a false report of a search that never ran.
+        tower_entry["outcome"] = "tuned" if watch_only else "no_confirmed_track"
         tower_entry["max_evidence"] = max_evidence
         tower_entry["max_detections"] = max_detections
         # As on the success path: a mid-dwell backoff may have moved these
@@ -1525,7 +1563,7 @@ class Calibrator:
     # ── Run loop ───────────────────────────────────────────────
 
     def _run(self, towers, original, budget_seconds, dwell_seconds, mode,
-             descent_only=False):
+             skip_confirmation=False):
         # Must happen before the first retune: the safe-corner handover can
         # only tell a frequency change from a no-op if it knows where the
         # radio actually is. See _seed_last_applied_fc.
@@ -1637,14 +1675,20 @@ class Calibrator:
                         # when a retune failed, which would let stale
                         # detections through the dwell's freshness guard.
                         applied_at = verified_at
-                        if descent_only:
-                            # The whole point: the operating point is
-                            # resolved, so stop. Its own outcome label, not
-                            # skipped_no_time — nothing was skipped and no
-                            # time ran out, and the UI must be able to say
-                            # "tuned" rather than inventing a shortage that
-                            # did not happen.
-                            tower_entry["outcome"] = "descent_only"
+                        if skip_confirmation:
+                            # Soak the resolved point rather than trusting
+                            # descent's one-second verdict on it: same
+                            # overload watch and same backoff the full dwell
+                            # uses, just no track to wait for. See
+                            # SOAK_SECONDS for why skipping this outright was
+                            # wrong. _dwell records final_* after any backoff,
+                            # so the fallback persists what the soak settled
+                            # on, not what descent first proposed.
+                            self._dwell(tower, fc, gain_a, gain_b, lna_state,
+                                        verified_at,
+                                        min(time.monotonic() + SOAK_SECONDS,
+                                            run_deadline),
+                                        tower_entry, watch_only=True)
                             result = None
                             continue
                         # Dwell gets the rest of this tower's slice — the
@@ -1697,18 +1741,18 @@ class Calibrator:
                     break
 
             if result is None and error is None:
-                if descent_only:
+                if skip_confirmation:
                     # Not a failure: this run did exactly what was asked. The
                     # state stays "failed" because there is no confirmed
                     # result — but the message must not borrow the dwell's
                     # "no aircraft was overhead" explanation for a dwell that
                     # never ran. Callers distinguish the two on the
-                    # descent_only flag in status, and the tuning itself is
+                    # skip_confirmation flag in status, and the tuning itself is
                     # persisted through the same fallback path below.
                     error = ("Tuning resolved. This run found the best "
-                             "non-overloading settings for this tower and "
-                             "stopped there, without waiting to confirm a "
-                             "track.")
+                             "settings for this tower and checked they held "
+                             "without overloading the receiver, but was not "
+                             "asked to wait for a confirmed track.")
                 elif mode == MODE_ADSB:
                     error = ("No ADS-B-verified track: every candidate tower "
                              "and gain setting was tried, but no confirmed "

--- a/src/calibrator.py
+++ b/src/calibrator.py
@@ -426,6 +426,11 @@ class Calibrator:
             # None for a cancelled run — cancel restores the original
             # tuning, so there is deliberately nothing to offer.
             "fallback": None,
+            # True when the caller asked for a descent-only run (setup wizard).
+            # Consumers need it to tell "we deliberately never looked for a
+            # track" from "we looked and found nothing" — the two have very
+            # different things to say to a user. See _run.
+            "descent_only": False,
             "error": None,
             "original": None,
             # None until the preflight has something to report. Only set when
@@ -451,7 +456,7 @@ class Calibrator:
         return status
 
     def start(self, towers, original, budget_seconds=TOTAL_BUDGET_SECONDS,
-              dwell_seconds=None, mode=MODE_TRACK):
+              dwell_seconds=None, mode=MODE_TRACK, descent_only=False):
         """Start a run. Returns (started, error).
 
         towers: list of {"name": str, "fc": int Hz} — first entry is dwelt on
@@ -463,6 +468,17 @@ class Calibrator:
         time remains after each tower's descent evenly across the towers
         still to go. Descent is never taken out of this — it runs under its
         own DESCENT_BACKSTOP_SECONDS ceiling.
+        descent_only: resolve each tower's operating point and stop, never
+        dwelling for a confirmed track. Built for the setup wizard, which
+        wants a non-overloading tuning rather than a confirmation: it turns a
+        ~15 minute run into roughly the descent's own ~200s, and since no
+        confirmation is attempted, none can be spurious — which matters while
+        _on_track_event still accepts tracks the sidecar itself flags as
+        implausible. The run ends with no result, so the no-track fallback
+        persists the resolved tuning exactly as it would otherwise.
+        Deliberately NOT expressed as dwell_seconds=0: that lands in the
+        "budget genuinely exhausted" branch and reports skipped_no_time,
+        which would be a false explanation here.
         mode: MODE_TRACK (any confirmed track) or MODE_ADSB (confirmed track
         that also matches a real aircraft's expected position, per the
         node's own truth.adsb.delay_tolerance/doppler_tolerance config — the
@@ -486,6 +502,7 @@ class Calibrator:
             self._status.update({
                 "state": "running",
                 "mode": mode,
+                "descent_only": bool(descent_only),
                 "started_at": _utcnow(),
                 "original": dict(original),
                 "_started_monotonic": time.monotonic(),
@@ -501,7 +518,8 @@ class Calibrator:
         self._cancel.clear()
         self._thread = threading.Thread(
             target=self._run, args=(list(towers), dict(original),
-                                    budget_seconds, dwell_seconds, mode),
+                                    budget_seconds, dwell_seconds, mode,
+                                    bool(descent_only)),
             daemon=True)
         self._thread.start()
         return True, None
@@ -1506,7 +1524,8 @@ class Calibrator:
 
     # ── Run loop ───────────────────────────────────────────────
 
-    def _run(self, towers, original, budget_seconds, dwell_seconds, mode):
+    def _run(self, towers, original, budget_seconds, dwell_seconds, mode,
+             descent_only=False):
         # Must happen before the first retune: the safe-corner handover can
         # only tell a frequency change from a no-op if it knows where the
         # radio actually is. See _seed_last_applied_fc.
@@ -1618,6 +1637,16 @@ class Calibrator:
                         # when a retune failed, which would let stale
                         # detections through the dwell's freshness guard.
                         applied_at = verified_at
+                        if descent_only:
+                            # The whole point: the operating point is
+                            # resolved, so stop. Its own outcome label, not
+                            # skipped_no_time — nothing was skipped and no
+                            # time ran out, and the UI must be able to say
+                            # "tuned" rather than inventing a shortage that
+                            # did not happen.
+                            tower_entry["outcome"] = "descent_only"
+                            result = None
+                            continue
                         # Dwell gets the rest of this tower's slice — the
                         # part descent was capped out of. A slow descent
                         # therefore shortens its own dwell but can never
@@ -1668,7 +1697,19 @@ class Calibrator:
                     break
 
             if result is None and error is None:
-                if mode == MODE_ADSB:
+                if descent_only:
+                    # Not a failure: this run did exactly what was asked. The
+                    # state stays "failed" because there is no confirmed
+                    # result — but the message must not borrow the dwell's
+                    # "no aircraft was overhead" explanation for a dwell that
+                    # never ran. Callers distinguish the two on the
+                    # descent_only flag in status, and the tuning itself is
+                    # persisted through the same fallback path below.
+                    error = ("Tuning resolved. This run found the best "
+                             "non-overloading settings for this tower and "
+                             "stopped there, without waiting to confirm a "
+                             "track.")
+                elif mode == MODE_ADSB:
                     error = ("No ADS-B-verified track: every candidate tower "
                              "and gain setting was tried, but no confirmed "
                              "track ever matched a real aircraft while one "

--- a/src/calibrator.py
+++ b/src/calibrator.py
@@ -1172,7 +1172,11 @@ class Calibrator:
         dict on success, None if the dwell budget expires. (MODE_ADSB uses
         _dwell_adsb instead — see the module docstring.)
         """
-        self._update(phase="dwelling")
+        # A soak is not dwelling for aircraft and must not say it is: its own
+        # phase, so both UIs can label it honestly. Reusing "dwelling" showed
+        # "Watching for aircraft…" through the setup wizard's soak — on a step
+        # whose whole copy promises no aircraft (caught in live testing).
+        self._update(phase="soaking" if watch_only else "dwelling")
         # Start from a genuinely empty tracker — see _reset_tracker. Skipped
         # for a watch_only soak: it never reads the tracker, so resetting it
         # would only disturb tracker_capture's always-on feed for no gain.
@@ -1684,11 +1688,19 @@ class Calibrator:
                             # wrong. _dwell records final_* after any backoff,
                             # so the fallback persists what the soak settled
                             # on, not what descent first proposed.
+                            soak_started = time.monotonic()
                             self._dwell(tower, fc, gain_a, gain_b, lna_state,
                                         verified_at,
-                                        min(time.monotonic() + SOAK_SECONDS,
+                                        min(soak_started + SOAK_SECONDS,
                                             run_deadline),
                                         tower_entry, watch_only=True)
+                            # Its own key, not dwell_seconds: how long the
+                            # point was proven to hold is the soak's whole
+                            # output, and reporting it as a dwell would
+                            # invite reading it as time spent looking for
+                            # aircraft.
+                            tower_entry["soak_seconds"] = round(
+                                time.monotonic() - soak_started, 1)
                             result = None
                             continue
                         # Dwell gets the rest of this tower's slice — the

--- a/src/routes/calibrate.py
+++ b/src/routes/calibrate.py
@@ -162,16 +162,26 @@ def start():
         return jsonify({"success": False,
                         "error": "ADS-B verified mode is not currently available"}), 409
 
+    # Descent-only is the setup wizard's shape: resolve the operating point
+    # and stop, rather than dwelling ~700s for a confirmation the wizard does
+    # not need. Opt-in per request, so the Configuration page entry point is
+    # untouched and keeps all three towers plus the full dwell. Paired there
+    # with scope: "current_tower", but deliberately independent of it — the
+    # two answer different questions (how many towers vs whether to dwell).
+    descent_only = bool(body.get("descent_only"))
+
     if not device_state.acquire_calibration_lock():
         return jsonify({"success": False,
                         "error": "Auto-calibration already in progress"}), 409
 
-    started, error = calibrator.start(towers, original, mode=mode)
+    started, error = calibrator.start(towers, original, mode=mode,
+                                      descent_only=descent_only)
     if not started:
         device_state.release_calibration_lock()
         return jsonify({"success": False, "error": error}), 409
 
     return jsonify({"success": True, "mode": mode,
+                    "descent_only": descent_only,
                     "towers": [tower["name"] for tower in towers]})
 
 

--- a/src/routes/calibrate.py
+++ b/src/routes/calibrate.py
@@ -162,26 +162,28 @@ def start():
         return jsonify({"success": False,
                         "error": "ADS-B verified mode is not currently available"}), 409
 
-    # Descent-only is the setup wizard's shape: resolve the operating point
-    # and stop, rather than dwelling ~700s for a confirmation the wizard does
-    # not need. Opt-in per request, so the Configuration page entry point is
-    # untouched and keeps all three towers plus the full dwell. Paired there
-    # with scope: "current_tower", but deliberately independent of it — the
-    # two answer different questions (how many towers vs whether to dwell).
-    descent_only = bool(body.get("descent_only"))
+    # The setup wizard's shape: resolve the operating point, soak it long
+    # enough to prove it is stable, and stop — rather than dwelling ~700s for
+    # a confirmation the wizard does not need. It still watches for overload;
+    # only the track wait is skipped (see calibrator.SOAK_SECONDS). Opt-in per
+    # request, so the Configuration page entry point is untouched and keeps
+    # all three towers plus the full dwell. Paired there with
+    # scope: "current_tower", but deliberately independent of it — the two
+    # answer different questions (how many towers vs whether to confirm).
+    skip_confirmation = bool(body.get("skip_confirmation"))
 
     if not device_state.acquire_calibration_lock():
         return jsonify({"success": False,
                         "error": "Auto-calibration already in progress"}), 409
 
     started, error = calibrator.start(towers, original, mode=mode,
-                                      descent_only=descent_only)
+                                      skip_confirmation=skip_confirmation)
     if not started:
         device_state.release_calibration_lock()
         return jsonify({"success": False, "error": error}), 409
 
     return jsonify({"success": True, "mode": mode,
-                    "descent_only": descent_only,
+                    "skip_confirmation": skip_confirmation,
                     "towers": [tower["name"] for tower in towers]})
 
 

--- a/static/calibrate.js
+++ b/static/calibrate.js
@@ -2,8 +2,8 @@
 //
 // Two entry points run calibration and they must not drift: the Configuration
 // page modal (a full run — every candidate tower, dwelling on each until a
-// track confirms) and the setup wizard step (descent-only, current tower, see
-// calibrator.py's descent_only). What they share is everything except the DOM:
+// track confirms) and the setup wizard step (current tower, descend then soak
+// for overload, no track wait — see calibrator.py's skip_confirmation). What they share is everything except the DOM:
 // the status vocabulary, the formatting, the "what did this run actually mean"
 // interpretation, and the fetch calls. Rendering stays with each caller, since
 // one is a Bootstrap modal and the other is a full-page wizard step.
@@ -38,7 +38,7 @@ window.RetinaCalibrate = (function() {
         skipped_no_time: 'never watched (the search ran out of time here)',
         tuning_not_applied: 'never watched (the radio did not accept this tuning)',
         unstable_overload: 'stopped (the signal kept overloading the receiver)',
-        descent_only: 'tuned (this run was not asked to wait for a track)',
+        tuned: 'tuned and held without overloading (no track was waited for)',
         not_reached: 'not reached'
     };
 
@@ -99,8 +99,8 @@ window.RetinaCalibrate = (function() {
         var watched = history.filter(function(h) {
             return h.outcome === 'no_confirmed_track' || h.outcome === 'confirmed_track';
         }).length;
-        var descentOnly = history.every(function(h) {
-            return h.outcome === 'descent_only';
+        var soakOnly = history.every(function(h) {
+            return h.outcome === 'tuned';
         });
         var lines = history.map(function(h) {
             var txt = OUTCOME_TEXT[h.outcome] || h.outcome || 'unknown';
@@ -109,10 +109,11 @@ window.RetinaCalibrate = (function() {
             if (h.tuning_error) extra += ' - ' + escapeHtml(h.tuning_error);
             return '<div>' + escapeHtml(h.tower_name || 'Tower') + ': ' + txt + extra + '</div>';
         });
-        // "Nothing was watched" is a warning for a run that meant to watch,
-        // and simply a description for one that never intended to — saying it
-        // about a descent-only run would invent a problem.
-        var lead = (watched === 0 && !descentOnly)
+        // "Nothing was watched" is a warning for a run that meant to watch
+        // for aircraft, and simply a description for one that never intended
+        // to. A soak DID watch — for overload, which is the thing it cared
+        // about — so saying this about it would invent a problem.
+        var lead = (watched === 0 && !soakOnly)
             ? '<strong>No tower was actually watched, so this is not evidence '
               + 'about aircraft.</strong><br>'
             : '';

--- a/static/calibrate.js
+++ b/static/calibrate.js
@@ -24,6 +24,9 @@ window.RetinaCalibrate = (function() {
         descending: 'Maximizing gain, backing off overload…',
         refining: 'Refining gain…',
         dwelling: 'Watching for aircraft…',
+        // The skip-confirmation soak: watching the settled operating point
+        // for overload, not waiting for a track. See calibrator.SOAK_SECONDS.
+        soaking: 'Checking the settings hold…',
         restoring: 'Restoring original tuning…'
     };
 

--- a/static/calibrate.js
+++ b/static/calibrate.js
@@ -1,0 +1,229 @@
+// Shared Auto-Calibrate driver.
+//
+// Two entry points run calibration and they must not drift: the Configuration
+// page modal (a full run — every candidate tower, dwelling on each until a
+// track confirms) and the setup wizard step (descent-only, current tower, see
+// calibrator.py's descent_only). What they share is everything except the DOM:
+// the status vocabulary, the formatting, the "what did this run actually mean"
+// interpretation, and the fetch calls. Rendering stays with each caller, since
+// one is a Bootstrap modal and the other is a full-page wizard step.
+//
+// Deliberately ES5-flavoured (var/function, no arrow functions) to match
+// setup.js, which is the more constrained of the two consumers.
+window.RetinaCalibrate = (function() {
+    'use strict';
+
+    function csrf() {
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        return meta ? meta.content : '';
+    }
+
+    var PHASE_LABELS = {
+        preflight: 'Checking the radio responds…',
+        recovering: 'Radio unresponsive, restarting it…',
+        descending: 'Maximizing gain, backing off overload…',
+        refining: 'Refining gain…',
+        dwelling: 'Watching for aircraft…',
+        restoring: 'Restoring original tuning…'
+    };
+
+    var MODE_LABELS = { track: 'Standard', adsb: 'ADS-B verified' };
+
+    // Per-tower outcomes the engine records but the run's summary message
+    // cannot express. Without these every failure reads as "probably no
+    // aircraft", including the ones that never looked for one.
+    var OUTCOME_TEXT = {
+        no_confirmed_track: 'watched, but nothing confirmed',
+        confirmed_track: 'confirmed a track',
+        skipped_no_time: 'never watched (the search ran out of time here)',
+        tuning_not_applied: 'never watched (the radio did not accept this tuning)',
+        unstable_overload: 'stopped (the signal kept overloading the receiver)',
+        descent_only: 'tuned (this run was not asked to wait for a track)',
+        not_reached: 'not reached'
+    };
+
+    function mhz(fc) { return (fc / 1e6).toFixed(1) + ' MHz'; }
+
+    function fmtSeconds(s) {
+        var m = Math.floor(s / 60), r = s % 60;
+        return m + ':' + (r < 10 ? '0' : '') + r;
+    }
+
+    function escapeHtml(s) {
+        var d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+
+    function warnBox(html) {
+        return '<div style="margin-top:10px;padding:8px 10px;border-radius:6px;'
+            + 'background:oklch(0.96 0.04 85);border:1px solid var(--warn,#b7791f);'
+            + 'color:var(--warn,#b7791f);font-size:12.5px;">' + html + '</div>';
+    }
+
+    // A server-pushed Mender deployment installs on its own schedule and
+    // cannot be refused from here, so it can replace the containers under a
+    // run. Say so rather than let the run die unexplained.
+    function updateWarning(status) {
+        if (!status.system_update) return '';
+        return warnBox('<strong>A system update is installing.</strong> '
+            + escapeHtml(status.system_update)
+            + '. It restarts the radar, so this calibration will not complete '
+            + 'and its results should be ignored. Run it again once the update '
+            + 'has finished.');
+    }
+
+    // The preflight only reports when it had to intervene. A clean probe is
+    // unremarkable; a restart is not — it persisted maximum attenuation to
+    // the config, deliberately and without reverting it (see calibrator.py's
+    // module docstring), so the user has to be told what was replaced or
+    // their gain settings appear to have changed by themselves.
+    function preflightNotice(status) {
+        var pf = status.preflight;
+        if (!pf || !pf.restarted) return '';
+        var was = pf.previous
+            ? ' Its previous setting was gain reduction A ' + pf.previous.gain_a
+              + ' dB / B ' + pf.previous.gain_b + ' dB, LNA state '
+              + pf.previous.lna_state + '.'
+            : '';
+        var lead = pf.recovered
+            ? 'The radio had stopped accepting tuning commands and was restarted.'
+            : 'The radio had stopped accepting tuning commands.';
+        return warnBox('<strong>' + lead + '</strong> It has been set to maximum '
+            + 'attenuation (gain reduction 59/59, LNA state 9) and that has '
+            + 'been saved to the configuration.' + was);
+    }
+
+    function diagnose(history) {
+        if (!history.length) return '';
+        var watched = history.filter(function(h) {
+            return h.outcome === 'no_confirmed_track' || h.outcome === 'confirmed_track';
+        }).length;
+        var descentOnly = history.every(function(h) {
+            return h.outcome === 'descent_only';
+        });
+        var lines = history.map(function(h) {
+            var txt = OUTCOME_TEXT[h.outcome] || h.outcome || 'unknown';
+            var extra = '';
+            if (h.dwell_seconds) extra = ' (' + Math.round(h.dwell_seconds) + 's)';
+            if (h.tuning_error) extra += ' - ' + escapeHtml(h.tuning_error);
+            return '<div>' + escapeHtml(h.tower_name || 'Tower') + ': ' + txt + extra + '</div>';
+        });
+        // "Nothing was watched" is a warning for a run that meant to watch,
+        // and simply a description for one that never intended to — saying it
+        // about a descent-only run would invent a problem.
+        var lead = (watched === 0 && !descentOnly)
+            ? '<strong>No tower was actually watched, so this is not evidence '
+              + 'about aircraft.</strong><br>'
+            : '';
+        return lead + lines.join('');
+    }
+
+    // The tuning a terminal run left available to persist, or null. A
+    // confirmed result wins; otherwise the no-track fallback, which exists
+    // precisely so a run that confirmed nothing still leaves something worth
+    // keeping (see calibrator.py's _apply_top_tower_fallback). Cancelled runs
+    // deliberately have neither.
+    function tuningOf(status) {
+        if (status.state === 'done' && status.result) return status.result;
+        return status.fallback || null;
+    }
+
+    function isTerminal(status) {
+        return status.state !== 'running' && status.state !== 'idle';
+    }
+
+    function post(url, body) {
+        var opts = { method: 'POST', headers: { 'X-CSRFToken': csrf() } };
+        if (body) {
+            opts.headers['Content-Type'] = 'application/json';
+            opts.body = JSON.stringify(body);
+        }
+        return fetch(url, opts).then(function(r) { return r.json(); });
+    }
+
+    function getStatus() {
+        return fetch('/calibrate/status').then(function(r) { return r.json(); });
+    }
+
+    // Poll /calibrate/status until the run leaves 'running', calling onStatus
+    // for every reading including the terminal one. Returns a stop function —
+    // callers that can be dismissed (modal close, wizard step change) must
+    // call it or the timer outlives the view.
+    function pollStatus(onStatus, intervalMs) {
+        var timer = null;
+        var stopped = false;
+        var every = intervalMs || 2000;
+        function tick() {
+            getStatus().then(function(status) {
+                if (stopped) return;
+                onStatus(status);
+                if (status.state === 'running') timer = setTimeout(tick, every);
+            }).catch(function() {
+                // Transient: the GUI blinks out while the stack restarts
+                // under us. Keep watching rather than declaring the run over.
+                if (!stopped) timer = setTimeout(tick, every);
+            });
+        }
+        tick();
+        return function stop() {
+            stopped = true;
+            if (timer) { clearTimeout(timer); timer = null; }
+        };
+    }
+
+    // Poll the shared config-apply queue to completion. Resolves with the
+    // terminal status; rejects only if it ends in 'failed'.
+    function pollApply(onProgress) {
+        return new Promise(function(resolve, reject) {
+            var misses = 0;
+            function tick() {
+                fetch('/config/apply/status')
+                    .then(function(r) { return r.json(); })
+                    .then(function(s) {
+                        misses = 0;
+                        if (s.state === 'running') {
+                            if (onProgress) onProgress(s);
+                            setTimeout(tick, 1000);
+                        } else if (s.state === 'failed') {
+                            reject(new Error(s.error || 'Apply failed'));
+                        } else {
+                            resolve(s);
+                        }
+                    })
+                    .catch(function() {
+                        // A miss or two is the stack restarting; a run of
+                        // them is a real problem worth surfacing rather than
+                        // polling forever behind a spinner.
+                        if (++misses >= 5) {
+                            reject(new Error('Progress could not be read'));
+                            return;
+                        }
+                        setTimeout(tick, 2000);
+                    });
+            }
+            tick();
+        });
+    }
+
+    return {
+        PHASE_LABELS: PHASE_LABELS,
+        MODE_LABELS: MODE_LABELS,
+        OUTCOME_TEXT: OUTCOME_TEXT,
+        mhz: mhz,
+        fmtSeconds: fmtSeconds,
+        escapeHtml: escapeHtml,
+        warnBox: warnBox,
+        updateWarning: updateWarning,
+        preflightNotice: preflightNotice,
+        diagnose: diagnose,
+        tuningOf: tuningOf,
+        isTerminal: isTerminal,
+        getStatus: getStatus,
+        pollStatus: pollStatus,
+        pollApply: pollApply,
+        start: function(body) { return post('/calibrate/start', body); },
+        cancel: function() { return post('/calibrate/cancel'); },
+        apply: function() { return post('/calibrate/apply'); }
+    };
+})();

--- a/static/setup.js
+++ b/static/setup.js
@@ -1232,15 +1232,44 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
 
             var tuning = CAL.tuningOf(status);
             if (tuning) {
+                var entry = (status.history || [])[0] || {};
+                var before = status.original;
+                // What the run changed, not just what it ended on: the owner
+                // has no other way to see that these settings are not the
+                // generic ones the radio shipped with.
+                var wasRow = before
+                    ? '<div style="font-size:12.5px;color:var(--ink-3);margin-top:6px;">'
+                      + 'Previously gain reduction A ' + before.gain_a + ' dB / B '
+                      + before.gain_b + ' dB, LNA state ' + before.lna_state + '.</div>'
+                    : '';
+                // An empty dwell_backoffs means the point never clipped across
+                // the whole soak. That is the reassurance the soak earns and
+                // the step otherwise never states.
+                var held = entry.soak_seconds
+                    ? '<div style="font-size:12.5px;color:var(--ink-3);margin-top:6px;">'
+                      + (((entry.dwell_backoffs || []).length === 0)
+                          ? 'Held cleanly for ' + Math.round(entry.soak_seconds)
+                            + 's with no sign of overload.'
+                          : 'Backed off ' + entry.dwell_backoffs.length
+                            + ' time(s) during a ' + Math.round(entry.soak_seconds)
+                            + 's check, and settled here.')
+                      + '</div>'
+                    : '';
                 resultEl.style.display = '';
                 resultEl.innerHTML =
                     '<div style="padding:14px 16px;border:1px solid var(--ok-edge);'
                     + 'background:var(--ok-soft);border-radius:var(--r-md);">'
                     + '<div style="font-weight:600;font-size:14px;color:var(--ok);">Receiver tuned</div>'
                     + '<div style="font-size:13px;color:var(--ink-2);margin-top:4px;">'
-                    + CAL.escapeHtml(tuning.tower_name || 'Tower') + ' at ' + CAL.mhz(tuning.fc)
-                    + ', gain reduction A ' + tuning.gain_a + ' dB / B ' + tuning.gain_b
-                    + ' dB, LNA state ' + tuning.lna_state + '.</div></div>';
+                    + 'Using <strong>' + CAL.escapeHtml(tuning.tower_name || 'Tower')
+                    + '</strong> at ' + CAL.mhz(tuning.fc) + '.</div>'
+                    + '<div style="font-size:13px;color:var(--ink-2);margin-top:8px;">'
+                    + 'Gain reduction A <strong>' + tuning.gain_a + ' dB</strong>'
+                    + ' / B <strong>' + tuning.gain_b + ' dB</strong>'
+                    + ', LNA state <strong>' + tuning.lna_state + '</strong>.</div>'
+                    + wasRow + held + '</div>';
+                // Static copy lives in the template — see #calWizNext there.
+                el('calWizNext').style.display = '';
             } else {
                 errorEl.style.display = '';
                 errorEl.innerHTML = '<span style="color:var(--ink-2);">'
@@ -1292,6 +1321,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
             el('calWizResult').innerHTML = '';
             el('calWizError').style.display = 'none';
             el('calWizError').innerHTML = '';
+            el('calWizNext').style.display = 'none';
             el('calWizStatus').textContent = '';
             advancing = false;
 
@@ -1324,6 +1354,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 el('calWizStatus').textContent = '';
                 el('calWizResult').style.display = 'none';
                 el('calWizError').style.display = 'none';
+                el('calWizNext').style.display = 'none';
                 show(false, true);
                 setButtons('running');
                 el('calWizPhase').textContent = 'Starting…';

--- a/static/setup.js
+++ b/static/setup.js
@@ -26,6 +26,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
         radar: 'Packages',
         location: 'Where is your receiver?',
         towers: 'Choose a tower',
+        calibrate: 'Tune the receiver',
         complete: 'You\'re all set'
     };
 
@@ -1156,7 +1157,223 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     };
     })();
 
-    // Step 6: Complete
+    // Step 6: Auto-Calibrate — descent-only against the tower just chosen.
+    //
+    // Deliberately a different run shape from the Configuration page's
+    // Auto-Calibrate: scope current_tower (the owner picked a tower one step
+    // ago; re-searching alternates contradicts that and triples the time) and
+    // descent_only (resolve the operating point, never dwell for a
+    // confirmation). ~3.5 min instead of ~15, and nothing can be falsely
+    // confirmed because nothing is confirmed at all. See calibrator.py.
+    enterHooks.calibrate = (function() {
+        var stopPoll = null;
+        var listenersAdded = false;
+        var advancing = false;
+
+        function el(id) { return document.getElementById(id); }
+
+        function show(intro, running) {
+            el('calWizIntro').style.display = intro ? '' : 'none';
+            el('calWizRunning').style.display = running ? '' : 'none';
+        }
+
+        function setButtons(state) {
+            el('calWizStartBtn').style.display  = state === 'idle' ? '' : 'none';
+            el('calWizSkipBtn').style.display   = state === 'running' ? 'none' : '';
+            el('calWizCancelBtn').style.display = state === 'running' ? '' : 'none';
+            el('calWizNextBtn').style.display   = state === 'terminal' ? '' : 'none';
+            el('calWizCancelBtn').disabled = false;
+        }
+
+        // A confirmed result or the no-track fallback both carry tuning worth
+        // keeping, and the wizard persists either without asking — the
+        // Configuration page's "Persist to config" button is not reachable
+        // from here, and the stack restart at /set-up/complete would discard
+        // anything left unsaved seconds later.
+        function persistThenAllowNext(status) {
+            var CAL = window.RetinaCalibrate;
+            var tuning = CAL.tuningOf(status);
+            if (!tuning) { setButtons('terminal'); return; }
+            var statusEl = el('calWizStatus');
+            statusEl.textContent = 'Saving settings…';
+            CAL.apply().then(function(d) {
+                if (!d.success) throw new Error(d.error || 'Apply failed');
+                // Wait for the merge+restart to finish before letting the user
+                // advance: /set-up/complete force-recreates the stack, and two
+                // overlapping restarts race the 90s restart lock, whose
+                // failure enforce_radar_mode swallows silently.
+                return CAL.pollApply(function(s) {
+                    var label = s.phase_label || 'Applying';
+                    if (s.phase === 'settling' && s.settle_remaining) {
+                        label += ' (' + s.settle_remaining + 's)';
+                    }
+                    statusEl.textContent = label + '…';
+                });
+            }).then(function() {
+                statusEl.textContent = 'Settings saved.';
+                setButtons('terminal');
+            }).catch(function(err) {
+                // Never blocks completion — the tuning is live either way, and
+                // the owner must be able to finish setup.
+                statusEl.textContent = 'Could not save settings: ' + err.message;
+                setButtons('terminal');
+            });
+        }
+
+        function renderTerminal(status) {
+            var CAL = window.RetinaCalibrate;
+            var resultEl = el('calWizResult');
+            var errorEl = el('calWizError');
+            show(false, false);
+            el('calWizSpinner').style.display = 'none';
+
+            var tuning = CAL.tuningOf(status);
+            if (tuning) {
+                resultEl.style.display = '';
+                resultEl.innerHTML =
+                    '<div style="padding:14px 16px;border:1px solid var(--ok-edge);'
+                    + 'background:var(--ok-soft);border-radius:var(--r-md);">'
+                    + '<div style="font-weight:600;font-size:14px;color:var(--ok);">Receiver tuned</div>'
+                    + '<div style="font-size:13px;color:var(--ink-2);margin-top:4px;">'
+                    + CAL.escapeHtml(tuning.tower_name || 'Tower') + ' at ' + CAL.mhz(tuning.fc)
+                    + ', gain reduction A ' + tuning.gain_a + ' dB / B ' + tuning.gain_b
+                    + ' dB, LNA state ' + tuning.lna_state + '.</div></div>';
+            } else {
+                errorEl.style.display = '';
+                errorEl.innerHTML = '<span style="color:var(--ink-2);">'
+                    + CAL.escapeHtml(status.error || 'Tuning did not complete.')
+                    + ' You can run this again later from Configuration.</span>';
+            }
+            errorEl.innerHTML += CAL.updateWarning(status) + CAL.preflightNotice(status);
+            if (errorEl.innerHTML) errorEl.style.display = '';
+            persistThenAllowNext(status);
+        }
+
+        function renderRunning(status) {
+            var CAL = window.RetinaCalibrate;
+            show(false, true);
+            el('calWizSpinner').style.display = '';
+            el('calWizPhase').textContent = CAL.PHASE_LABELS[status.phase] || 'Starting…';
+            if (status.current) {
+                el('calWizDetail').style.display = '';
+                el('calWizTower').textContent = status.current.tower_name || '-';
+                el('calWizFc').textContent = CAL.mhz(status.current.fc);
+                el('calWizGains').textContent =
+                    'A ' + status.current.gain_a + ' dB / B ' + status.current.gain_b + ' dB';
+                el('calWizLna').textContent =
+                    status.current.lna_state == null ? '-' : status.current.lna_state;
+                var rf = status.rf || {};
+                el('calWizOverload').textContent = rf.overload_a == null ? '-'
+                    : ('A ' + (rf.overload_a ? 'OVERLOAD' : 'ok')
+                       + ' / B ' + (rf.overload_b ? 'OVERLOAD' : 'ok'));
+            }
+        }
+
+        function watch() {
+            if (stopPoll) stopPoll();
+            setButtons('running');
+            stopPoll = window.RetinaCalibrate.pollStatus(function(status) {
+                if (status.state === 'running') { renderRunning(status); return; }
+                stopPoll = null;
+                window._calWizStopPoll = null;
+                renderTerminal(status);
+            });
+            // Published so leaveHooks.calibrate, which lives outside this
+            // closure, can stop the timer when the step goes off screen.
+            window._calWizStopPoll = stopPoll;
+        }
+
+        return function() {
+            var CAL = window.RetinaCalibrate;
+            el('calWizResult').style.display = 'none';
+            el('calWizResult').innerHTML = '';
+            el('calWizError').style.display = 'none';
+            el('calWizError').innerHTML = '';
+            el('calWizStatus').textContent = '';
+            advancing = false;
+
+            // Never auto-start: this hook fires on every entry, including
+            // when the owner clicks back to a step they already finished.
+            // Reattach to whatever the node is actually doing instead — the
+            // run is a background thread there, not something this tab owns.
+            CAL.getStatus().then(function(status) {
+                if (status.state === 'running') { watch(); return; }
+                if (CAL.isTerminal(status) && CAL.tuningOf(status)) {
+                    // A finished run from this session (or before a reload):
+                    // show what it found rather than offering to redo it.
+                    renderTerminal(status);
+                    return;
+                }
+                // Includes "step says calibrate, calibrator says idle", which
+                // is the normal state after a reboot mid-run — the start
+                // prompt is the honest thing to show, not an error.
+                show(true, false);
+                setButtons('idle');
+            }).catch(function() {
+                show(true, false);
+                setButtons('idle');
+            });
+
+            if (listenersAdded) return;
+            listenersAdded = true;
+
+            el('calWizStartBtn').addEventListener('click', function() {
+                el('calWizStatus').textContent = '';
+                el('calWizResult').style.display = 'none';
+                el('calWizError').style.display = 'none';
+                show(false, true);
+                setButtons('running');
+                el('calWizPhase').textContent = 'Starting…';
+                window.RetinaCalibrate.start({
+                    scope: 'current_tower',
+                    descent_only: true
+                }).then(function(d) {
+                    if (!d.success) {
+                        show(true, false);
+                        setButtons('idle');
+                        el('calWizError').style.display = '';
+                        el('calWizError').innerHTML =
+                            '<span style="color:var(--danger,#b91c1c);">'
+                            + window.RetinaCalibrate.escapeHtml(d.error || 'Could not start') + '</span>';
+                        return;
+                    }
+                    watch();
+                }).catch(function() {
+                    show(true, false);
+                    setButtons('idle');
+                    el('calWizError').style.display = '';
+                    el('calWizError').textContent = 'Could not start tuning.';
+                });
+            });
+
+            el('calWizCancelBtn').addEventListener('click', function() {
+                el('calWizCancelBtn').disabled = true;
+                el('calWizStatus').textContent = 'Cancelling…';
+                window.RetinaCalibrate.cancel().catch(function() {});
+            });
+
+            el('calWizSkipBtn').addEventListener('click', function() {
+                if (advancing) return;
+                advancing = true;
+                advance();
+            });
+
+            el('calWizNextBtn').addEventListener('click', function() {
+                if (advancing) return;
+                advancing = true;
+                advance();
+            });
+        };
+    })();
+
+    // Leaving the step must not leave a timer running against a view that is
+    // no longer on screen. The run itself continues on the node, and
+    // re-entering reattaches to it.
+    leaveHooks.calibrate = function() {
+        if (window._calWizStopPoll) { window._calWizStopPoll(); window._calWizStopPoll = null; }
+    };
+
+    // Step 7: Complete
     enterHooks.complete = function() {
         window.removeEventListener('beforeunload', handleBeforeUnload);
         if (backBtn) backBtn.style.display = 'none';

--- a/static/setup.js
+++ b/static/setup.js
@@ -1157,14 +1157,17 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
     };
     })();
 
-    // Step 6: Auto-Calibrate — descent-only against the tower just chosen.
+    // Step 6: Auto-Calibrate against the tower just chosen.
     //
     // Deliberately a different run shape from the Configuration page's
     // Auto-Calibrate: scope current_tower (the owner picked a tower one step
     // ago; re-searching alternates contradicts that and triples the time) and
-    // descent_only (resolve the operating point, never dwell for a
-    // confirmation). ~3.5 min instead of ~15, and nothing can be falsely
-    // confirmed because nothing is confirmed at all. See calibrator.py.
+    // skip_confirmation (descend, then soak the resolved point for overload,
+    // but never wait for a confirmed track). ~4 min instead of ~15, and
+    // nothing can be falsely confirmed because nothing is confirmed at all.
+    // The soak is not optional: descent proves a point over one second, and
+    // intermittent clipping only shows when the point is sat on — see
+    // calibrator.py's SOAK_SECONDS.
     enterHooks.calibrate = (function() {
         var stopPoll = null;
         var listenersAdded = false;
@@ -1326,7 +1329,7 @@ function initSetupWizard(resumeStep, highestStepName, devMode, isRerun, demoMode
                 el('calWizPhase').textContent = 'Starting…';
                 window.RetinaCalibrate.start({
                     scope: 'current_tower',
-                    descent_only: true
+                    skip_confirmation: true
                 }).then(function(d) {
                     if (!d.success) {
                         show(true, false);

--- a/templates/config.html
+++ b/templates/config.html
@@ -653,6 +653,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="/static/calibrate.js"></script>
 <script>
 // Mode segmented control — change is staged; applied when user clicks Apply changes
 (function() {
@@ -1364,60 +1365,15 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
     var pollTimer = null;
     var lastStatus = null;
 
-    var PHASE_LABELS = {
-        preflight: 'Checking the radio responds…',
-        recovering: 'Radio unresponsive, restarting it…',
-        descending: 'Maximizing gain, backing off overload…',
-        refining: 'Refining gain…',
-        dwelling: 'Watching for aircraft…',
-        restoring: 'Restoring original tuning…'
-    };
-
-    var MODE_LABELS = { track: 'Standard', adsb: 'ADS-B verified' };
-
-    function mhz(fc) { return (fc / 1e6).toFixed(1) + ' MHz'; }
-
-    function fmtSeconds(s) {
-        var m = Math.floor(s / 60), r = s % 60;
-        return m + ':' + (r < 10 ? '0' : '') + r;
-    }
-
-    function escapeHtml(s) {
-        var d = document.createElement('div');
-        d.textContent = s;
-        return d.innerHTML;
-    }
-
-    // Per-tower outcomes the engine records but the run's summary message
-    // cannot express. Without these every failure reads as "probably no
-    // aircraft", including the ones that never looked for one.
-    var OUTCOME_TEXT = {
-        no_confirmed_track: 'watched, but nothing confirmed',
-        confirmed_track: 'confirmed a track',
-        skipped_no_time: 'never watched (the search ran out of time here)',
-        tuning_not_applied: 'never watched (the radio did not accept this tuning)',
-        unstable_overload: 'stopped (the signal kept overloading the receiver)',
-        not_reached: 'not reached'
-    };
-
-    function diagnose(history) {
-        if (!history.length) return '';
-        var watched = history.filter(function(h) {
-            return h.outcome === 'no_confirmed_track' || h.outcome === 'confirmed_track';
-        }).length;
-        var lines = history.map(function(h) {
-            var txt = OUTCOME_TEXT[h.outcome] || h.outcome || 'unknown';
-            var extra = '';
-            if (h.dwell_seconds) extra = ' (' + Math.round(h.dwell_seconds) + 's)';
-            if (h.tuning_error) extra += ' - ' + escapeHtml(h.tuning_error);
-            return '<div>' + escapeHtml(h.tower_name || 'Tower') + ': ' + txt + extra + '</div>';
-        });
-        var lead = watched === 0
-            ? '<strong>No tower was actually watched, so this is not evidence '
-              + 'about aircraft.</strong><br>'
-            : '';
-        return lead + lines.join('');
-    }
+    // Shared with the setup wizard's calibrate step — see static/calibrate.js
+    // for why the vocabulary and interpretation live there rather than here.
+    var CAL = window.RetinaCalibrate;
+    var PHASE_LABELS = CAL.PHASE_LABELS;
+    var MODE_LABELS = CAL.MODE_LABELS;
+    var mhz = CAL.mhz;
+    var fmtSeconds = CAL.fmtSeconds;
+    var escapeHtml = CAL.escapeHtml;
+    var diagnose = CAL.diagnose;
 
     function setTerminalButtons() {
         spinner.style.display = 'none';
@@ -1442,45 +1398,9 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
             .forEach(function(el) { el.disabled = locked; });
     }
 
-    // A server-pushed Mender deployment installs on its own schedule and
-    // cannot be refused from here, so it can replace the containers under a
-    // run. Say so rather than let the run die unexplained.
-    function updateWarning(status) {
-        if (!status.system_update) return '';
-        return '<div style="margin-top:10px;padding:8px 10px;border-radius:6px;'
-            + 'background:oklch(0.96 0.04 85);border:1px solid var(--warn,#b7791f);'
-            + 'color:var(--warn,#b7791f);font-size:12.5px;">'
-            + '<strong>A system update is installing.</strong> '
-            + escapeHtml(status.system_update)
-            + '. It restarts the radar, so this calibration will not complete '
-            + 'and its results should be ignored. Run it again once the update '
-            + 'has finished.</div>';
-    }
+    var updateWarning = CAL.updateWarning;
 
-    // The preflight only reports when it had to intervene. A clean probe is
-    // unremarkable; a restart is not — it persisted maximum attenuation to
-    // the config, deliberately and without reverting it (see calibrator.py's
-    // module docstring), so the user has to be told what was replaced or
-    // their gain settings appear to have changed by themselves.
-    function preflightNotice(status) {
-        var pf = status.preflight;
-        if (!pf || !pf.restarted) return '';
-        var was = pf.previous
-            ? ' Its previous setting was gain reduction A ' + pf.previous.gain_a
-              + ' dB / B ' + pf.previous.gain_b + ' dB, LNA state '
-              + pf.previous.lna_state + ', which you can restore in the '
-              + 'Capture fields below.'
-            : '';
-        var lead = pf.recovered
-            ? 'The radio had stopped accepting tuning commands and was restarted.'
-            : 'The radio had stopped accepting tuning commands.';
-        return '<div style="margin-top:10px;padding:8px 10px;border-radius:6px;'
-            + 'background:oklch(0.96 0.04 85);border:1px solid var(--warn,#b7791f);'
-            + 'color:var(--warn,#b7791f);font-size:12.5px;">'
-            + '<strong>' + lead + '</strong> It has been set to maximum '
-            + 'attenuation (gain reduction 59/59, LNA state 9) and that has '
-            + 'been saved to the configuration.' + was + '</div>';
-    }
+    var preflightNotice = CAL.preflightNotice;
 
     function render(status) {
         lastStatus = status;

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -48,6 +48,7 @@
             {% include "setup/_packages.html" %}
             {% include "setup/_location.html" %}
             {% include "setup/_towers.html" %}
+            {% include "setup/_calibrate.html" %}
             {% include "setup/_complete.html" %}
 
         </div>
@@ -90,6 +91,15 @@
                 <button type="button" class="ds-btn primary" id="towerSaveBtn" disabled>Save &amp; continue</button>
             </div>
 
+            {# Auto-Calibrate — optional, never blocks completion #}
+            <div id="stepBtns-calibrate" class="step-foot-btns" style="display:none;">
+                <span id="calWizStatus" style="font-size:13px;color:var(--ink-3);"></span>
+                <button type="button" class="ds-btn ghost"   id="calWizSkipBtn">Skip →</button>
+                <button type="button" class="ds-btn ghost"   id="calWizCancelBtn" style="display:none;">Cancel</button>
+                <button type="button" class="ds-btn primary" id="calWizStartBtn">Optimise reception</button>
+                <button type="button" class="ds-btn primary" id="calWizNextBtn" style="display:none;">Continue →</button>
+            </div>
+
             {# Complete #}
             <div id="stepBtns-complete" class="step-foot-btns" style="display:none;">
                 <a href="/" class="ds-btn primary">Go to dashboard →</a>
@@ -102,6 +112,7 @@
 
 {% block scripts %}
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="/static/calibrate.js"></script>
     <script src="/static/setup.js"></script>
     <script>
         initSetupWizard({{ resume_step|tojson }}, {{ highest_step|default(none)|tojson }}, {{ dev_mode|default(false)|tojson }}, {{ is_rerun|default(false)|tojson }}, {{ demo_mode|default(false)|tojson }});

--- a/templates/setup/_calibrate.html
+++ b/templates/setup/_calibrate.html
@@ -1,12 +1,15 @@
-<!-- Step 6: Auto-Calibrate (descent-only, current tower) -->
+<!-- Step 6: Auto-Calibrate (current tower, no track confirmation) -->
 <div data-step="calibrate" class="step-panel" style="display:none;">
     <div class="wiz-title-row">
         <h1>Tune the receiver</h1>
-        {# Deliberately not "looking for aircraft": this run is descent-only
-           (see calibrator.py's descent_only), so there is no dwell and no
-           track to wait for. Promising aircraft here would set the owner up
-           to read a normal result as a failure. #}
-        <p>Find the best gain settings for your location. Takes a few minutes, and you can skip it.</p>
+        {# Deliberately not "looking for aircraft": this run skips track
+           confirmation (see calibrator.py's skip_confirmation), so there is
+           nothing to wait for a plane for. It does still watch the settled
+           point for overload — that is the soak, and it is why the phase
+           reads "dwelling" for ~45s at the end. Promising aircraft here
+           would set the owner up to read a normal result as a failure. #}
+        <p>Find the best gain settings for your location.<br>
+            Takes a few minutes, and you can skip it.</p>
     </div>
 
     {# Pre-run explainer. Replaced by the progress view once a run starts. #}

--- a/templates/setup/_calibrate.html
+++ b/templates/setup/_calibrate.html
@@ -6,8 +6,9 @@
            confirmation (see calibrator.py's skip_confirmation), so there is
            nothing to wait for a plane for. It does still watch the settled
            point for overload — that is the soak, and it is why the phase
-           reads "dwelling" for ~45s at the end. Promising aircraft here
-           would set the owner up to read a normal result as a failure. #}
+           reads "Checking the settings hold…" for ~45s at the end. Promising
+           aircraft here would set the owner up to read a normal result as a
+           failure. #}
         <p>Find the best gain settings for your location.<br>
             Takes a few minutes, and you can skip it.</p>
     </div>
@@ -41,7 +42,42 @@
         </div>
     </div>
 
-    {# Terminal view — outcome plus what was saved #}
+    {# Terminal view — outcome plus what was saved. Filled from the run's
+       status by renderTerminal in setup.js, since the values are dynamic. #}
     <div id="calWizResult" style="display:none;margin-top:14px;"></div>
     <div id="calWizError" style="display:none;margin-top:14px;font-size:13px;"></div>
+
+    {# Post-run explanation, shown under the "Receiver tuned" box once a run
+       finishes and produced tuning. Deliberately static markup rather than a
+       string in setup.js: none of it depends on the run, and copy this long
+       should be editable without touching JavaScript.
+
+       Keep the outer div and its id. setup.js reveals it in renderTerminal
+       and hides it again both on re-entry and on starting a new run, so
+       losing the id silently drops all of this. #}
+    <div id="calWizNext" style="display:none;margin-top:16px;">
+        <div style="padding:14px 16px;border:1px solid var(--edge,#d8dee6);border-radius:var(--r-md);">
+
+            <p style="font-size:13px;color:var(--ink-2);margin:0 0 10px;">
+                This process has resulted in a gain configuration that operates
+                both your reference and surveillance tuners in an optimal state
+                with regard to clipping. This does not necessarily mean it is
+                the optimal configuration for detecting aircraft.
+            </p>
+
+            <p style="font-size:13px;color:var(--ink-2);margin:0 0 10px;">
+                After you continue, you can explore the device's configuration
+                options and you can run Auto-Calibrate again during a period
+                of significant air traffic to tune your system further.
+            </p>
+
+            <p style="font-size:13px;color:var(--ink-2);margin:0;">
+                You may also find that tuning your <strong>Minimum SNR</strong>
+                (default 7.0 dB) to your node's observed noise floor improves
+                Auto-Calibrate's performance. Manual tuning is available as
+                well.
+            </p>
+
+        </div>
+    </div>
 </div>

--- a/templates/setup/_calibrate.html
+++ b/templates/setup/_calibrate.html
@@ -1,0 +1,44 @@
+<!-- Step 6: Auto-Calibrate (descent-only, current tower) -->
+<div data-step="calibrate" class="step-panel" style="display:none;">
+    <div class="wiz-title-row">
+        <h1>Tune the receiver</h1>
+        {# Deliberately not "looking for aircraft": this run is descent-only
+           (see calibrator.py's descent_only), so there is no dwell and no
+           track to wait for. Promising aircraft here would set the owner up
+           to read a normal result as a failure. #}
+        <p>Find the best gain settings for your location. Takes a few minutes, and you can skip it.</p>
+    </div>
+
+    {# Pre-run explainer. Replaced by the progress view once a run starts. #}
+    <div id="calWizIntro" class="step-stack">
+        <p style="font-size:13px;color:var(--ink-2);margin:0 0 10px;">
+            Your radio starts on generic settings that are not chosen for your
+            site. This tries progressively more sensitive settings against your
+            chosen tower and keeps the strongest one that does not overload the
+            receiver.
+        </p>
+        <p style="font-size:13px;color:var(--ink-3);margin:0;">
+            The radar restarts at the end to pick up the new settings. You can
+            run this again at any time from Configuration.
+        </p>
+    </div>
+
+    {# Progress view #}
+    <div id="calWizRunning" style="display:none;">
+        <div style="display:flex;gap:10px;align-items:center;">
+            <span id="calWizSpinner" class="spinner-border spinner-border-sm text-primary"></span>
+            <span id="calWizPhase" style="font-weight:600;font-size:14px;"></span>
+        </div>
+        <div id="calWizDetail" style="display:none;margin-top:12px;font-size:13px;color:var(--ink-2);">
+            <div>Tower: <span id="calWizTower">-</span></div>
+            <div>Centre frequency: <span id="calWizFc">-</span></div>
+            <div>Gain reduction: <span id="calWizGains">-</span></div>
+            <div>LNA state: <span id="calWizLna">-</span></div>
+            <div>Receiver: <span id="calWizOverload">-</span></div>
+        </div>
+    </div>
+
+    {# Terminal view — outcome plus what was saved #}
+    <div id="calWizResult" style="display:none;margin-top:14px;"></div>
+    <div id="calWizError" style="display:none;margin-top:14px;font-size:13px;"></div>
+</div>

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -16,6 +16,7 @@ sidecar's RESET wiping accumulated state between candidate towers.
 import copy
 import json
 import os
+import time
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -264,6 +265,7 @@ def fast(monkeypatch):
     monkeypatch.setattr(calmod, "RF_STATUS_POLL_SECONDS", 0.005)
     monkeypatch.setattr(calmod, "DWELL_POLL_SECONDS", 0.01)
     monkeypatch.setattr(calmod, "TRACKER_FEED_POLL_SECONDS", 0.01)
+    monkeypatch.setattr(calmod, "SOAK_SECONDS", 0.5)
 
 
 def run_to_completion(cal, towers, original=ORIGINAL, budget=10, dwell=3.0):
@@ -1167,31 +1169,84 @@ class TestNoTrackFallback:
             cal._thread.join(timeout=10)
 
 
-class TestDescentOnly:
-    """The setup wizard's run shape: resolve the operating point and stop,
-    never dwelling for a confirmation (see calibrator.start's descent_only)."""
+class TestSkipConfirmation:
+    """The setup wizard's run shape: resolve the operating point, soak it to
+    prove it holds, and stop without waiting for a track (see
+    calibrator.start's skip_confirmation)."""
 
-    def test_descent_only_skips_the_dwell_and_persists_the_tuning(self, fast):
+    def test_skip_confirmation_never_confirms_but_still_persists_tuning(self, fast):
         client = FakeBlah2Client()
         tracker_client = FakeRetinaTrackerClient(confirm_after=1)
         cal = Calibrator(client, tracker_client)
         started, error = cal.start([TOWER], ORIGINAL, budget_seconds=10,
-                                   descent_only=True)
+                                   skip_confirmation=True)
         assert started, error
-        cal._thread.join(timeout=10)
+        cal._thread.join(timeout=20)
         status = cal.get_status()
-        # Even with a tracker that would confirm instantly, no dwell runs, so
-        # there is no result — and therefore nothing that can be spurious.
+        # Even with a tracker that would confirm instantly, the soak feeds it
+        # nothing and never reads it — so there is no result, and therefore
+        # nothing that can be spurious.
         assert status["state"] == "failed"
         assert status["result"] is None
-        assert status["descent_only"] is True
-        assert status["history"][0]["outcome"] == "descent_only"
+        assert status["skip_confirmation"] is True
+        assert status["history"][0]["outcome"] == "tuned"
         # The tuning still lands, via the same fallback path a no-track run
         # uses — that is what makes this shape usable in the wizard.
         assert status["fallback"] is not None
         assert status["fallback"]["fc"] == TOWER["fc"]
 
-    def test_descent_only_never_reports_skipped_no_time(self, fast):
+    def test_soak_catches_overload_descent_could_not_see(self, fast, monkeypatch):
+        """The whole reason the soak exists. Descent proves a candidate over
+        OVERLOAD_SETTLE_SECONDS — one second in production. A point that only
+        starts clipping once it is sat on is invisible to that, and skipping
+        the dwell entirely would persist the one-second verdict."""
+        monkeypatch.setattr(calmod, "DWELL_OVERLOAD_CHECK_SECONDS", 0.02)
+        monkeypatch.setattr(calmod, "SOAK_SECONDS", 3.0)
+        clipping = {"on": False}
+        client = FakeBlah2Client(
+            overload_rule=lambda fc, ga, gb, lna: (False, clipping["on"]))
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=30,
+                               skip_confirmation=True)
+        assert started
+        # Clip only once the descent has settled and the soak has begun, so
+        # this can only be caught by watching the resolved point.
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if cal.get_status().get("phase") == "dwelling":
+                break
+            time.sleep(0.01)
+        else:
+            cal.cancel()
+            cal._thread.join(timeout=10)
+            pytest.fail("soak never started")
+        clipping["on"] = True
+        cal._thread.join(timeout=30)
+
+        status = cal.get_status()
+        entry = status["history"][0]
+        assert entry.get("dwell_backoffs"), "the soak never retreated from overload"
+        # And the retreat must reach what gets persisted — otherwise the run
+        # moves the hardware to safety and then writes the unsafe values back.
+        assert status["fallback"]["gain_a"] == entry["final_gain_a"]
+        assert status["fallback"]["gain_b"] == entry["final_gain_b"]
+        assert status["fallback"]["lna_state"] == entry["final_lna_state"]
+        assert status["fallback"]["gain_b"] == client.current["gain_b"]
+
+    def test_a_clean_soak_reports_tuned(self, fast):
+        """A point that holds for the whole soak is the success case, and
+        must not be reported as any kind of shortfall."""
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=30,
+                               skip_confirmation=True)
+        assert started
+        cal._thread.join(timeout=20)
+        entry = cal.get_status()["history"][0]
+        assert entry["outcome"] == "tuned"
+        assert not entry.get("dwell_backoffs")
+
+    def test_skip_confirmation_never_reports_skipped_no_time(self, fast):
         """The regression this flag exists to avoid. dwell_seconds=0 would
         land in the "budget genuinely exhausted" branch and label the tower
         skipped_no_time, telling the user time ran out when nothing of the
@@ -1199,7 +1254,7 @@ class TestDescentOnly:
         client = FakeBlah2Client()
         cal = Calibrator(client, FakeRetinaTrackerClient())
         started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=10,
-                               descent_only=True)
+                               skip_confirmation=True)
         assert started
         cal._thread.join(timeout=10)
         status = cal.get_status()
@@ -1207,14 +1262,14 @@ class TestDescentOnly:
         assert "no aircraft was overhead" not in (status["error"] or "")
         assert "Tuning resolved" in (status["error"] or "")
 
-    def test_descent_only_still_resolves_a_real_operating_point(self, fast):
+    def test_skip_confirmation_still_resolves_a_real_operating_point(self, fast):
         """Descent must do its actual job — the shorter run is only worth
         anything if the tuning it lands on is the one the descent proved."""
         client = FakeBlah2Client(
             overload_rule=lambda fc, ga, gb, lna: (False, gb < 37))
         cal = Calibrator(client, FakeRetinaTrackerClient())
         started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=10,
-                               descent_only=True)
+                               skip_confirmation=True)
         assert started
         cal._thread.join(timeout=10)
         status = cal.get_status()
@@ -1224,13 +1279,13 @@ class TestDescentOnly:
 
     def test_a_normal_run_is_unaffected(self, fast):
         """The Configuration-page entry point must keep dwelling and keep
-        confirming — descent_only defaults off."""
+        confirming — skip_confirmation defaults off."""
         client = FakeBlah2Client(detection=moving_track_detections())
         tracker_client = FakeRetinaTrackerClient(confirm_after=1)
         status = run_to_completion(Calibrator(client, tracker_client), [TOWER])
         assert status["state"] == "done"
         assert status["result"] is not None
-        assert status["descent_only"] is False
+        assert status["skip_confirmation"] is False
 
 
 class TestTrackerSidecarIntegration:
@@ -1916,7 +1971,7 @@ class TestRoutes:
             resp = app_client.post('/calibrate/apply')
         assert resp.status_code == 409
 
-    def test_start_passes_descent_only_through(self, app_client):
+    def test_start_passes_skip_confirmation_through(self, app_client):
         """The wizard's run shape has to survive the route, and the
         Configuration page must not pick it up by accident."""
         import app as app_module
@@ -1924,10 +1979,10 @@ class TestRoutes:
                           return_value=(True, None)) as started:
             resp = app_client.post('/calibrate/start',
                                    json={"scope": "current_tower",
-                                         "descent_only": True})
+                                         "skip_confirmation": True})
         assert resp.status_code == 200
-        assert resp.get_json()["descent_only"] is True
-        assert started.call_args.kwargs["descent_only"] is True
+        assert resp.get_json()["skip_confirmation"] is True
+        assert started.call_args.kwargs["skip_confirmation"] is True
         # scope: current_tower means exactly one tower, not three.
         assert len(started.call_args.args[0]) == 1
 
@@ -1938,8 +1993,8 @@ class TestRoutes:
                           return_value=(True, None)) as started:
             resp = app_client.post('/calibrate/start', json={})
         assert resp.status_code == 200
-        assert resp.get_json()["descent_only"] is False
-        assert started.call_args.kwargs["descent_only"] is False
+        assert resp.get_json()["skip_confirmation"] is False
+        assert started.call_args.kwargs["skip_confirmation"] is False
 
     def test_apply_of_a_cancelled_run_is_rejected(self, app_client):
         """Cancel restores the original tuning and never records a fallback,
@@ -2078,7 +2133,8 @@ class TestSharedCalibrateDriver:
     @staticmethod
     def _module_surface():
         import re
-        src = open(os.path.join(REPO_ROOT, 'static', 'calibrate.js')).read()
+        with open(os.path.join(REPO_ROOT, 'static', 'calibrate.js')) as f:
+            src = f.read()
         # The `return { ... }` block at the end is the public surface.
         tail = src[src.rindex('return {'):]
         return set(re.findall(r'^\s{8}(\w+):', tail, re.M))
@@ -2088,7 +2144,8 @@ class TestSharedCalibrateDriver:
         import re
         names = set()
         for rel in (('templates', 'config.html'), ('static', 'setup.js')):
-            src = open(os.path.join(REPO_ROOT, *rel)).read()
+            with open(os.path.join(REPO_ROOT, *rel)) as f:
+                src = f.read()
             names |= set(re.findall(r'\bCAL\.(\w+)', src))
             names |= set(re.findall(r'\bwindow\.RetinaCalibrate\.(\w+)', src))
         return names
@@ -2101,8 +2158,10 @@ class TestSharedCalibrateDriver:
             f"and the wizard step would break at runtime")
 
     def test_both_consumers_actually_load_the_module(self):
-        cfg = open(os.path.join(REPO_ROOT, 'templates', 'config.html')).read()
-        setup = open(os.path.join(REPO_ROOT, 'templates', 'setup.html')).read()
+        with open(os.path.join(REPO_ROOT, 'templates', 'config.html')) as f:
+            cfg = f.read()
+        with open(os.path.join(REPO_ROOT, 'templates', 'setup.html')) as f:
+            setup = f.read()
         assert '/static/calibrate.js' in cfg
         assert '/static/calibrate.js' in setup
         # Order matters: the module must be parsed before the page script
@@ -2113,7 +2172,8 @@ class TestSharedCalibrateDriver:
     def test_config_page_no_longer_defines_its_own_copies(self):
         """The point of the extraction. If these come back, the two entry
         points can disagree about what a status means."""
-        cfg = open(os.path.join(REPO_ROOT, 'templates', 'config.html')).read()
+        with open(os.path.join(REPO_ROOT, 'templates', 'config.html')) as f:
+            cfg = f.read()
         for dupe in ('var OUTCOME_TEXT', 'function diagnose(', 'function mhz(',
                      'function preflightNotice(', 'function updateWarning('):
             assert dupe not in cfg, f"{dupe} is defined again in config.html"

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1167,6 +1167,72 @@ class TestNoTrackFallback:
             cal._thread.join(timeout=10)
 
 
+class TestDescentOnly:
+    """The setup wizard's run shape: resolve the operating point and stop,
+    never dwelling for a confirmation (see calibrator.start's descent_only)."""
+
+    def test_descent_only_skips_the_dwell_and_persists_the_tuning(self, fast):
+        client = FakeBlah2Client()
+        tracker_client = FakeRetinaTrackerClient(confirm_after=1)
+        cal = Calibrator(client, tracker_client)
+        started, error = cal.start([TOWER], ORIGINAL, budget_seconds=10,
+                                   descent_only=True)
+        assert started, error
+        cal._thread.join(timeout=10)
+        status = cal.get_status()
+        # Even with a tracker that would confirm instantly, no dwell runs, so
+        # there is no result — and therefore nothing that can be spurious.
+        assert status["state"] == "failed"
+        assert status["result"] is None
+        assert status["descent_only"] is True
+        assert status["history"][0]["outcome"] == "descent_only"
+        # The tuning still lands, via the same fallback path a no-track run
+        # uses — that is what makes this shape usable in the wizard.
+        assert status["fallback"] is not None
+        assert status["fallback"]["fc"] == TOWER["fc"]
+
+    def test_descent_only_never_reports_skipped_no_time(self, fast):
+        """The regression this flag exists to avoid. dwell_seconds=0 would
+        land in the "budget genuinely exhausted" branch and label the tower
+        skipped_no_time, telling the user time ran out when nothing of the
+        sort happened."""
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=10,
+                               descent_only=True)
+        assert started
+        cal._thread.join(timeout=10)
+        status = cal.get_status()
+        assert status["history"][0]["outcome"] != "skipped_no_time"
+        assert "no aircraft was overhead" not in (status["error"] or "")
+        assert "Tuning resolved" in (status["error"] or "")
+
+    def test_descent_only_still_resolves_a_real_operating_point(self, fast):
+        """Descent must do its actual job — the shorter run is only worth
+        anything if the tuning it lands on is the one the descent proved."""
+        client = FakeBlah2Client(
+            overload_rule=lambda fc, ga, gb, lna: (False, gb < 37))
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=10,
+                               descent_only=True)
+        assert started
+        cal._thread.join(timeout=10)
+        status = cal.get_status()
+        assert status["fallback"]["gain_b"] == 39
+        assert status["fallback"]["gain_b"] == client.current["gain_b"]
+        assert status["fallback"]["lna_state"] == client.current["lna_state"]
+
+    def test_a_normal_run_is_unaffected(self, fast):
+        """The Configuration-page entry point must keep dwelling and keep
+        confirming — descent_only defaults off."""
+        client = FakeBlah2Client(detection=moving_track_detections())
+        tracker_client = FakeRetinaTrackerClient(confirm_after=1)
+        status = run_to_completion(Calibrator(client, tracker_client), [TOWER])
+        assert status["state"] == "done"
+        assert status["result"] is not None
+        assert status["descent_only"] is False
+
+
 class TestTrackerSidecarIntegration:
     """Directly exercises the shared-sidecar-specific mechanics that don't
     have another natural home: per-dwell reset and the staleness guard on
@@ -1850,6 +1916,31 @@ class TestRoutes:
             resp = app_client.post('/calibrate/apply')
         assert resp.status_code == 409
 
+    def test_start_passes_descent_only_through(self, app_client):
+        """The wizard's run shape has to survive the route, and the
+        Configuration page must not pick it up by accident."""
+        import app as app_module
+        with patch.object(app_module.calibrator, 'start',
+                          return_value=(True, None)) as started:
+            resp = app_client.post('/calibrate/start',
+                                   json={"scope": "current_tower",
+                                         "descent_only": True})
+        assert resp.status_code == 200
+        assert resp.get_json()["descent_only"] is True
+        assert started.call_args.kwargs["descent_only"] is True
+        # scope: current_tower means exactly one tower, not three.
+        assert len(started.call_args.args[0]) == 1
+
+    def test_start_defaults_to_a_full_run(self, app_client):
+        """No flag from the Configuration page — three towers, full dwell."""
+        import app as app_module
+        with patch.object(app_module.calibrator, 'start',
+                          return_value=(True, None)) as started:
+            resp = app_client.post('/calibrate/start', json={})
+        assert resp.status_code == 200
+        assert resp.get_json()["descent_only"] is False
+        assert started.call_args.kwargs["descent_only"] is False
+
     def test_apply_of_a_cancelled_run_is_rejected(self, app_client):
         """Cancel restores the original tuning and never records a fallback,
         so there is nothing to keep — the route must not invent one."""
@@ -1973,3 +2064,56 @@ class TestRoutes:
         assert user['capture']['fc'] == 105_100_000
         assert user['capture']['device']['gainReduction'] == [30, 45]
         assert user['capture']['device']['lnaState'] == 6
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), '..')
+
+
+class TestSharedCalibrateDriver:
+    """static/calibrate.js is consumed by two callers that cannot be
+    unit-tested here (browser JS). The one failure this guards is the one the
+    extraction introduced: a consumer referencing something the module does
+    not export, which silently breaks the Auto-Calibrate modal at runtime."""
+
+    @staticmethod
+    def _module_surface():
+        import re
+        src = open(os.path.join(REPO_ROOT, 'static', 'calibrate.js')).read()
+        # The `return { ... }` block at the end is the public surface.
+        tail = src[src.rindex('return {'):]
+        return set(re.findall(r'^\s{8}(\w+):', tail, re.M))
+
+    @staticmethod
+    def _referenced_names():
+        import re
+        names = set()
+        for rel in (('templates', 'config.html'), ('static', 'setup.js')):
+            src = open(os.path.join(REPO_ROOT, *rel)).read()
+            names |= set(re.findall(r'\bCAL\.(\w+)', src))
+            names |= set(re.findall(r'\bwindow\.RetinaCalibrate\.(\w+)', src))
+        return names
+
+    def test_every_referenced_helper_is_exported(self):
+        missing = self._referenced_names() - self._module_surface()
+        assert not missing, (
+            f"config.html/setup.js reference {sorted(missing)}, which "
+            f"static/calibrate.js does not export - the Auto-Calibrate modal "
+            f"and the wizard step would break at runtime")
+
+    def test_both_consumers_actually_load_the_module(self):
+        cfg = open(os.path.join(REPO_ROOT, 'templates', 'config.html')).read()
+        setup = open(os.path.join(REPO_ROOT, 'templates', 'setup.html')).read()
+        assert '/static/calibrate.js' in cfg
+        assert '/static/calibrate.js' in setup
+        # Order matters: the module must be parsed before the page script
+        # that dereferences window.RetinaCalibrate at IIFE-evaluation time.
+        assert cfg.index('/static/calibrate.js') < cfg.index('RetinaCalibrate;')
+        assert setup.index('/static/calibrate.js') < setup.index('/static/setup.js')
+
+    def test_config_page_no_longer_defines_its_own_copies(self):
+        """The point of the extraction. If these come back, the two entry
+        points can disagree about what a status means."""
+        cfg = open(os.path.join(REPO_ROOT, 'templates', 'config.html')).read()
+        for dupe in ('var OUTCOME_TEXT', 'function diagnose(', 'function mhz(',
+                     'function preflightNotice(', 'function updateWarning('):
+            assert dupe not in cfg, f"{dupe} is defined again in config.html"

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1213,7 +1213,7 @@ class TestSkipConfirmation:
         # this can only be caught by watching the resolved point.
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            if cal.get_status().get("phase") == "dwelling":
+            if cal.get_status().get("phase") == "soaking":
                 break
             time.sleep(0.01)
         else:
@@ -1232,6 +1232,46 @@ class TestSkipConfirmation:
         assert status["fallback"]["gain_b"] == entry["final_gain_b"]
         assert status["fallback"]["lna_state"] == entry["final_lna_state"]
         assert status["fallback"]["gain_b"] == client.current["gain_b"]
+
+    def test_soak_does_not_claim_to_be_watching_for_aircraft(self, fast):
+        """Caught in live testing on owl: the soak reused the dwell's phase,
+        so the wizard step — whose copy deliberately promises no aircraft —
+        displayed "Watching for aircraft…" for its whole 45s."""
+        seen = []
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        real_update = cal._update
+
+        def spy(**kwargs):
+            if "phase" in kwargs:
+                seen.append(kwargs["phase"])
+            return real_update(**kwargs)
+
+        cal._update = spy
+        started, _ = cal.start([TOWER], ORIGINAL, budget_seconds=30,
+                               skip_confirmation=True)
+        assert started
+        cal._thread.join(timeout=20)
+        assert "soaking" in seen
+        assert "dwelling" not in seen
+
+    def test_a_normal_run_still_reports_dwelling(self, fast):
+        """The Configuration page really is watching for aircraft, and must
+        keep saying so."""
+        seen = []
+        client = FakeBlah2Client()
+        cal = Calibrator(client, FakeRetinaTrackerClient())
+        real_update = cal._update
+
+        def spy(**kwargs):
+            if "phase" in kwargs:
+                seen.append(kwargs["phase"])
+            return real_update(**kwargs)
+
+        cal._update = spy
+        run_to_completion(cal, [TOWER], dwell=0.3)
+        assert "dwelling" in seen
+        assert "soaking" not in seen
 
     def test_a_clean_soak_reports_tuned(self, fast):
         """A point that holds for the whole soak is the success case, and

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -394,15 +394,37 @@ class TestSetupWizardLocationStep:
                 < html.index('data-step="calibrate"')
                 < html.index('data-step="complete"'))
 
-    def test_calibrate_step_does_not_promise_aircraft(self, app_client):
-        """The wizard run is descent-only, so there is no dwell and no track
-        to wait for. Promising aircraft would make a normal result read as a
-        failure — see the Copy note on this step."""
+    def test_calibrate_step_does_not_promise_aircraft_before_the_run(self, app_client):
+        """The wizard run never waits for a track, so copy shown *before* and
+        *during* it must not lead the owner to expect aircraft — a normal
+        result would then read as a failure. Scoped to the pre-result half on
+        purpose: the post-run explainer does discuss aircraft, to say why none
+        were waited for, which is the opposite problem."""
         html = app_client.get('/set-up').data.decode()
         start = html.index('data-step="calibrate"')
         panel = html[start:html.index('data-step="complete"')]
-        assert 'aircraft' not in panel.lower()
-        assert 'gain settings' in panel.lower()
+        before_result = panel[:panel.index('id="calWizResult"')]
+        assert 'aircraft' not in before_result.lower()
+        assert 'gain settings' in before_result.lower()
+
+    def test_calibrate_step_has_a_slot_for_the_post_run_explanation(self, app_client):
+        """The copy itself is the author's to write; this only guards the
+        wiring. setup.js reveals #calWizNext on a terminal run and hides it
+        again on re-entry, so losing the id would silently drop whatever is
+        written there."""
+        html = app_client.get('/set-up').data.decode()
+        start = html.index('data-step="calibrate"')
+        panel = html[start:html.index('data-step="complete"')]
+        assert 'id="calWizNext"' in panel
+
+        with open(os.path.join(os.path.dirname(__file__), '..',
+                               'static', 'setup.js')) as f:
+            setup_js = f.read()
+        assert "el('calWizNext').style.display = ''" in setup_js
+        # Both reset paths must hide it again: re-entering the step, and
+        # starting a fresh run. Not an exact count, so adding a legitimate
+        # third reset later does not fail this.
+        assert setup_js.count("el('calWizNext').style.display = 'none'") >= 2
 
     def test_setup_page_loads_shared_calibrate_driver(self, app_client):
         """The wizard step and the Configuration modal must not drift — both

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -377,12 +377,38 @@ class TestSetupWizardLocationStep:
         assert 'Find towers' in html
 
     def test_setup_page_has_all_steps(self, app_client):
-        """Setup wizard has all 6 step panels."""
+        """Setup wizard has all 7 step panels."""
         resp = app_client.get('/set-up')
         html = resp.data.decode()
         assert 'data-step="location"' in html
         assert 'data-step="towers"' in html
+        assert 'data-step="calibrate"' in html
         assert 'data-step="complete"' in html
+
+    def test_calibrate_step_sits_between_towers_and_complete(self, app_client):
+        """Steps are discovered from DOM order, so the include order in
+        setup.html *is* the wizard order — tuning has to come after a tower
+        is chosen and before the completion restart."""
+        html = app_client.get('/set-up').data.decode()
+        assert (html.index('data-step="towers"')
+                < html.index('data-step="calibrate"')
+                < html.index('data-step="complete"'))
+
+    def test_calibrate_step_does_not_promise_aircraft(self, app_client):
+        """The wizard run is descent-only, so there is no dwell and no track
+        to wait for. Promising aircraft would make a normal result read as a
+        failure — see the Copy note on this step."""
+        html = app_client.get('/set-up').data.decode()
+        start = html.index('data-step="calibrate"')
+        panel = html[start:html.index('data-step="complete"')]
+        assert 'aircraft' not in panel.lower()
+        assert 'gain settings' in panel.lower()
+
+    def test_setup_page_loads_shared_calibrate_driver(self, app_client):
+        """The wizard step and the Configuration modal must not drift — both
+        consume static/calibrate.js."""
+        html = app_client.get('/set-up').data.decode()
+        assert '/static/calibrate.js' in html
 
     def test_setup_page_includes_leaflet(self, app_client):
         """Setup wizard loads Leaflet JS and CSS."""


### PR DESCRIPTION
## What

Adds a "Tune the receiver" step between tower selection and completion, so a node leaves first boot on settings chosen for its site rather than blah2's generic defaults (`gainReduction: [40, 40]`, `lnaState: 4`).

ClickUp: 86cb71r91. Builds on PR #68, already merged.

## The wizard's run is a different shape, deliberately

The Configuration page entry point is **unchanged**: still three towers, still the full dwell with track confirmation. It posts only `{mode}`, so both new parameters default off.

The wizard posts two extra parameters:

- **`scope: "current_tower"`** because the owner chose a tower one step earlier, and re-searching alternates both contradicts that choice and triples the run time. The route already accepted this.
- **`skip_confirmation`** because what the wizard needs is a stable non-overloading operating point, not a confirmed track.

`skip_confirmation` drops the track wait but **keeps the overload watch**. After the descent it soaks the resolved point for `SOAK_SECONDS` (45s), checking every 5s and retreating up to `MAX_DWELL_BACKOFFS` times. Dropping the dwell entirely was my first attempt and it was a defect, not an optimisation: descent proves a candidate over one second, and the comment on `DWELL_OVERLOAD_CHECK_SECONDS` records a live node where a marginal point cycled Overload_Detected/Corrected until the SDRplay API stopped answering control calls. See commit 6bb46a8.

It is a real flag rather than `dwell_seconds=0`, because zero lands in the "budget genuinely exhausted" branch and reports `skipped_no_time`, telling the owner time ran out when nothing of the sort happened.

Measured on owl: descent ~200s per tower, a full dwell consumes the rest of the 900s budget.

| Run shape | Descent | Dwell or soak | Total |
| --- | --- | --- | --- |
| Configuration page, unchanged | ~200s x3 | remainder of budget | ~15 min |
| Wizard | ~200s | 45s soak, overload only | ~4 min |

Since no confirmation is attempted, none can be spurious. That matters while `_on_track_event` still ignores the tracker's own plausibility verdict: on owl, 9 of 14 confirmed tracks were flagged `is_anomalous` / `supersonic` with zero ADS-B correlation. The Configuration page keeps that exposure and it is tracked separately.

## Other behaviour

The step persists automatically via `/calibrate/apply` (a confirmed result, or PR #68's no-track fallback), then polls the apply to completion before advancing. Skipping that wait races `/set-up/complete`'s `enforce_radar_mode` for the 90s restart lock, whose failure it swallows silently.

It never blocks completion, never auto-starts (the hook fires on every entry, including clicking back), reattaches to a run in progress rather than owning it, and renders "step says calibrate, calibrator says idle" as the start prompt rather than an error.

Shared driver extracted to `static/calibrate.js`: status vocabulary, formatting, terminal interpretation and the fetch layer, consumed by both entry points. Rendering stays per-caller. `config.html` drops ~85 lines of duplicated helpers.

## Bug fix that affects the Configuration page today

The `unstable_overload` exit in `_dwell` never recorded `final_*`. When the overload watch gave up after `MAX_DWELL_BACKOFFS`, `_dwell_backoff` had already retreated the hardware to safety, but the history entry still held descent's pre-retreat values, and the no-track fallback reads those. So a run detected sustained overload, protected the device, then persisted the very tuning it had just proved unstable. Not gated behind the new flag, since gating would mean keeping the bug on the path where it actually bites.

## Testing

566 tests, ruff clean, both JS files parse.

Live-verified on owl (192.168.0.144), real SDRplay:

```
13:35:09  phase=dwelling  el=213  ovl=False/False   <- soak begins, descent took ~213s
13:35:50  phase=dwelling  el=254  ovl=False/False   <- ~45s later, clean throughout
13:35:55  state=failed  outcome=tuned  fallback=SET  apply=running/settling
          fallback: WGBY-TV @ 213000000, gain (20, 20), LNA 1
```

The step persisted with no human click. Cancel and Skip were then verified by hand, and the service log confirms neither issued `/calibrate/apply`, so neither wrote config.

Live testing also caught a defect now fixed: the soak displayed "Watching for aircraft..." for its whole 45 seconds, on a step whose copy deliberately avoids promising aircraft. The soak now has its own `soaking` phase, fixed in the engine rather than by special-casing the label, with tests in both directions.

## Reviewer notes

1. **No browser has opened the Configuration-page modal.** This is the main gap. The extraction refactored shipped, working code, and `config.html` now depends on `/static/calibrate.js` loading. Behaviour should be identical, but if that file fails the modal breaks outright rather than degrading, and no Python test can reach it. Worth a look at the 19 lines of aliasing in `config.html` and a click through the modal.
2. Not exercised on hardware: the soak's overload backoff, and the `unstable_overload` fix above. owl never clipped, so both have only run in tests.
3. Commit `d68c8ba` carries 6 ruff violations in isolation. They are fixed by `6bb46a8`, so the tip is green, but that commit alone would fail CI. Squash if bisectability matters.
4. `test_tracker_capture.py::test_refresh_failure_does_not_kill_capture_loop` is a known timing flake on loaded runners, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)