### PR TITLE
20260827 - Let the config express a node with no location

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -144,19 +144,42 @@ class CaptureFormConfig(BaseModel):
 # ============================================================================
 # Location Settings
 # ============================================================================
+#: The six numbers that make a bistatic geometry. Names are excluded: they are
+#: labels, and a position without one is still a position.
+LOCATION_COORDINATE_FIELDS = (
+    "rx_latitude", "rx_longitude", "rx_altitude",
+    "tx_latitude", "tx_longitude", "tx_altitude",
+)
+
+
 class LocationFormConfig(BaseModel):
-    """Flat location config for form display."""
-    rx_latitude: float = Field(ge=-90, le=90, title="Receiver Latitude", description="decimal degrees")
-    rx_longitude: float = Field(ge=-180, le=180, title="Receiver Longitude", description="decimal degrees")
-    rx_altitude: float = Field(title="Receiver Altitude", description="meters")
-    rx_name: str = Field(title="Receiver Name", description="location name")
-    tx_latitude: float = Field(ge=-90, le=90, title="Transmitter Latitude", description="decimal degrees")
-    tx_longitude: float = Field(ge=-180, le=180, title="Transmitter Longitude", description="decimal degrees")
-    tx_altitude: float = Field(title="Transmitter Altitude", description="meters")
+    """Flat location config for form display.
+
+    Optional, because a node has no location until its owner picks a tower and
+    retina-node ships these null rather than defaulting to a plausible site.
+    Optional is not partial, though: see the validator below.
+    """
+    rx_latitude: float | None = Field(None, ge=-90, le=90, title="Receiver Latitude", description="decimal degrees")
+    rx_longitude: float | None = Field(None, ge=-180, le=180, title="Receiver Longitude", description="decimal degrees")
+    rx_altitude: float | None = Field(None, title="Receiver Altitude", description="meters")
+    rx_name: str | None = Field(None, title="Receiver Name", description="location name")
+    tx_latitude: float | None = Field(None, ge=-90, le=90, title="Transmitter Latitude", description="decimal degrees")
+    tx_longitude: float | None = Field(None, ge=-180, le=180, title="Transmitter Longitude", description="decimal degrees")
+    tx_altitude: float | None = Field(None, title="Transmitter Altitude", description="meters")
     # 32 chars is retina-telemetry's tx_callsign limit, not a display concern:
     # a longer name means it cannot build a NodeConfig, so registration and
     # every config resend fail and the node never reaches the server.
-    tx_name: str = Field(max_length=TX_NAME_MAX_LENGTH, title="Transmitter Name", description="location name")
+    tx_name: str | None = Field(None, max_length=TX_NAME_MAX_LENGTH, title="Transmitter Name", description="location name")
+
+    # The all-or-nothing rule is enforced on save in routes/config.py, not
+    # here: it is a cross-field rule like the ADS-B source trio, so each
+    # complaint can be attached to the box it concerns. A model validator would
+    # also need pydantic v2, and nodes run v1.
+
+    @property
+    def is_located(self) -> bool:
+        """Whether this carries a usable geometry. Never partially true."""
+        return all(getattr(self, f) is not None for f in LOCATION_COORDINATE_FIELDS)
 
 
 # ============================================================================

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 
 from apply_service import ConfigChangeRefused
 from config_schema import (
+    LOCATION_COORDINATE_FIELDS,
     AdsbTruthConfig,
     CaptureFormConfig,
     LocationFormConfig,
@@ -111,6 +112,34 @@ def delete_key():
 _ADSB_SOURCE_FIELDS = ("adsb_source_host", "adsb_source_port", "adsb_source_protocol")
 
 
+def _location_errors(location_flat):
+    """Per-field errors for a geometry that is neither complete nor empty.
+
+    A node legitimately has no location until its owner picks a tower, so an
+    empty set is fine. A partial one is not: blah2 derives its whole bistatic
+    solution from these six numbers, and a missing one becomes NaN rather than
+    an error, so the radar runs and silently associates nothing. This is the
+    only place an owner finds out.
+
+    Names are excluded. They are labels, and a position without one is still a
+    position.
+    """
+    missing = [f for f in LOCATION_COORDINATE_FIELDS if location_flat.get(f) in (None, "")]
+    if not missing or len(missing) == len(LOCATION_COORDINATE_FIELDS):
+        return {}
+
+    # Form-level rather than per-field: the location block in config.html is
+    # hand-rendered and does not look up config_errors, so per-field keys would
+    # re-render the page with nothing highlighted and no explanation. It also
+    # reads better as one sentence than as five lit-up boxes, because the rule
+    # is about the group.
+    return {"_form": (
+        "A location needs all six coordinates or none. Missing: "
+        + ", ".join(f.replace("_", " ") for f in missing)
+        + ". Clear all six to leave this node unsited."
+    )}
+
+
 def _adsb_source_errors(tar1090_data):
     """Per-field errors for a source that is neither complete nor legitimately empty."""
     missing = [f for f in _ADSB_SOURCE_FIELDS if tar1090_data.get(f) in (None, "")]
@@ -163,6 +192,8 @@ def save_config():
             LocationFormConfig(**location_flat)
         except ValidationError as e:
             all_errors.update(ConfigManager.format_validation_errors(e, 'location'))
+        for key, message in _location_errors(location_flat).items():
+            all_errors.setdefault(key, message)
 
     if truth_data:
         try:

--- a/src/routes/home.py
+++ b/src/routes/home.py
@@ -22,10 +22,12 @@ def index():
 
     config = config_mgr.load_merged_config()
     location = config.get('location', {}) or {}
+    # `or ''` rather than a .get default: on an unsited node the key exists
+    # with a null value, so the default never fires and the page renders "None".
     tx = location.get('tx', {}) or {}
-    tx_name = tx.get('name', '')
+    tx_name = tx.get('name') or ''
     rx = location.get('rx', {}) or {}
-    rx_name = rx.get('name', '')
+    rx_name = rx.get('name') or ''
 
     # None when the telemetry package isn't installed, which is not a fault —
     # the card is simply absent. See telemetry_status.py.

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -206,10 +206,20 @@ def select():
     }
 
     try:
-        LocationFormConfig(**location_flat)
+        validated = LocationFormConfig(**location_flat)
     except ValidationError as e:
         errors = ConfigManager.format_validation_errors(e, "location")
         return jsonify({"success": False, "errors": errors}), 400
+
+    # The model now permits a wholly empty location, because a node
+    # legitimately has none. This endpoint is the one that sets one, so an
+    # empty POST must not silently unsite a configured node.
+    if not validated.is_located:
+        return jsonify({
+            "success": False,
+            "errors": {"location": "a tower selection must carry a full receiver "
+                                   "and transmitter position"},
+        }), 400
 
     location_nested = ConfigManager.unflatten_location_from_form(location_flat)
     existing_user = config_mgr.load_user_config()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -226,6 +226,33 @@ class TestConfigSaveRoute:
     'capture.device.type' because we use flat Pydantic schemas for validation.
     """
 
+    def test_save_accepts_an_empty_location(self, app_client, user_config_file):
+        """A node legitimately has no location until its owner picks a tower,
+        so clearing every field must be allowed rather than rejected."""
+        response = app_client.post('/config/save', data={
+            'location.rx_latitude': '', 'location.rx_longitude': '',
+            'location.rx_altitude': '', 'location.rx_name': '',
+            'location.tx_latitude': '', 'location.tx_longitude': '',
+            'location.tx_altitude': '', 'location.tx_name': '',
+        }, follow_redirects=False)
+
+        assert response.status_code == 302
+
+    def test_save_rejects_a_partial_location(self, app_client, user_config_file):
+        """blah2 derives its whole bistatic solution from these six numbers, and
+        a missing one becomes NaN rather than an error, so the radar would run
+        and silently associate nothing. This is where an owner finds out."""
+        response = app_client.post('/config/save', data={
+            'location.rx_latitude': '42.241528',
+            'location.rx_longitude': '-72.648361',
+            'location.rx_altitude': '619.2',
+            'location.rx_name': 'ret824685c9',
+        }, follow_redirects=False)
+
+        # Re-renders the form with errors rather than redirecting.
+        assert response.status_code == 200
+        assert b'all six coordinates or none' in response.data
+
     def test_save_valid_config(self, app_client, user_config_file):
         """Valid config should be saved to user.yml."""
         response = app_client.post('/config/save', data={

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -161,6 +161,39 @@ class TestLocationFormConfig:
         assert config.rx_latitude == 37.7644
         assert config.tx_name == 'KSCZ-LD'
 
+    def test_an_unsited_node_is_valid(self):
+        """A node has no location until its owner picks a tower, and
+        retina-node ships these null. The schema has to be able to say that."""
+        config = LocationFormConfig()
+
+        assert config.is_located is False
+        assert config.rx_latitude is None
+
+    def test_a_partial_location_is_not_located(self):
+        """The model permits it; the all-or-nothing rule is enforced on save in
+        routes/config.py, beside the ADS-B source trio."""
+        assert LocationFormConfig(rx_latitude=37.7644, rx_longitude=-122.3954).is_located is False
+
+    def test_names_alone_do_not_make_a_location(self):
+        assert LocationFormConfig(rx_name='somewhere', tx_name='a tower').is_located is False
+
+    def test_zero_counts_as_located(self):
+        """Testing for truthiness would report a node on the equator as unsited."""
+        config = LocationFormConfig(
+            rx_latitude=0, rx_longitude=0, rx_altitude=0, rx_name='x',
+            tx_latitude=0, tx_longitude=0, tx_altitude=0, tx_name='y'
+        )
+
+        assert config.is_located is True
+
+    def test_bounds_still_apply_to_a_set_coordinate(self):
+        """Optional must not mean unchecked."""
+        with pytest.raises(ValidationError):
+            LocationFormConfig(
+                rx_latitude=91, rx_longitude=0, rx_altitude=0, rx_name='Test',
+                tx_latitude=0, tx_longitude=0, tx_altitude=0, tx_name='Test'
+            )
+
     def test_tx_name_length_cap(self):
         """tx_name is capped at 32 — retina-telemetry's tx_callsign limit.
 

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -281,6 +281,26 @@ class TestTowerCacheRemove:
 class TestTowerSelect:
     """Tests for POST /towers/select route."""
 
+    def test_select_refuses_an_empty_location(self, app_client, config_files):
+        """The model now allows an empty location, because a node legitimately
+        has none. This endpoint sets one, so it must never clear one."""
+        resp = app_client.post(
+            '/towers/select',
+            data=json.dumps({"tx_callsign": "ATN6"}),
+            content_type='application/json',
+        )
+
+        assert resp.status_code == 400
+
+    def test_select_refuses_a_partial_location(self, app_client, config_files):
+        resp = app_client.post(
+            '/towers/select',
+            data=json.dumps({"rx_latitude": -33.8688, "tx_callsign": "ATN6"}),
+            content_type='application/json',
+        )
+
+        assert resp.status_code == 400
+
     def test_select_saves_location(self, app_client, config_files):
         """Saves RX + TX location to user.yml with node_id and callsign."""
         user_path, _ = config_files


### PR DESCRIPTION
Phase 1 of stopping nodes from asserting a location nobody chose. ([86cba5qt4](https://app.clickup.com/t/86cba5qt4))

**Not ordering-critical.** Verified that current `main` already copes with a null location: the config page renders blanks, and `parse_flat_form_data` drops empty fields before validation so a save succeeds. This is an improvement rather than a prerequisite, and can land in any order relative to retina-node.

## Why

retina-node is about to ship the receiver and transmitter geometry null until an owner picks a tower, so this side should be able to *represent* that state rather than merely survive it.

## What

`LocationFormConfig`'s fields become optional, and `is_located` says whether a usable geometry is present. Names are excluded: a position without one is still a position.

**The all-or-nothing rule lives in `routes/config.py` beside `_adsb_source_errors`, not in the model.** Two reasons, and the second is the one that matters:

1. It is a cross-field rule of exactly that shape, and there is already a precedent for where those live.
2. **Nodes run pydantic 1.10.4**, where `model_validator` does not exist. My first cut used it, and importing it on a node raised `ImportError` — which would have stopped retina-gui booting on the entire fleet. Caught by testing against the node's own interpreter; the dev venv (2.13.4) and CI (unpinned `pydantic` in requirements.txt) were both green. `config_schema.py` already carries a `PYDANTIC_V2` flag, so dual-version support is deliberate and I had broken it.

It is reported **form-level rather than per-field**, because the location block in `config.html` is hand-rendered and does not look up `config_errors` — per-field keys would re-render the page with nothing highlighted and no explanation. It also reads better as one sentence, since the rule is about the group. Uses `setdefault` so it cannot clobber a calibration refusal.

A half-set geometry is the worst of the three states: blah2 derives its whole bistatic solution from those six numbers and a missing one becomes NaN rather than an error, so the radar runs and silently associates nothing.

## Also

- **`/towers/select` keeps requiring a complete geometry.** The model now permits an empty location, and that endpoint sets one rather than clears one, so without an explicit check an empty POST would silently unsite a configured node.
- **`home.py`** used `.get('name', '')`, which returns `None` rather than the default when the key is present with a null value, so an unsited node rendered the string `"None"`.
- Zero is treated as a real coordinate throughout.

Nothing was needed for rendering or clearing: the template already guards `is not none`, `parse_flat_form_data` already drops blank fields, and `calibrate.py` already refuses a tower lookup without a receiver position.

## Testing

5 new schema tests, 2 new save-route tests, 2 new `/towers/select` tests. Full suite green (593), ruff and the dead-code gate pass.

**Verified against owl-ded9's own pydantic 1.10.4**: import OK, `is_located` correct for sited / unsited / partial / 0,0, out-of-bounds still rejected, and the config page's render path produces 8 fields with `None` values for a null config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)