### PR TITLE
Remote support access, gated by two owner agreements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ tests/__pycache__/
 
 # Dev mode local data
 src/dev_data/
+# Also at the repo root: services.secret_key() writes one there the first
+# time the app or the suite runs outside DEV_MODE's temp dirs. Only the
+# src/ path was ignored, so it kept turning up in commits.
+dev_data/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,8 @@ flask-wtf
 pydantic
 requests
 pyyaml
-pyjwt
+# [crypto] because Cloudflare Access signs its assertions RS256, and PyJWT
+# cannot verify those without cryptography. It has been present transitively so
+# far, which is why nothing noticed: a clean install would leave the node unable
+# to verify any assertion, failing closed and locking support out.
+pyjwt[crypto]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask-wtf
 pydantic
 requests
 pyyaml
+pyjwt

--- a/src/access_identity.py
+++ b/src/access_identity.py
@@ -38,12 +38,15 @@ refuses. Failing closed is the only safe reading of "we cannot tell who this is"
 """
 
 import json
+import logging
 import threading
 import time
 
 import jwt
 import requests
 from jwt import PyJWKSet
+
+log = logging.getLogger(__name__)
 
 #: Written by node-infra alongside the connector token and installed by owl-os.
 #: {"team_domain": "offworldlab.cloudflareaccess.com", "aud": "<64 hex chars>"}
@@ -59,6 +62,40 @@ JWKS_TTL_SECONDS = 3600
 #: freshly issued token because the node is three seconds behind would be a
 #: confusing way to fail.
 CLOCK_LEEWAY_SECONDS = 30
+
+
+def _short(value):
+    """Enough of an identifier to match against, not enough to fill a line."""
+    value = str(value or "")
+    return value if len(value) <= 12 else value[:12] + "..."
+
+
+def _kid(token):
+    """The key id a token claims, for the log only.
+
+    Read without verifying anything, which is safe here precisely because the
+    caller has already decided to refuse: this only ever describes a rejection.
+    """
+    try:
+        return _short(jwt.get_unverified_header(token).get("kid"))
+    except Exception:
+        return "unreadable"
+
+
+def _claim(token, name):
+    """One unverified claim, for explaining a rejection.
+
+    Never use this to decide anything. It exists so a log line can say which
+    audience a refused token named, which is the difference between a two minute
+    fix and an afternoon on a live node.
+    """
+    try:
+        value = jwt.decode(token, options={"verify_signature": False}).get(name)
+    except Exception:
+        return "unreadable"
+    if isinstance(value, list):
+        return [_short(v) for v in value]
+    return _short(value)
 
 
 class AccessIdentity:
@@ -148,17 +185,36 @@ class AccessIdentity:
         Cloudflare being unreachable. The caller cannot act differently on any
         of them, and distinguishing them in a return value would invite somebody
         to treat one as good enough.
+
+        The *log* does distinguish them, at WARNING, because operationally they
+        could not be more different: a wrong audience is a misconfiguration
+        nobody will spot from the outside, and an unreachable Cloudflare is an
+        outage. Returning a bare None for both once cost an afternoon of
+        instrumenting a live node to find out which had happened, since a
+        refusal left no trace anywhere.
+
+        The token is never logged. It is a bearer credential for its session,
+        and a log that quotes it hands that session to anyone who can read logs.
+        The claims are, because they are what the decision turned on.
         """
         if not token:
             return None
 
         team_domain, audience = self.config()
         if not team_domain:
+            log.warning(
+                "Refusing an Access assertion: no usable configuration at %s. "
+                "Every request on the support hostname will be refused until "
+                "node-infra delivers it.", self.config_path)
             return None
 
         try:
             key = self._signing_key(token, team_domain)
             if key is None:
+                log.warning(
+                    "Refusing an Access assertion: signed with key id %s, which "
+                    "is not one of %s's published keys.",
+                    _kid(token), team_domain)
                 return None
             claims = jwt.decode(
                 token,
@@ -169,11 +225,38 @@ class AccessIdentity:
                 leeway=CLOCK_LEEWAY_SECONDS,
                 options={"require": ["exp", "aud", "iss"]},
             )
-        except (jwt.InvalidTokenError, requests.RequestException,
-                ValueError, KeyError):
+        except jwt.InvalidAudienceError:
+            # Worth its own message. This is what a token minted for one of the
+            # team's other Access applications looks like, and the fix is a
+            # configuration change rather than anything the caller did wrong.
+            log.warning(
+                "Refusing an Access assertion: it names audience %r, but this "
+                "node's application is %s. Either it was issued for a different "
+                "application, or access.json is stale.",
+                _claim(token, "aud"), _short(audience))
+            return None
+        except jwt.InvalidTokenError as exc:
+            log.warning("Refusing an Access assertion: %s: %s",
+                        type(exc).__name__, exc)
+            return None
+        except requests.RequestException as exc:
+            # Not a refusal of *this* token so much as an inability to judge it.
+            # Distinct from the above because nothing is wrong with the request.
+            log.warning(
+                "Refusing an Access assertion: could not reach %s for signing "
+                "keys: %s", team_domain, exc)
+            return None
+        except (ValueError, KeyError) as exc:
+            log.warning("Refusing an Access assertion: malformed: %s: %s",
+                        type(exc).__name__, exc)
             return None
 
         # Cloudflare puts the address in `email`. A token that verifies but
         # names nobody is not an identity, and returning something truthy for it
         # would let a caller believe it had authenticated a person.
-        return (claims.get("email") or "").strip() or None
+        email = (claims.get("email") or "").strip()
+        if not email:
+            log.warning("Refusing an Access assertion: it verifies, but carries "
+                        "no email claim, so it identifies nobody.")
+            return None
+        return email

--- a/src/access_identity.py
+++ b/src/access_identity.py
@@ -1,0 +1,179 @@
+"""Verifying that a request really was authenticated by Cloudflare Access.
+
+Cloudflare puts a signed assertion in `Cf-Access-Jwt-Assertion` on every request
+it lets through. This turns that into an email address, or into nothing.
+
+## Why verify at all, when Access sits in front
+
+In normal operation nothing unauthenticated reaches the node: the tunnel serves
+one hostname, and Access intercepts by hostname. This is for the case where that
+stops being true. An Access application deleted, renamed or misconfigured leaves
+the hostname open and the node happily serving it, and node-infra's
+reconciliation would notice eventually rather than immediately.
+
+So this is the node's own answer to "did Cloudflare actually vouch for you",
+independent of anything upstream continuing to be configured correctly.
+
+## What is checked, and why each one matters
+
+    signature   against the team's published keys. Without it the header is a
+                claim anyone can type.
+    audience    the tag of *this node's* Access application. Without it, a token
+                minted for any other application in the same team is accepted
+                here, and the team already runs Access on other hostnames.
+    issuer      the team domain, so a valid token from some other Cloudflare
+                team is not enough.
+    expiry      with a little leeway for clock drift, which these nodes have.
+
+Missing any one of those turns verification into decoration. The audience is the
+one most easily left out, because a token that fails it still has a perfectly
+good signature.
+
+## Configuration
+
+Both values arrive from node-infra in a small file beside the tunnel token,
+because the audience is generated per Access application and so differs per
+node. Absent or unreadable means no identity can be established, and the caller
+refuses. Failing closed is the only safe reading of "we cannot tell who this is".
+"""
+
+import json
+import threading
+import time
+
+import jwt
+import requests
+from jwt import PyJWKSet
+
+#: Written by node-infra alongside the connector token and installed by owl-os.
+#: {"team_domain": "offworldlab.cloudflareaccess.com", "aud": "<64 hex chars>"}
+DEFAULT_CONFIG_PATH = "/data/cloudflared/access.json"
+
+#: Cloudflare rotates signing keys, so a cached set goes stale. An hour is well
+#: inside their rotation window, and an unrecognised key id refetches
+#: immediately regardless, so this is a ceiling on staleness rather than the
+#: mechanism that handles rotation.
+JWKS_TTL_SECONDS = 3600
+
+#: Nodes keep time with chrony but can drift while offline, and rejecting a
+#: freshly issued token because the node is three seconds behind would be a
+#: confusing way to fail.
+CLOCK_LEEWAY_SECONDS = 30
+
+
+class AccessIdentity:
+    """Turns a Cloudflare Access assertion into a verified email address."""
+
+    def __init__(self, config_path=DEFAULT_CONFIG_PATH, ttl=JWKS_TTL_SECONDS,
+                 http=requests):
+        self.config_path = config_path
+        self.ttl = ttl
+        self.http = http
+        self._jwks = None
+        self._jwks_domain = None
+        self._fetched_at = 0.0
+        # Requests are served by threads; without this two arriving together
+        # could each fetch, and one could install a key set for a team domain
+        # the other had just changed away from.
+        self._lock = threading.Lock()
+
+    # ── configuration ────────────────────────────────────────────
+
+    def config(self):
+        """(team_domain, audience), or (None, None) when it cannot be read."""
+        try:
+            with open(self.config_path) as f:
+                data = json.load(f)
+        except (OSError, ValueError):
+            return None, None
+        if not isinstance(data, dict):
+            return None, None
+        domain = (data.get("team_domain") or "").strip()
+        audience = (data.get("aud") or "").strip()
+        if not domain or not audience:
+            return None, None
+        return domain, audience
+
+    def is_configured(self):
+        return self.config() != (None, None)
+
+    # ── signing keys ─────────────────────────────────────────────
+
+    def _fetch_jwks(self, team_domain):
+        url = f"https://{team_domain}/cdn-cgi/access/certs"
+        response = self.http.get(url, timeout=10)
+        response.raise_for_status()
+        return PyJWKSet.from_dict(response.json())
+
+    def _signing_key(self, token, team_domain):
+        """The key this token was signed with, refetching once if it is new.
+
+        An unrecognised key id means either a rotation we have not seen or a
+        forged header. Refetching once distinguishes them: after a fresh fetch a
+        key that still does not exist is not one of Cloudflare's.
+        """
+        kid = jwt.get_unverified_header(token).get("kid")
+        if not kid:
+            return None
+
+        with self._lock:
+            stale = (self._jwks is None
+                     or self._jwks_domain != team_domain
+                     or time.time() - self._fetched_at > self.ttl)
+            if stale:
+                self._jwks = self._fetch_jwks(team_domain)
+                self._jwks_domain = team_domain
+                self._fetched_at = time.time()
+
+            try:
+                return self._jwks[kid]
+            except KeyError:
+                pass
+
+            self._jwks = self._fetch_jwks(team_domain)
+            self._jwks_domain = team_domain
+            self._fetched_at = time.time()
+            try:
+                return self._jwks[kid]
+            except KeyError:
+                return None
+
+    # ── the answer ───────────────────────────────────────────────
+
+    def identity(self, token):
+        """The verified email address, or None.
+
+        None covers every way this can fail: no configuration, no token, a bad
+        signature, the wrong audience, the wrong team, an expired assertion, or
+        Cloudflare being unreachable. The caller cannot act differently on any
+        of them, and distinguishing them in a return value would invite somebody
+        to treat one as good enough.
+        """
+        if not token:
+            return None
+
+        team_domain, audience = self.config()
+        if not team_domain:
+            return None
+
+        try:
+            key = self._signing_key(token, team_domain)
+            if key is None:
+                return None
+            claims = jwt.decode(
+                token,
+                key.key,
+                algorithms=["RS256"],
+                audience=audience,
+                issuer=f"https://{team_domain}",
+                leeway=CLOCK_LEEWAY_SECONDS,
+                options={"require": ["exp", "aud", "iss"]},
+            )
+        except (jwt.InvalidTokenError, requests.RequestException,
+                ValueError, KeyError):
+            return None
+
+        # Cloudflare puts the address in `email`. A token that verifies but
+        # names nobody is not an identity, and returning something truthy for it
+        # would let a caller believe it had authenticated a person.
+        return (claims.get("email") or "").strip() or None

--- a/src/app.py
+++ b/src/app.py
@@ -27,12 +27,14 @@ from services import (  # noqa: F401  (re-exported for routes)
     TELEMETRY_STATUS_PATH,
     TOWER_FINDER_URL,
     USER_CONFIG_PATH,
+    access_identity,
     apply_service,
     blah2_client,
     calibrator,
     config_mgr,
     device_state,
     mender,
+    mender_connect,
     network_mgr,
     node_name,
     peers,
@@ -260,7 +262,16 @@ def _gate_the_remote_pathways():
     if request.path.startswith(_REMOTE_PUBLIC_PREFIXES):
         return None
 
-    if not session.get('remote_authed'):
+    # Cloudflare Access is the gate in front of this hostname, so a valid
+    # assertion is who this is. Verified on the node rather than trusted from a
+    # header: if the Access application were ever deleted or misconfigured the
+    # hostname would be open, and this is the only thing that would notice.
+    identity = access_identity.identity(
+        request.headers.get('Cf-Access-Jwt-Assertion'))
+    if identity:
+        g.access_identity = identity
+
+    if not (identity or session.get('remote_authed')):
         if request.method == 'GET':
             # full_path always appends '?', even with no query string, which
             # would send people to '/config?' after signing in.
@@ -278,9 +289,10 @@ def _gate_the_remote_pathways():
         # outlived the session.
         abort(403)
 
-    # Authenticated, but some things still need someone at the device. The
-    # password may have been shared, and these are the operations that would let
-    # the person it was shared with outlast a rotation of it.
+    # Authenticated, but some things still need someone at the device, and that
+    # applies to our own engineers too. If an Access session could add an SSH key
+    # here, support access would be a route to shell access and the two owner
+    # agreements would stop being independent of each other.
     if requires_presence(request.path):
         abort(403, "This can only be done from the local network")
 

--- a/src/app.py
+++ b/src/app.py
@@ -273,7 +273,17 @@ def inject_globals():
     from routes.fleet import banner_nodes
 
     owl_os_version, retina_node_version = mender.get_versions()
+
+    # Which pathway this request arrived on. Templates need it because some
+    # links are only reachable one way: the service cards point at other ports
+    # on the LAN, and at tunnel paths remotely. Defaults to LAN, so anything
+    # rendered outside a request (or before the gate runs) keeps the behaviour
+    # the node has always had.
+    from remote_access import LAN, OWNER
+    is_remote = getattr(g, 'pathway', LAN) == OWNER
+
     return {
+        'is_remote': is_remote,
         'node_id': get_node_id(),
         # Which pathway this request arrived on, so templates can hide what the
         # owner pathway is not allowed to reach anyway.

--- a/src/app.py
+++ b/src/app.py
@@ -179,6 +179,17 @@ def _reapply_shell_agreement():
 if not DEV_MODE:
     device_state.apply_startup_preferences()
     _reapply_shell_agreement()
+    # The inventory marker is the only thing node-infra reads, and a node that
+    # has never been touched has no state file and so no marker. That was
+    # consistent while support access defaulted off; it is not now that it
+    # defaults on, and without this such a node would keep reporting
+    # remote_access=false until somebody happened to toggle something.
+    #
+    # Best effort, like the marker write it wraps: never worth failing a boot.
+    try:
+        remote_access.publish_marker()
+    except Exception:
+        app.logger.exception("Could not publish the support access marker")
 
 # Always boot into radar mode — delete any persisted spectrum state
 try:

--- a/src/app.py
+++ b/src/app.py
@@ -231,7 +231,7 @@ def _gate_the_remote_pathways():
     Three pathways, and only one of them is challenged here:
 
       LAN     owl.local, ret4c844c20.local, a bare IP. Unauthenticated, exactly
-              as it has always been — being on the network is the credential.
+              as it has always been. Being on the network is the credential.
       ADMIN   ret4c844c20.admin.retnode.com. Cloudflare Access already
               authenticated whoever this is, at the edge, before the request
               reached the tunnel.

--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-from flask import Flask, jsonify, redirect, request
+from flask import Flask, abort, g, jsonify, redirect, request, session, url_for
 from flask_wtf.csrf import CSRFError, CSRFProtect
 
 # Configuration and shared services live in their own module because this one
@@ -18,6 +18,7 @@ from services import (  # noqa: F401  (re-exported for routes)
     MERGED_CONFIG_PATH,
     NODE_ID_FILE,
     PROJECT_ROOT,
+    REMOTE_ACCESS_DOMAIN,
     RETINA_NODE_PATH,
     RETINA_SPECTRUM_URL,
     RETINA_TRACKER_EVENTS_PATH,
@@ -36,7 +37,9 @@ from services import (  # noqa: F401  (re-exported for routes)
     node_name,
     peers,
     read_node_id,
+    remote_access,
     retina_tracker_client,
+    secret_key,
     ssh_keys,
     telemetry_status,
     tracker_capture,
@@ -45,13 +48,8 @@ from services import (  # noqa: F401  (re-exported for routes)
 app = Flask(__name__,
             template_folder=os.path.join(PROJECT_ROOT, 'templates'),
             static_folder=os.path.join(PROJECT_ROOT, 'static'))
-# Left as-is deliberately. Persisting this key is a real fix, but it is
-# already implemented as services.secret_key() on 20260828-remote-access,
-# whose login session needs the same guarantee. Carrying a second copy
-# here merges without a conflict and leaves TWO identical definitions in
-# services.py, which is worse than the gap. See that branch, or land it
-# on main on its own if it is needed before that one is reviewed.
-app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', os.urandom(32).hex())
+# Persisted to /data rather than regenerated per process. See services.secret_key.
+app.config['SECRET_KEY'] = secret_key()
 # Flask-WTF expires a CSRF token 3600s after it is issued. The setup wizard
 # reads its token once at page load and reuses it for the entire run (see
 # postJSON in setup.js), and a real run routinely passes the hour: reading
@@ -63,6 +61,25 @@ app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', os.urandom(32).hex())
 # stays signed with SECRET_KEY and bound to the session cookie, so it still
 # expires when the session does.
 app.config['WTF_CSRF_TIME_LIMIT'] = None
+
+# The session only ever exists on the owner pathway, which is always HTTPS
+# through the tunnel, so Secure costs nothing there. The LAN stays plain HTTP
+# and stays session-less. SESSION_COOKIE_SECURE is settable so tests (and a dev
+# server on http://localhost) can still hold a cookie.
+app.config['SESSION_COOKIE_SECURE'] = (
+    os.environ.get('SESSION_COOKIE_SECURE', '' if DEV_MODE else '1').lower()
+    in ('1', 'true', 'yes')
+)
+app.config['SESSION_COOKIE_HTTPONLY'] = True
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
+# Host-only, enforced by the browser rather than by us remembering not to set a
+# Domain. Every node is a sibling under one registrable domain, so without this
+# one node could set a `.retnode.com` cookie that shadows another node's and
+# leaves a working node refusing to log anybody in. The prefix requires Secure,
+# so it can only be used where the cookie is Secure anyway.
+if app.config['SESSION_COOKIE_SECURE']:
+    app.config['SESSION_COOKIE_NAME'] = '__Host-session'
+
 csrf = CSRFProtect(app)
 
 if not DEV_MODE:
@@ -163,6 +180,9 @@ def inject_globals():
     owl_os_version, retina_node_version = mender.get_versions()
     return {
         'node_id': get_node_id(),
+        # Which of the three pathways this request arrived on, so templates can
+        # hide what the owner pathway is not allowed to reach anyway.
+        'pathway': getattr(g, 'pathway', 'lan'),
         'owl_os_version': owl_os_version,
         'retina_node_version': retina_node_version,
         # One banner tab per node, on every page. An in-memory list, copied
@@ -180,6 +200,7 @@ from routes.home import bp as home_bp
 from routes.mender_routes import bp as mender_bp
 from routes.mode import bp as mode_bp
 from routes.network import bp as network_bp
+from routes.remote_access import bp as remote_access_bp
 from routes.setup import bp as setup_bp
 from routes.towers import bp as towers_bp
 from routes.tracker_preview import bp as tracker_preview_bp
@@ -194,6 +215,76 @@ app.register_blueprint(network_bp)
 app.register_blueprint(calibrate_bp)
 app.register_blueprint(tracker_preview_bp)
 app.register_blueprint(fleet_bp)
+app.register_blueprint(remote_access_bp)
+
+
+# Reachable on the owner pathway without a session: the login page itself, the
+# assets it needs to render, and the favicon. Everything else is behind the
+# password.
+_REMOTE_PUBLIC_PREFIXES = ('/login', '/static', '/favicon')
+
+
+@app.before_request
+def _gate_the_remote_pathways():
+    """Decide what this request is allowed to be, based on the hostname it used.
+
+    Three pathways, and only one of them is challenged here:
+
+      LAN     owl.local, ret4c844c20.local, a bare IP. Unauthenticated, exactly
+              as it has always been — being on the network is the credential.
+      ADMIN   ret4c844c20.admin.retnode.com. Cloudflare Access already
+              authenticated whoever this is, at the edge, before the request
+              reached the tunnel.
+      OWNER   ret<id>.retnode.com. Nothing upstream checked anybody, so the
+              password is the only gate and it is checked here.
+
+    Registered before the calibration hook below, and that ordering is load
+    bearing: Flask runs app-level before_request handlers in registration order,
+    and the calibration hook redirects GETs to /config. If it ran first, an
+    unauthenticated visitor arriving during a calibration would be bounced to a
+    page they are not allowed to see instead of to the login form.
+    """
+    from remote_access import ADMIN, LAN, classify_host, requires_presence
+
+    g.pathway = classify_host(request.host, read_node_id(), REMOTE_ACCESS_DOMAIN)
+    if g.pathway in (LAN, ADMIN):
+        return None
+
+    # 404 rather than 403 when the owner has not turned this on. The tunnel
+    # should not be up at all in that state, so anything arriving here is either
+    # a stale DNS record or someone guessing; neither is owed confirmation that
+    # a node answers to this name.
+    if not remote_access.is_enabled():
+        abort(404)
+
+    if request.path.startswith(_REMOTE_PUBLIC_PREFIXES):
+        return None
+
+    if not session.get('remote_authed'):
+        if request.method == 'GET':
+            # full_path always appends '?', even with no query string, which
+            # would send people to '/config?' after signing in.
+            wanted = request.full_path.rstrip('?') or '/'
+            return redirect(url_for('remote_access.login', next=wanted))
+        # A POST from a page whose session expired. 403 rather than a redirect,
+        # so fetch() callers get a status they can act on instead of an HTML
+        # login page parsed as JSON.
+        #
+        # Note this is not the only rejection such a request can get. CSRFProtect
+        # is constructed above, so its before_request is registered first and
+        # runs first: a stale page's POST usually carries a stale token and is
+        # refused with 400 before reaching here. Both are refusals; only the
+        # status differs, and which one you see depends on whether the token
+        # outlived the session.
+        abort(403)
+
+    # Authenticated, but some things still need someone at the device. The
+    # password may have been shared, and these are the operations that would let
+    # the person it was shared with outlast a rotation of it.
+    if requires_presence(request.path):
+        abort(403, "This can only be done from the local network")
+
+    return None
 
 
 @app.errorhandler(CSRFError)

--- a/src/app.py
+++ b/src/app.py
@@ -121,8 +121,64 @@ app.session_interface = _PathwaySessionInterface()
 
 csrf = CSRFProtect(app)
 
+
+def _reapply_shell_agreement():
+    """Make mender-connect agree with the owner's recorded choice.
+
+    The choice lives in /data, which is its own partition and survives an OS
+    update. The enforcement lives in /etc/mender/mender-connect.conf, on the
+    A/B rootfs, which does not: an update replaces it with the template owl-os
+    ships, where Terminal and PortForward are both enabled.
+
+    Nothing re-applied it, so an owner who declined a shell had it restored by
+    the next update while the marker, the config page and the `remote_shell`
+    inventory attribute all still reported it declined. Recorded state and
+    enforced state diverged silently, in the permissive direction, which is the
+    only direction that matters here: everyone would have believed the refusal
+    was still in force.
+
+    That makes the marker in /data authoritative and this the thing that
+    enforces it, rather than the write that happened to run when the owner last
+    clicked.
+
+    Acts only on a mismatch, which matters twice over. This module body is
+    executed twice per process (see services.py), so the second pass finds
+    nothing to do; and a node whose config already agrees is left alone rather
+    than rewritten and its daemon restarted on every boot.
+    """
+    if DEV_MODE:
+        return
+    try:
+        wanted = remote_access.is_shell_allowed()
+        actual = mender_connect.is_shell_enabled()
+        # None means the config could not be read. mender_connect refuses to
+        # invent a replacement, and it is right to: writing a plausible one
+        # would reconstruct transfer limits and a shell user we have no basis
+        # for, and could widen access rather than restore it.
+        if actual is None or actual == wanted:
+            return
+        ok, error = mender_connect.set_shell_enabled(wanted)
+        if ok:
+            app.logger.warning(
+                "Re-applied the remote shell agreement: the owner has it %s, "
+                "but this node was set to %s sessions. An OS update replaces "
+                "mender-connect.conf, so this is the expected repair after one.",
+                "on" if wanted else "off",
+                "allow" if actual else "refuse")
+        else:
+            app.logger.error(
+                "Could not re-apply the remote shell agreement (%s). This node "
+                "will %s sessions while its owner has it %s.",
+                error, "allow" if actual else "refuse", "on" if wanted else "off")
+    except Exception:
+        # Never let this stop the GUI booting. A node that will not serve its
+        # own config page is worse than one whose shell setting needs a click.
+        app.logger.exception("Re-applying the remote shell agreement failed")
+
+
 if not DEV_MODE:
     device_state.apply_startup_preferences()
+    _reapply_shell_agreement()
 
 # Always boot into radar mode — delete any persisted spectrum state
 try:

--- a/src/app.py
+++ b/src/app.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 
 from flask import Flask, abort, g, jsonify, redirect, request, session, url_for
+from flask.sessions import SecureCookieSessionInterface
 from flask_wtf.csrf import CSRFError, CSRFProtect
 
 # Configuration and shared services live in their own module because this one
@@ -64,23 +65,59 @@ app.config['SECRET_KEY'] = secret_key()
 # expires when the session does.
 app.config['WTF_CSRF_TIME_LIMIT'] = None
 
-# The session only ever exists on the owner pathway, which is always HTTPS
-# through the tunnel, so Secure costs nothing there. The LAN stays plain HTTP
-# and stays session-less. SESSION_COOKIE_SECURE is settable so tests (and a dev
-# server on http://localhost) can still hold a cookie.
+# Whether Secure cookies are permitted at all. Off in dev so a server on
+# http://localhost can still hold one; on elsewhere, where it gates the remote
+# pathway below rather than applying to every response.
 app.config['SESSION_COOKIE_SECURE'] = (
     os.environ.get('SESSION_COOKIE_SECURE', '' if DEV_MODE else '1').lower()
     in ('1', 'true', 'yes')
 )
 app.config['SESSION_COOKIE_HTTPONLY'] = True
 app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
-# Host-only, enforced by the browser rather than by us remembering not to set a
-# Domain. Every node is a sibling under one registrable domain, so without this
-# one node could set a `.retnode.com` cookie that shadows another node's and
-# leaves a working node refusing to log anybody in. The prefix requires Secure,
-# so it can only be used where the cookie is Secure anyway.
-if app.config['SESSION_COOKIE_SECURE']:
-    app.config['SESSION_COOKIE_NAME'] = '__Host-session'
+
+
+class _PathwaySessionInterface(SecureCookieSessionInterface):
+    """Cookie flags that follow the pathway instead of one global setting.
+
+    This used to be a single config: Secure everywhere, and the `__Host-` name
+    whenever Secure was on. The reasoning was that the session only mattered on
+    the remote pathway, which is always HTTPS, so the LAN could simply go
+    without one.
+
+    That was wrong, and badly so. A browser silently discards a Secure cookie
+    delivered over plain HTTP, which is exactly what the LAN is. So the LAN held
+    no session at all, and CSRFProtect keeps its token *in the session*, so
+    every POST an owner made from their own network was rejected with 400: the
+    config page, every toggle, the setup wizard. Curl hid it completely, because
+    it keeps the cookie where a browser refuses to.
+
+    So Secure is applied where it is true rather than where it is convenient.
+    The `__Host-` prefix is still worth having on the remote pathway, where
+    every node is a sibling under one registrable domain and without it one node
+    could set a `.retnode.com` cookie that shadows another's. The prefix
+    requires Secure, so the two answers have to move together.
+    """
+
+    def _is_remote(self):
+        try:
+            from remote_access import OWNER, classify_host
+            return (app.config['SESSION_COOKIE_SECURE']
+                    and classify_host(request.host, read_node_id(),
+                                      REMOTE_ACCESS_DOMAIN) == OWNER)
+        except Exception:
+            # Fail towards the LAN. A node that cannot tell which pathway it is
+            # on must not end up unable to hold a session on the one owners
+            # actually use, which is the failure this class exists to fix.
+            return False
+
+    def get_cookie_secure(self, app):
+        return self._is_remote()
+
+    def get_cookie_name(self, app):
+        return '__Host-session' if self._is_remote() else 'session'
+
+
+app.session_interface = _PathwaySessionInterface()
 
 csrf = CSRFProtect(app)
 

--- a/src/app.py
+++ b/src/app.py
@@ -180,8 +180,8 @@ def inject_globals():
     owl_os_version, retina_node_version = mender.get_versions()
     return {
         'node_id': get_node_id(),
-        # Which of the three pathways this request arrived on, so templates can
-        # hide what the owner pathway is not allowed to reach anyway.
+        # Which pathway this request arrived on, so templates can hide what the
+        # owner pathway is not allowed to reach anyway.
         'pathway': getattr(g, 'pathway', 'lan'),
         'owl_os_version': owl_os_version,
         'retina_node_version': retina_node_version,
@@ -228,15 +228,15 @@ _REMOTE_PUBLIC_PREFIXES = ('/login', '/static', '/favicon')
 def _gate_the_remote_pathways():
     """Decide what this request is allowed to be, based on the hostname it used.
 
-    Three pathways, and only one of them is challenged here:
+    Two pathways, and only one of them is challenged here:
 
-      LAN     owl.local, ret4c844c20.local, a bare IP. Unauthenticated, exactly
-              as it has always been. Being on the network is the credential.
-      ADMIN   ret4c844c20.admin.retnode.com. Cloudflare Access already
-              authenticated whoever this is, at the edge, before the request
-              reached the tunnel.
-      OWNER   ret<id>.retnode.com. Nothing upstream checked anybody, so the
-              password is the only gate and it is checked here.
+      LAN     owl.local, ret4c844c20.local, a bare IP, and anything arriving
+              over a Mender port-forward, which lands as `localhost`.
+              Unauthenticated, exactly as it has always been: being on the
+              network is the credential, and Mender has already authenticated
+              and logged the engineer who opened the forward.
+      OWNER   ret<id>.retnode.com, over the tunnel. Nothing upstream checked
+              anybody, so the password is the only gate and it is checked here.
 
     Registered before the calibration hook below, and that ordering is load
     bearing: Flask runs app-level before_request handlers in registration order,
@@ -244,10 +244,10 @@ def _gate_the_remote_pathways():
     unauthenticated visitor arriving during a calibration would be bounced to a
     page they are not allowed to see instead of to the login form.
     """
-    from remote_access import ADMIN, LAN, classify_host, requires_presence
+    from remote_access import LAN, classify_host, requires_presence
 
     g.pathway = classify_host(request.host, read_node_id(), REMOTE_ACCESS_DOMAIN)
-    if g.pathway in (LAN, ADMIN):
+    if g.pathway == LAN:
         return None
 
     # 404 rather than 403 when the owner has not turned this on. The tunnel

--- a/src/mender_connect.py
+++ b/src/mender_connect.py
@@ -1,0 +1,161 @@
+"""Enforcing the remote shell agreement, by editing what mender-connect will do.
+
+The owner can decline interactive access without declining anything else. That
+is enforced here, on the node, by turning off two of mender-connect's features
+and restarting it:
+
+    Terminal      the remote shell Mender's dashboard offers
+    PortForward   forwarding a local port to one on the node
+
+Both have to go. Disabling only the terminal leaves `port-forward 2222:localhost:22`
+reaching sshd directly, and a port-forward also arrives at this GUI with a Host
+of `localhost`, which classifies as the local network and so bypasses the
+restrictions that stop the support pathway granting SSH keys.
+
+## What is deliberately left alone
+
+`FileTransfer` stays enabled. It is how node-infra delivers and clears the
+Cloudflare tunnel token, so gating it here would make the two agreements
+dependent on each other: a node whose owner had declined the shell could never
+receive a support tunnel. It cannot be used to obtain a shell, because sshd
+trusts only /data/retina-gui/authorized_keys, which is root-owned and outside
+the chroot Mender file transfer writes into.
+
+`MenderClient` stays enabled, and mender-authd and mender-updated are untouched
+entirely. Enrolment, OTA updates and inventory reporting continue whatever the
+owner decides. They live in different daemons that share no process or
+dependency with mender-connect, which is what makes that promise structural
+rather than a matter of care.
+
+## Why this refuses rather than repairs
+
+A missing or unparseable config is not rewritten from defaults. The file
+carries file-transfer limits, the shell user and session caps that are not ours
+to reconstruct, and writing a plausible-looking replacement could silently widen
+what a session may do. Refusing leaves the node exactly as it was, which is the
+safer failure.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+
+DEFAULT_CONF_PATH = "/etc/mender/mender-connect.conf"
+SERVICE = "mender-connect"
+
+#: Only used when writing a config where none existed, which on a node never
+#: happens. Matches what the OS image ships.
+DEFAULT_CONF_MODE = 0o644
+
+#: The two features the agreement governs. Order is not significant; both are
+#: written together so the file can never describe a half-applied state.
+GATED_FEATURES = ("Terminal", "PortForward")
+
+
+class MenderConnect:
+    """Reads and writes mender-connect's feature switches."""
+
+    def __init__(self, conf_path=DEFAULT_CONF_PATH, service=SERVICE, dev_mode=False):
+        self.conf_path = conf_path
+        self.service = service
+        self.dev_mode = dev_mode
+
+    # ── reading ──────────────────────────────────────────────────
+
+    def _read(self):
+        """The parsed config, or None when it cannot be trusted."""
+        try:
+            with open(self.conf_path) as f:
+                conf = json.load(f)
+        except (OSError, ValueError):
+            return None
+        return conf if isinstance(conf, dict) else None
+
+    def is_shell_enabled(self):
+        """True, False, or None when the config cannot be read.
+
+        None is a distinct answer on purpose. "We cannot tell" and "the owner
+        declined" look the same to a boolean and mean very different things to
+        anyone deciding whether the agreement is being honoured.
+        """
+        conf = self._read()
+        if conf is None:
+            return None
+        return not any(
+            bool((conf.get(feature) or {}).get("Disable"))
+            for feature in GATED_FEATURES
+        )
+
+    # ── writing ──────────────────────────────────────────────────
+
+    def set_shell_enabled(self, enabled):
+        """Apply the agreement. Returns (ok, error).
+
+        Writes both features together and restarts the service, so the running
+        daemon and the file on disk always agree.
+        """
+        enabled = bool(enabled)
+
+        if self.dev_mode:
+            # Nothing to enforce off-device, but still write the file so the
+            # config page reflects the choice during development.
+            return self._write({feature: {"Disable": not enabled}
+                                for feature in GATED_FEATURES})
+
+        conf = self._read()
+        if conf is None:
+            return False, (f"{self.conf_path} is missing or unreadable, so the "
+                           f"remote shell setting cannot be applied")
+
+        for feature in GATED_FEATURES:
+            section = conf.get(feature)
+            conf[feature] = {**section, "Disable": not enabled} if isinstance(section, dict) \
+                else {"Disable": not enabled}
+
+        ok, error = self._write(conf)
+        if not ok:
+            return False, error
+
+        try:
+            # Restarted rather than reloaded: mender-connect reads its config at
+            # startup only, so a reload would leave the daemon serving the
+            # previous answer while the file claimed otherwise.
+            result = subprocess.run(["systemctl", "restart", self.service],
+                                    capture_output=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            return False, f"Timed out restarting {self.service}"
+        except OSError as e:
+            return False, f"Could not restart {self.service}: {e}"
+
+        if result.returncode != 0:
+            detail = (result.stderr or b"").decode(errors="replace").strip()
+            return False, f"Could not restart {self.service}: {detail}"
+        return True, None
+
+    def _write(self, conf):
+        """Replace the config atomically, keeping the mode it already had.
+
+        Carried over rather than chosen: the image ships this file 0644 root,
+        and tightening it here would be an unrelated change smuggled in behind
+        a setting the owner toggled. DEFAULT_CONF_MODE only applies when there
+        is no existing file to copy, which off-device is the normal case.
+        """
+        directory = os.path.dirname(self.conf_path) or "."
+        try:
+            mode = stat.S_IMODE(os.stat(self.conf_path).st_mode)
+        except OSError:
+            mode = DEFAULT_CONF_MODE
+
+        try:
+            os.makedirs(directory, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(dir=directory)
+            with os.fdopen(fd, "w") as f:
+                json.dump(conf, f, indent=2)
+                f.write("\n")
+            os.chmod(tmp_path, mode)
+            os.rename(tmp_path, self.conf_path)
+        except OSError as e:
+            return False, f"Could not write {self.conf_path}: {e}"
+        return True, None

--- a/src/remote_access.py
+++ b/src/remote_access.py
@@ -94,6 +94,17 @@ CLOUDFLARED_UNIT = "cloudflared.service"
 #: holds the password, and the inventory script is POSIX shell.
 ENABLED_MARKER = "remote-access-enabled"
 
+#: The remote shell agreement, recorded by its exception rather than its
+#: presence, exactly as device_state records cloud services.
+#:
+#: The two agreements default differently and so are stored differently. Support
+#: access defaults OFF, so its marker means "wanted". Shell access defaults ON,
+#: because every node in the fleet already has it and defaulting off would
+#: silently withdraw something owners already rely on; recording only the
+#: exception means an untouched node needs no migration, and a missing or
+#: unwritable /data cannot quietly revoke access nobody declined.
+SHELL_DISABLED_MARKER = "remote-shell-disabled"
+
 #: No 0/O, 1/l/I. A password read aloud across a room or copied off a screen is
 #: the normal case here, and character pairs nobody can distinguish turn that
 #: into a support conversation.
@@ -160,6 +171,42 @@ class RemoteAccess:
     def has_password(self):
         return bool(self._read().get("password"))
 
+    # ── the remote shell agreement ───────────────────────────────
+
+    def is_shell_allowed(self):
+        """Whether the owner permits interactive access over Mender.
+
+        Independent of everything else in this module. Declining it does not
+        affect the support tunnel, and declining support does not affect this.
+        """
+        return not os.path.exists(
+            os.path.join(self.data_dir, SHELL_DISABLED_MARKER))
+
+    def record_shell_allowed(self, allowed):
+        """Record the owner's choice. Returns (ok, error).
+
+        Records only. Enforcing it is mender_connect's job, and the caller
+        applies that FIRST so this file never claims a state the node is not
+        actually in.
+        """
+        marker = os.path.join(self.data_dir, SHELL_DISABLED_MARKER)
+        try:
+            os.makedirs(self.data_dir, exist_ok=True)
+            if allowed:
+                try:
+                    os.remove(marker)
+                except FileNotFoundError:
+                    pass
+            else:
+                # World readable like the other marker: the inventory scripts
+                # run as root and there is nothing here to protect.
+                with open(marker, "w") as f:
+                    f.write("")
+                os.chmod(marker, 0o644)
+        except OSError as e:
+            return False, f"Could not record the remote shell setting: {e}"
+        return True, None
+
     def get_password(self):
         """The password itself, for display. "" when none is set.
 
@@ -178,6 +225,7 @@ class RemoteAccess:
             "enabled": bool(state.get("enabled")) and bool(state.get("password")),
             "requested": bool(state.get("enabled")),
             "has_password": bool(state.get("password")),
+            "shell_allowed": self.is_shell_allowed(),
             "updated_at": state.get("updated_at"),
         }
 

--- a/src/remote_access.py
+++ b/src/remote_access.py
@@ -19,11 +19,26 @@ tunnel neither receives it nor could ask for it. That is the point of doing this
 on the node rather than with an identity provider: the owner decides who gets in,
 and there is no account to create and no email to collect.
 
-Stored hashed, so a lost password is replaced rather than recovered. That is a
-deliberate departure from the phone-hotspot model this otherwise imitates — a
-hotspot shows you its password whenever you ask, and this cannot. Recovery is
-setting a new one from the LAN, which needs physical presence, which is the same
-authority a factory reset would need.
+## Stored in the clear, deliberately
+
+This is the phone-hotspot model, not the user-account model: the owner sets
+something memorable, looks it up whenever they need to share it, and changes it
+when they want. A hash cannot do the middle one, and encrypting instead would be
+theatre — any key the node needs to decrypt has to live on the node beside the
+ciphertext.
+
+It costs less than it sounds like it does. The only readers of the plaintext are
+people who already own the node: the config page shows it on the LAN pathway
+alone, and the LAN pathway is unauthenticated anyway, so anyone who can read it
+there could already change every setting on the box. Mender's remote terminal is
+root, so staff are in the same position with or without this. Nothing is
+protected by hashing here that is not already open.
+
+Two consequences worth being deliberate about. Someone briefly on the house
+network can note the password down and keep *remote* access after they leave,
+which LAN access alone would not have given them — the owner's remedy is to
+change it, same as a hotspot. And a memorable password is the kind people reuse,
+so the config page says out loud that anyone on the local network can see it.
 
 ## Why the device-presence tier exists
 
@@ -41,22 +56,20 @@ import secrets
 import tempfile
 import time
 
-from werkzeug.security import check_password_hash, generate_password_hash
-
-# Hashing method is werkzeug's default, whatever that is for the version
-# installed. Measured on a live pi5-v3 node (werkzeug 2.2.2, which predates
-# scrypt and so picks pbkdf2:sha256:260000): ~147 ms to hash, ~143 ms to verify.
+# Comparison is constant-time, which is the one thing a plaintext store still has
+# to get right: a plain == leaks the password a character at a time through how
+# long the mismatch took to find.
 #
-# That cost is the point on a login form, but it is also why the edge rate limit
-# is not optional: at 143 ms of CPU per attempt, an unthrottled guessing run is a
-# load problem on a board already busy running the radar, quite apart from
-# eventually finding the password.
+# Note what is *not* here any more. Hashing used to cost ~145 ms per attempt on a
+# pi5-v3, which incidentally throttled guessing. A string compare is free, so the
+# rate limit at Cloudflare's edge is now the only thing standing between this and
+# an offline-speed guessing run. It is not optional.
 
-#: Twelve is the floor for anything the owner types. Short enough to be typed on
-#: a phone, long enough that the edge rate limit is a backstop rather than the
-#: only defence. The generated default below is much stronger and is what most
-#: nodes will actually run with.
-MIN_PASSWORD_LENGTH = 12
+#: Eight, matching the WPA2 minimum a phone hotspot enforces — this imitates that
+#: model, and a floor people already recognise beats one they have to discover.
+#: It is short, and deliberately so; the edge rate limit is what makes it safe
+#: rather than the length. Anyone wanting real strength can press Generate.
+MIN_PASSWORD_LENGTH = 8
 
 #: No 0/O, 1/l/I. A password read aloud across a room or copied off a screen is
 #: the normal case here, and character pairs nobody can distinguish turn that
@@ -119,18 +132,29 @@ class RemoteAccess:
         because the owner has no way to tell the difference from outside.
         """
         state = self._read()
-        return bool(state.get("enabled")) and bool(state.get("password_hash"))
+        return bool(state.get("enabled")) and bool(state.get("password"))
 
     def has_password(self):
-        return bool(self._read().get("password_hash"))
+        return bool(self._read().get("password"))
+
+    def get_password(self):
+        """The password itself, for display. "" when none is set.
+
+        Separate from status() on purpose. status() is handed to the config
+        template on every pathway and returned by the toggle endpoint as JSON;
+        this is only ever read where the pathway allows it (see routes/config.py).
+        Keeping them apart means the password cannot reach a template or a
+        response by being carried along inside something else.
+        """
+        return self._read().get("password") or ""
 
     def status(self):
-        """What the config page needs to render the section."""
+        """What the config page needs to render the section. Never the password."""
         state = self._read()
         return {
-            "enabled": bool(state.get("enabled")) and bool(state.get("password_hash")),
+            "enabled": bool(state.get("enabled")) and bool(state.get("password")),
             "requested": bool(state.get("enabled")),
-            "has_password": bool(state.get("password_hash")),
+            "has_password": bool(state.get("password")),
             "updated_at": state.get("updated_at"),
         }
 
@@ -139,18 +163,14 @@ class RemoteAccess:
     def verify(self, password):
         """Check a submitted password. False whenever no password is set.
 
-        ``check_password_hash`` compares in constant time, so this does not leak
-        the password through how long it took to reject it.
+        Encoded before comparing because compare_digest refuses non-ASCII str,
+        and nothing stops an owner picking a password with an accent in it.
         """
-        password_hash = self._read().get("password_hash")
-        if not password_hash or not password:
+        stored = self._read().get("password")
+        if not stored or not password:
             return False
-        try:
-            return check_password_hash(password_hash, password)
-        except (ValueError, TypeError):
-            # A hash written by a future format, or a corrupted file. Refusing
-            # is the only safe reading of "we cannot tell".
-            return False
+        return secrets.compare_digest(stored.encode("utf-8"),
+                                      password.encode("utf-8"))
 
     # ── writing ──────────────────────────────────────────────────
 
@@ -170,7 +190,7 @@ class RemoteAccess:
         ok, error = self.validate_password(password)
         if not ok:
             return False, error
-        return self._update(password_hash=generate_password_hash(password))
+        return self._update(password=password)
 
     def set_enabled(self, enabled):
         """Turn remote access on or off. Returns (ok, error).
@@ -190,9 +210,9 @@ class RemoteAccess:
         state["updated_at"] = int(time.time())
         try:
             os.makedirs(self.data_dir, exist_ok=True)
-            # 0600 from creation rather than chmod-ed afterwards, so the hash is
-            # never briefly world-readable. Same reasoning as the telemetry
-            # bearer token's handling in retina-telemetry's state.py.
+            # 0600 from creation rather than chmod-ed afterwards, so the
+            # password is never briefly world-readable. It matters more now that
+            # the file holds the password itself rather than a hash of it.
             fd, tmp_path = tempfile.mkstemp(dir=self.data_dir)
             os.chmod(tmp_path, 0o600)
             with os.fdopen(fd, "w") as f:

--- a/src/remote_access.py
+++ b/src/remote_access.py
@@ -92,6 +92,10 @@ CLOUDFLARED_UNIT = "cloudflared.service"
 #:
 #: A marker rather than the state file itself because that one is 0600 root and
 #: holds the password, and the inventory script is POSIX shell.
+#:
+#: Presence still means enabled, which is why defaulting on needs the file to
+#: appear on a node nobody has touched: the inventory script reads the file, not
+#: is_enabled(). publish_marker() at startup is what puts it there.
 ENABLED_MARKER = "remote-access-enabled"
 
 #: The remote shell agreement, recorded by its exception rather than its
@@ -166,12 +170,21 @@ class RemoteAccess:
         Access now and the page no longer offers a way to set one, so that
         condition made the setting impossible to turn on at all.
 
-        Nothing is advertised prematurely by dropping it. The hostname only
+        Nothing is advertised prematurely by defaulting on. The hostname only
         starts serving once the connector has a token, and node-infra installs
         the Access config before the token precisely so the node can identify
         callers from the first request it answers.
+
+        TEMPORARY: defaults ON, so a node that has never been touched publishes
+        `remote_access=true` and gets a tunnel without anyone opting in. That is
+        deliberate for now and is meant to be reverted: the setting exists to be
+        the owner's choice, and a default of on makes it a choice they have to
+        discover in order to decline. Tracked, with the revert, on the ticket in
+        Deployment Issues & Improvements.
+
+        Restoring the old behaviour is one word: drop the `True` below.
         """
-        return bool(self._read().get("enabled"))
+        return bool(self._read().get("enabled", True))
 
     def has_password(self):
         return bool(self._read().get("password"))
@@ -227,7 +240,9 @@ class RemoteAccess:
         """What the config page needs to render the section. Never the password."""
         state = self._read()
         return {
-            "enabled": bool(state.get("enabled")),
+            # is_enabled(), not the raw field: the default lives in one place
+            # and this is the page that would otherwise disagree with it.
+            "enabled": self.is_enabled(),
             "has_password": bool(state.get("password")),
             "shell_allowed": self.is_shell_allowed(),
             "updated_at": state.get("updated_at"),
@@ -290,6 +305,17 @@ class RemoteAccess:
 
         self._sync_marker()
         return True, None
+
+    def publish_marker(self):
+        """Write the inventory marker to match is_enabled(), at startup.
+
+        The marker is the whole node-to-server channel for this setting, and a
+        node that has never been touched has no state file and so has never had
+        one written. While the default was off that was consistent: no file, no
+        tunnel. With the default on it is not, and the node would keep reporting
+        `remote_access=false` until somebody happened to toggle something.
+        """
+        self._sync_marker()
 
     def _sync_marker(self):
         """Make the inventory marker agree with is_enabled().

--- a/src/remote_access.py
+++ b/src/remote_access.py
@@ -1,23 +1,28 @@
 """Remote access: the opt-in switch, and the password the node checks visitors against.
 
-Two hostnames reach this GUI once a Cloudflare tunnel is up, and they are told
-apart by nothing except the ``Host`` header:
+One hostname reaches this GUI once a Cloudflare tunnel is up:
 
-    ret4c844c20.retnode.com          the owner. Must present the password below.
-    ret4c844c20.admin.retnode.com    Offworld staff. Gated by Cloudflare Access
-                                     at the edge; this GUI asks them for nothing.
+    ret4c844c20.retnode.com    the owner, from anywhere. Must present the
+                               password below.
 
 Everything else (``owl.local``, ``ret4c844c20.local``, an IP) is the LAN, which
 is unauthenticated exactly as it has always been. Being on the network is the
 credential there, and nothing in this module changes that.
 
+Offworld staff are not a third case. They reach a node with
+``mender-cli port-forward``, which arrives with a Host of ``localhost`` and so
+counts as the LAN. Mender has already authenticated them and logged the session,
+which is why there is no staff hostname, no Cloudflare Access application and no
+fleet-wide staff password anywhere in this design.
+
 ## The password never leaves the node
 
-It is generated here, stored here, verified here. It is not in the tunnel token,
-not in the telemetry registration payload, and the server that provisions the
-tunnel neither receives it nor could ask for it. That is the point of doing this
-on the node rather than with an identity provider: the owner decides who gets in,
-and there is no account to create and no email to collect.
+It is generated here, stored here, verified here. Nothing sends it anywhere: the
+only thing that leaves this node is a marker file saying remote access is on,
+carried up as a Mender inventory attribute. node-infra provisions a tunnel from
+that and never learns the password, because it has no reason to. That is the
+point of doing this on the node rather than with an identity provider: the owner
+decides who gets in, and there is no account to create and no email to collect.
 
 ## Stored in the clear, deliberately
 
@@ -47,12 +52,14 @@ shared password could add an SSH key, they would keep a way in that outlived the
 rotation, and the owner's only remedy would be reinstalling the node. So key
 management, password changes and Mender installs are refused on the owner
 pathway even when the session is valid. See PRESENCE_REQUIRED_PREFIXES. The LAN
-and the admin hostname are unaffected.
+is unaffected, so an owner at home and an engineer on a port-forward both keep
+the full interface.
 """
 
 import json
 import os
 import secrets
+import subprocess
 import tempfile
 import time
 
@@ -70,6 +77,22 @@ import time
 #: It is short, and deliberately so; the edge rate limit is what makes it safe
 #: rather than the length. Anyone wanting real strength can press Generate.
 MIN_PASSWORD_LENGTH = 8
+
+#: Where owl-os keeps the connector token, and the unit that consumes it. Read
+#: only to report whether the tunnel is actually up; nothing here writes either.
+TUNNEL_TOKEN_PATH = "/data/cloudflared/tunnel-token"
+CLOUDFLARED_UNIT = "cloudflared.service"
+
+#: The file owl-os's mender-inventory-retina-remote-access script looks for.
+#:
+#: This is the entire node-to-server channel for this feature. The node states
+#: what its owner wants by the presence of this file; Mender carries it up as
+#: the `remote_access` inventory attribute on its next poll; node-infra reads
+#: that and decides whether a tunnel should exist. Nothing here calls a server.
+#:
+#: A marker rather than the state file itself because that one is 0600 root and
+#: holds the password, and the inventory script is POSIX shell.
+ENABLED_MARKER = "remote-access-enabled"
 
 #: No 0/O, 1/l/I. A password read aloud across a room or copied off a screen is
 #: the normal case here, and character pairs nobody can distinguish turn that
@@ -220,29 +243,99 @@ class RemoteAccess:
             os.rename(tmp_path, self.state_file)
         except OSError as e:
             return False, f"Could not save remote access settings: {e}"
+
+        self._sync_marker()
         return True, None
+
+    def _sync_marker(self):
+        """Make the inventory marker agree with is_enabled().
+
+        Recomputed after every write rather than set at the toggle. The marker
+        has to reflect the conjunction of two values written by two different
+        methods, so deriving it in one of them is how the two drift apart.
+
+        Best effort. A marker that failed to appear costs the owner one Mender
+        inventory cycle, whereas refusing the whole save because of it would
+        lose a password they just typed.
+        """
+        marker = os.path.join(self.data_dir, ENABLED_MARKER)
+        try:
+            if self.is_enabled():
+                # World readable on purpose: mender-authd runs the inventory
+                # scripts and there is nothing in here to protect.
+                with open(marker, "w") as f:
+                    f.write("")
+                os.chmod(marker, 0o644)
+            else:
+                try:
+                    os.remove(marker)
+                except FileNotFoundError:
+                    pass
+        except OSError:
+            pass
+
+
+# ── is the tunnel actually up ────────────────────────────────────
+
+def tunnel_status(token_path=TUNNEL_TOKEN_PATH, unit=CLOUDFLARED_UNIT):
+    """Report the connector's real state, asked of systemd rather than a server.
+
+    Nothing on the node knows whether provisioning succeeded, and under this
+    design nothing needs to: node-infra puts a token on the box, owl-os starts
+    the connector, and the honest answer to "is it working" is whether that unit
+    is up. cloudflared is Type=notify and only signals ready once it has
+    connections to the edge, so an active unit means genuinely reachable rather
+    than merely launched.
+
+    Returns one of:
+      "waiting"  opted in, but no token has arrived yet
+      "up"       token installed and the connector is running
+      "down"     token installed and the connector is not
+      "unknown"  systemctl could not be asked (dev machine, test run)
+    """
+    try:
+        if os.path.getsize(token_path) == 0:
+            return "waiting"
+    except OSError:
+        return "waiting"
+
+    try:
+        result = subprocess.run(["systemctl", "is-active", unit],
+                                capture_output=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    return "up" if result.returncode == 0 else "down"
 
 
 # ── which pathway a request arrived on ───────────────────────────
 
 LAN = "lan"
 OWNER = "owner"
-ADMIN = "admin"
 
 
 def classify_host(host, node_id, domain):
-    """Return LAN, OWNER or ADMIN for the Host header of a request.
+    """Return LAN or OWNER for the Host header of a request.
 
-    The three pathways are distinguished by name alone, because they are the
-    same service on the same port and there is nothing else to distinguish them
-    by. cloudflared forwards the hostname the request arrived on, so a visitor
-    cannot reach the owner hostname and present themselves as the admin one.
+    Two pathways, distinguished by name alone, because they are the same service
+    on the same port and there is nothing else to tell them apart. cloudflared
+    forwards the hostname the request arrived on, so a visitor cannot reach the
+    tunnel hostname and present themselves as something else.
 
-    Fails closed on the remote domain. Anything under it that is not recognised
-    as the admin name is treated as OWNER, so a hostname this node does not
-    expect (a stale DNS record, a provisioning bug, a domain-wide wildcard
-    someone added) demands a password rather than being mistaken for the LAN and
-    waved through. Only names with no relationship to the remote domain are LAN.
+    There is deliberately no staff pathway. Offworld engineers reach a node
+    through Mender port-forward, which lands with a Host of `localhost` and is
+    therefore LAN: unauthenticated, exactly like standing in the house. That is
+    why no second hostname, Cloudflare Access application or fleet-wide staff
+    password is needed anywhere in this design.
+
+    Fails closed on the remote domain. Anything under it is treated as OWNER, so
+    a hostname this node does not expect (a stale DNS record, a provisioning
+    bug, a domain-wide wildcard someone added) demands a password rather than
+    being mistaken for the LAN and waved through. Only names with no
+    relationship to the remote domain are LAN.
+
+    node_id is unused now that there is only one remote name to recognise. It
+    stays in the signature because the caller has it and a future scheme that
+    varies by node would want it back.
     """
     host = (host or "").split(":")[0].strip().rstrip(".").lower()
     domain = (domain or "").strip().rstrip(".").lower()
@@ -250,13 +343,9 @@ def classify_host(host, node_id, domain):
         return LAN
 
     suffix = "." + domain
-    if not (host == domain or host.endswith(suffix)):
-        return LAN
-
-    node_id = (node_id or "").strip().lower()
-    if node_id and host == f"{node_id}.admin{suffix}":
-        return ADMIN
-    return OWNER
+    if host == domain or host.endswith(suffix):
+        return OWNER
+    return LAN
 
 
 def requires_presence(path):

--- a/src/remote_access.py
+++ b/src/remote_access.py
@@ -7,7 +7,7 @@ apart by nothing except the ``Host`` header:
     ret4c844c20.admin.retnode.com    Offworld staff. Gated by Cloudflare Access
                                      at the edge; this GUI asks them for nothing.
 
-Everything else — ``owl.local``, ``ret4c844c20.local``, an IP — is the LAN, which
+Everything else (``owl.local``, ``ret4c844c20.local``, an IP) is the LAN, which
 is unauthenticated exactly as it has always been. Being on the network is the
 credential there, and nothing in this module changes that.
 
@@ -24,7 +24,7 @@ and there is no account to create and no email to collect.
 This is the phone-hotspot model, not the user-account model: the owner sets
 something memorable, looks it up whenever they need to share it, and changes it
 when they want. A hash cannot do the middle one, and encrypting instead would be
-theatre — any key the node needs to decrypt has to live on the node beside the
+theatre: any key the node needs to decrypt has to live on the node beside the
 ciphertext.
 
 It costs less than it sounds like it does. The only readers of the plaintext are
@@ -36,7 +36,7 @@ protected by hashing here that is not already open.
 
 Two consequences worth being deliberate about. Someone briefly on the house
 network can note the password down and keep *remote* access after they leave,
-which LAN access alone would not have given them — the owner's remedy is to
+which LAN access alone would not have given them. The owner's remedy is to
 change it, same as a hotspot. And a memorable password is the kind people reuse,
 so the config page says out loud that anyone on the local network can see it.
 
@@ -46,7 +46,7 @@ Rotating the password has to *mean* something. If a visitor authenticated with a
 shared password could add an SSH key, they would keep a way in that outlived the
 rotation, and the owner's only remedy would be reinstalling the node. So key
 management, password changes and Mender installs are refused on the owner
-pathway even when the session is valid — see PRESENCE_REQUIRED_PREFIXES. The LAN
+pathway even when the session is valid. See PRESENCE_REQUIRED_PREFIXES. The LAN
 and the admin hostname are unaffected.
 """
 
@@ -65,7 +65,7 @@ import time
 # rate limit at Cloudflare's edge is now the only thing standing between this and
 # an offline-speed guessing run. It is not optional.
 
-#: Eight, matching the WPA2 minimum a phone hotspot enforces — this imitates that
+#: Eight, matching the WPA2 minimum a phone hotspot enforces. This imitates that
 #: model, and a floor people already recognise beats one they have to discover.
 #: It is short, and deliberately so; the edge rate limit is what makes it safe
 #: rather than the length. Anyone wanting real strength can press Generate.
@@ -239,7 +239,7 @@ def classify_host(host, node_id, domain):
     cannot reach the owner hostname and present themselves as the admin one.
 
     Fails closed on the remote domain. Anything under it that is not recognised
-    as the admin name is treated as OWNER — so a hostname this node does not
+    as the admin name is treated as OWNER, so a hostname this node does not
     expect (a stale DNS record, a provisioning bug, a domain-wide wildcard
     someone added) demands a password rather than being mistaken for the LAN and
     waved through. Only names with no relationship to the remote domain are LAN.

--- a/src/remote_access.py
+++ b/src/remote_access.py
@@ -1,0 +1,244 @@
+"""Remote access: the opt-in switch, and the password the node checks visitors against.
+
+Two hostnames reach this GUI once a Cloudflare tunnel is up, and they are told
+apart by nothing except the ``Host`` header:
+
+    ret4c844c20.retnode.com          the owner. Must present the password below.
+    ret4c844c20.admin.retnode.com    Offworld staff. Gated by Cloudflare Access
+                                     at the edge; this GUI asks them for nothing.
+
+Everything else — ``owl.local``, ``ret4c844c20.local``, an IP — is the LAN, which
+is unauthenticated exactly as it has always been. Being on the network is the
+credential there, and nothing in this module changes that.
+
+## The password never leaves the node
+
+It is generated here, stored here, verified here. It is not in the tunnel token,
+not in the telemetry registration payload, and the server that provisions the
+tunnel neither receives it nor could ask for it. That is the point of doing this
+on the node rather than with an identity provider: the owner decides who gets in,
+and there is no account to create and no email to collect.
+
+Stored hashed, so a lost password is replaced rather than recovered. That is a
+deliberate departure from the phone-hotspot model this otherwise imitates — a
+hotspot shows you its password whenever you ask, and this cannot. Recovery is
+setting a new one from the LAN, which needs physical presence, which is the same
+authority a factory reset would need.
+
+## Why the device-presence tier exists
+
+Rotating the password has to *mean* something. If a visitor authenticated with a
+shared password could add an SSH key, they would keep a way in that outlived the
+rotation, and the owner's only remedy would be reinstalling the node. So key
+management, password changes and Mender installs are refused on the owner
+pathway even when the session is valid — see PRESENCE_REQUIRED_PREFIXES. The LAN
+and the admin hostname are unaffected.
+"""
+
+import json
+import os
+import secrets
+import tempfile
+import time
+
+from werkzeug.security import check_password_hash, generate_password_hash
+
+# Hashing method is werkzeug's default, whatever that is for the version
+# installed. Measured on a live pi5-v3 node (werkzeug 2.2.2, which predates
+# scrypt and so picks pbkdf2:sha256:260000): ~147 ms to hash, ~143 ms to verify.
+#
+# That cost is the point on a login form, but it is also why the edge rate limit
+# is not optional: at 143 ms of CPU per attempt, an unthrottled guessing run is a
+# load problem on a board already busy running the radar, quite apart from
+# eventually finding the password.
+
+#: Twelve is the floor for anything the owner types. Short enough to be typed on
+#: a phone, long enough that the edge rate limit is a backstop rather than the
+#: only defence. The generated default below is much stronger and is what most
+#: nodes will actually run with.
+MIN_PASSWORD_LENGTH = 12
+
+#: No 0/O, 1/l/I. A password read aloud across a room or copied off a screen is
+#: the normal case here, and character pairs nobody can distinguish turn that
+#: into a support conversation.
+_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789"
+
+#: Four groups of four, hyphenated: 16 characters from a 31-symbol alphabet is
+#: about 79 bits, which is not brute-forceable at any online rate.
+_GENERATED_GROUPS = 4
+_GENERATED_GROUP_LEN = 4
+
+#: Refused on the owner pathway even with a valid session. Prefix-matched.
+#:
+#: These are the operations that would let a visitor outlive the password they
+#: were given, or take the node away from its owner:
+#:
+#:   /ssh-keys        an added key survives every future password rotation
+#:   /remote-access   changing the password locks the owner out of their own node
+#:   /mender/install  pushes new firmware, and can leave the node unreachable
+#:
+#: Everything else on the GUI is fair game for whoever the owner shared with.
+PRESENCE_REQUIRED_PREFIXES = (
+    "/ssh-keys",
+    "/remote-access",
+    "/mender/install",
+)
+
+
+def generate_password():
+    """A strong default, in the shape of a thing a person will retype."""
+    groups = [
+        "".join(secrets.choice(_ALPHABET) for _ in range(_GENERATED_GROUP_LEN))
+        for _ in range(_GENERATED_GROUPS)
+    ]
+    return "-".join(groups)
+
+
+class RemoteAccess:
+    """The node's own record of whether remote access is on, and its password."""
+
+    def __init__(self, state_file):
+        self.state_file = state_file
+        self.data_dir = os.path.dirname(state_file)
+
+    # ── reading ──────────────────────────────────────────────────
+
+    def _read(self):
+        try:
+            with open(self.state_file) as f:
+                state = json.load(f)
+        except (OSError, ValueError):
+            return {}
+        return state if isinstance(state, dict) else {}
+
+    def is_enabled(self):
+        """True only when the owner turned it on *and* set a password.
+
+        Both halves are required deliberately. A node advertising a hostname it
+        will refuse every visitor on is worse than one that never advertised it,
+        because the owner has no way to tell the difference from outside.
+        """
+        state = self._read()
+        return bool(state.get("enabled")) and bool(state.get("password_hash"))
+
+    def has_password(self):
+        return bool(self._read().get("password_hash"))
+
+    def status(self):
+        """What the config page needs to render the section."""
+        state = self._read()
+        return {
+            "enabled": bool(state.get("enabled")) and bool(state.get("password_hash")),
+            "requested": bool(state.get("enabled")),
+            "has_password": bool(state.get("password_hash")),
+            "updated_at": state.get("updated_at"),
+        }
+
+    # ── verifying ────────────────────────────────────────────────
+
+    def verify(self, password):
+        """Check a submitted password. False whenever no password is set.
+
+        ``check_password_hash`` compares in constant time, so this does not leak
+        the password through how long it took to reject it.
+        """
+        password_hash = self._read().get("password_hash")
+        if not password_hash or not password:
+            return False
+        try:
+            return check_password_hash(password_hash, password)
+        except (ValueError, TypeError):
+            # A hash written by a future format, or a corrupted file. Refusing
+            # is the only safe reading of "we cannot tell".
+            return False
+
+    # ── writing ──────────────────────────────────────────────────
+
+    @staticmethod
+    def validate_password(password):
+        """Return (ok, error) for a password the owner typed."""
+        password = password or ""
+        if len(password) < MIN_PASSWORD_LENGTH:
+            return False, (f"Password must be at least {MIN_PASSWORD_LENGTH} "
+                           f"characters")
+        if password.strip() != password:
+            return False, "Password cannot start or end with a space"
+        return True, None
+
+    def set_password(self, password):
+        """Store a new password. Returns (ok, error)."""
+        ok, error = self.validate_password(password)
+        if not ok:
+            return False, error
+        return self._update(password_hash=generate_password_hash(password))
+
+    def set_enabled(self, enabled):
+        """Turn remote access on or off. Returns (ok, error).
+
+        Turning it on without a password is refused rather than silently
+        half-applied: see is_enabled() for why an advertised-but-unusable
+        hostname is the worst of the three states.
+        """
+        enabled = bool(enabled)
+        if enabled and not self.has_password():
+            return False, "Set a password before turning on remote access"
+        return self._update(enabled=enabled)
+
+    def _update(self, **changes):
+        state = self._read()
+        state.update(changes)
+        state["updated_at"] = int(time.time())
+        try:
+            os.makedirs(self.data_dir, exist_ok=True)
+            # 0600 from creation rather than chmod-ed afterwards, so the hash is
+            # never briefly world-readable. Same reasoning as the telemetry
+            # bearer token's handling in retina-telemetry's state.py.
+            fd, tmp_path = tempfile.mkstemp(dir=self.data_dir)
+            os.chmod(tmp_path, 0o600)
+            with os.fdopen(fd, "w") as f:
+                json.dump(state, f)
+            os.rename(tmp_path, self.state_file)
+        except OSError as e:
+            return False, f"Could not save remote access settings: {e}"
+        return True, None
+
+
+# ── which pathway a request arrived on ───────────────────────────
+
+LAN = "lan"
+OWNER = "owner"
+ADMIN = "admin"
+
+
+def classify_host(host, node_id, domain):
+    """Return LAN, OWNER or ADMIN for the Host header of a request.
+
+    The three pathways are distinguished by name alone, because they are the
+    same service on the same port and there is nothing else to distinguish them
+    by. cloudflared forwards the hostname the request arrived on, so a visitor
+    cannot reach the owner hostname and present themselves as the admin one.
+
+    Fails closed on the remote domain. Anything under it that is not recognised
+    as the admin name is treated as OWNER — so a hostname this node does not
+    expect (a stale DNS record, a provisioning bug, a domain-wide wildcard
+    someone added) demands a password rather than being mistaken for the LAN and
+    waved through. Only names with no relationship to the remote domain are LAN.
+    """
+    host = (host or "").split(":")[0].strip().rstrip(".").lower()
+    domain = (domain or "").strip().rstrip(".").lower()
+    if not host or not domain:
+        return LAN
+
+    suffix = "." + domain
+    if not (host == domain or host.endswith(suffix)):
+        return LAN
+
+    node_id = (node_id or "").strip().lower()
+    if node_id and host == f"{node_id}.admin{suffix}":
+        return ADMIN
+    return OWNER
+
+
+def requires_presence(path):
+    """True for operations refused on the owner pathway (see the module docstring)."""
+    return (path or "").startswith(PRESENCE_REQUIRED_PREFIXES)

--- a/src/remote_access.py
+++ b/src/remote_access.py
@@ -159,14 +159,19 @@ class RemoteAccess:
         return state if isinstance(state, dict) else {}
 
     def is_enabled(self):
-        """True only when the owner turned it on *and* set a password.
+        """Whether the owner permits support to reach this node's interface.
 
-        Both halves are required deliberately. A node advertising a hostname it
-        will refuse every visitor on is worse than one that never advertised it,
-        because the owner has no way to tell the difference from outside.
+        The owner's choice alone. It used to also require a password, from when
+        the owner signed in with one; support access is gated by Cloudflare
+        Access now and the page no longer offers a way to set one, so that
+        condition made the setting impossible to turn on at all.
+
+        Nothing is advertised prematurely by dropping it. The hostname only
+        starts serving once the connector has a token, and node-infra installs
+        the Access config before the token precisely so the node can identify
+        callers from the first request it answers.
         """
-        state = self._read()
-        return bool(state.get("enabled")) and bool(state.get("password"))
+        return bool(self._read().get("enabled"))
 
     def has_password(self):
         return bool(self._read().get("password"))
@@ -222,8 +227,7 @@ class RemoteAccess:
         """What the config page needs to render the section. Never the password."""
         state = self._read()
         return {
-            "enabled": bool(state.get("enabled")) and bool(state.get("password")),
-            "requested": bool(state.get("enabled")),
+            "enabled": bool(state.get("enabled")),
             "has_password": bool(state.get("password")),
             "shell_allowed": self.is_shell_allowed(),
             "updated_at": state.get("updated_at"),
@@ -264,16 +268,8 @@ class RemoteAccess:
         return self._update(password=password)
 
     def set_enabled(self, enabled):
-        """Turn remote access on or off. Returns (ok, error).
-
-        Turning it on without a password is refused rather than silently
-        half-applied: see is_enabled() for why an advertised-but-unusable
-        hostname is the worst of the three states.
-        """
-        enabled = bool(enabled)
-        if enabled and not self.has_password():
-            return False, "Set a password before turning on remote access"
-        return self._update(enabled=enabled)
+        """Turn support access on or off. Returns (ok, error)."""
+        return self._update(enabled=bool(enabled))
 
     def _update(self, **changes):
         state = self._read()

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -55,10 +55,21 @@ def _remote_access_context():
     question, and comes from retina-telemetry's status document once that side
     exists.
     """
+    from flask import g
+
     from app import REMOTE_ACCESS_DOMAIN, read_node_id, remote_access
+
+    # The password is rendered only where the owner expects it to be visible:
+    # their own network. /config is reachable on the owner pathway too, and
+    # showing it there would make "nobody off your network can see this" false —
+    # someone the password was shared with could read it back off the page.
+    # Withheld rather than masked, so it is not in the HTML at all.
+    pathway = getattr(g, 'pathway', 'lan')
 
     return {
         'remote_access': remote_access.status(),
+        'remote_password': remote_access.get_password() if pathway != 'owner' else '',
+        'remote_password_visible': pathway != 'owner',
         'remote_host': f"{read_node_id()}.{REMOTE_ACCESS_DOMAIN}",
         'remote_password_min': MIN_PASSWORD_LENGTH,
     }

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -43,8 +43,8 @@ def _check_wizard_not_active():
 def _remote_access_context():
     """Remote access state, for every template this blueprint renders.
 
-    Deliberately not passed per call site. config.html has two render points —
-    /config, and the validation-error branch of /config/save — and handing them
+    Deliberately not passed per call site. config.html has two render points:
+    /config, and the validation-error branch of /config/save. Handing them
     the same three arguments by hand is how the second one shipped without them.
     A context processor is the version of this that cannot drift when a third
     render point appears.
@@ -61,7 +61,7 @@ def _remote_access_context():
 
     # The password is rendered only where the owner expects it to be visible:
     # their own network. /config is reachable on the owner pathway too, and
-    # showing it there would make "nobody off your network can see this" false —
+    # showing it there would make "nobody off your network can see this" false:
     # someone the password was shared with could read it back off the page.
     # Withheld rather than masked, so it is not in the HTML at all.
     pathway = getattr(g, 'pathway', 'lan')

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -12,7 +12,6 @@ from config_schema import (
 )
 from form_utils import schema_to_form_fields
 from node_name import MAX_LENGTH as NAME_MAX_LENGTH
-from remote_access import MIN_PASSWORD_LENGTH
 
 bp = Blueprint('config', __name__)
 
@@ -51,32 +50,24 @@ def _remote_access_context():
 
     remote_host is derived rather than reported: the hostname is a pure function
     of node_id and the zone, so the page can name the address before anything
-    has provisioned it. Whether the tunnel is actually *up* is a separate
-    question, and comes from retina-telemetry's status document once that side
-    exists.
+    has provisioned it.
     """
-    from flask import g
-
-    from app import REMOTE_ACCESS_DOMAIN, read_node_id, remote_access
+    from app import REMOTE_ACCESS_DOMAIN, mender_connect, read_node_id, remote_access
     from remote_access import tunnel_status
-
-    # The password is rendered only where the owner expects it to be visible:
-    # their own network. /config is reachable on the owner pathway too, and
-    # showing it there would make "nobody off your network can see this" false:
-    # someone the password was shared with could read it back off the page.
-    # Withheld rather than masked, so it is not in the HTML at all.
-    pathway = getattr(g, 'pathway', 'lan')
 
     return {
         'remote_access': remote_access.status(),
+        # The *enforced* shell state, read back from mender-connect's own config
+        # rather than from what we recorded. They can disagree: an enforcement
+        # that failed, or a hand-edited config, would otherwise leave this page
+        # confidently showing a choice the node is not honouring. True, False,
+        # or None when the config cannot be read at all.
+        'shell_enforced': mender_connect.is_shell_enabled(),
         # Asked of systemd, not of a server. Nothing on the node is told whether
         # provisioning worked, so the honest answer to "is it reachable" is
         # whether the connector is up. See remote_access.tunnel_status.
         'remote_tunnel': tunnel_status() if remote_access.is_enabled() else 'off',
-        'remote_password': remote_access.get_password() if pathway != 'owner' else '',
-        'remote_password_visible': pathway != 'owner',
         'remote_host': f"{read_node_id()}.{REMOTE_ACCESS_DOMAIN}",
-        'remote_password_min': MIN_PASSWORD_LENGTH,
     }
 
 

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -12,6 +12,7 @@ from config_schema import (
 )
 from form_utils import schema_to_form_fields
 from node_name import MAX_LENGTH as NAME_MAX_LENGTH
+from remote_access import MIN_PASSWORD_LENGTH
 
 bp = Blueprint('config', __name__)
 
@@ -36,6 +37,31 @@ def _check_wizard_not_active():
         return None
     if device_state.is_setup_wizard_in_progress():
         return redirect('/set-up')
+
+
+@bp.context_processor
+def _remote_access_context():
+    """Remote access state, for every template this blueprint renders.
+
+    Deliberately not passed per call site. config.html has two render points —
+    /config, and the validation-error branch of /config/save — and handing them
+    the same three arguments by hand is how the second one shipped without them.
+    A context processor is the version of this that cannot drift when a third
+    render point appears.
+
+    remote_host is derived rather than reported: the hostname is a pure function
+    of node_id and the zone, so the page can name the address before anything
+    has provisioned it. Whether the tunnel is actually *up* is a separate
+    question, and comes from retina-telemetry's status document once that side
+    exists.
+    """
+    from app import REMOTE_ACCESS_DOMAIN, read_node_id, remote_access
+
+    return {
+        'remote_access': remote_access.status(),
+        'remote_host': f"{read_node_id()}.{REMOTE_ACCESS_DOMAIN}",
+        'remote_password_min': MIN_PASSWORD_LENGTH,
+    }
 
 
 @bp.route("/config")

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -58,6 +58,7 @@ def _remote_access_context():
     from flask import g
 
     from app import REMOTE_ACCESS_DOMAIN, read_node_id, remote_access
+    from remote_access import tunnel_status
 
     # The password is rendered only where the owner expects it to be visible:
     # their own network. /config is reachable on the owner pathway too, and
@@ -68,6 +69,10 @@ def _remote_access_context():
 
     return {
         'remote_access': remote_access.status(),
+        # Asked of systemd, not of a server. Nothing on the node is told whether
+        # provisioning worked, so the honest answer to "is it reachable" is
+        # whether the connector is up. See remote_access.tunnel_status.
+        'remote_tunnel': tunnel_status() if remote_access.is_enabled() else 'off',
         'remote_password': remote_access.get_password() if pathway != 'owner' else '',
         'remote_password_visible': pathway != 'owner',
         'remote_host': f"{read_node_id()}.{REMOTE_ACCESS_DOMAIN}",

--- a/src/routes/remote_access.py
+++ b/src/routes/remote_access.py
@@ -1,0 +1,124 @@
+"""Login for the owner pathway, and the controls that configure it.
+
+The login half is reachable from the owner hostname (it has to be — it is the
+thing standing in front of everything else). The configuration half lives under
+/remote-access, which app.py's gate refuses on that pathway entirely: changing
+the password or the toggle needs someone at the device or on the admin hostname.
+See remote_access.PRESENCE_REQUIRED_PREFIXES.
+"""
+
+from flask import (
+    Blueprint,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
+from remote_access import generate_password
+
+bp = Blueprint('remote_access', __name__)
+
+
+def _safe_next(target):
+    """Only ever redirect back into this site.
+
+    request.full_path is put in the query string by the gate, so this value is
+    attacker-supplied in the ordinary case of somebody being sent a link. A bare
+    path is the only shape accepted: anything scheme-relative ("//evil.test") or
+    absolute would turn the login page into an open redirect.
+    """
+    if not target or not target.startswith('/'):
+        return '/'
+    if target.startswith('//') or target.startswith('/\\'):
+        return '/'
+    return target
+
+
+@bp.route("/login", methods=["GET"])
+def login():
+    """The password prompt shown on the owner hostname."""
+    if session.get('remote_authed'):
+        return redirect(_safe_next(request.args.get('next')))
+    return render_template("login.html",
+                           next=request.args.get('next', ''),
+                           error=None)
+
+
+@bp.route("/login", methods=["POST"])
+def do_login():
+    from app import remote_access
+
+    target = _safe_next(request.form.get('next'))
+    if remote_access.verify(request.form.get('password', '')):
+        session.clear()
+        session['remote_authed'] = True
+        # Not permanent: the cookie dies with the browser session. A node's
+        # password is shared more freely than an account password, so a
+        # remembered login on a borrowed laptop is a likelier way to lose
+        # control of a node than the inconvenience of signing in again.
+        session.permanent = False
+        return redirect(target)
+
+    # Deliberately says nothing about whether a password is even set. The only
+    # real defence against guessing is the rate limit at Cloudflare's edge —
+    # there is none in this process — so this page gives an attacker no signal
+    # to work with beyond pass or fail.
+    return render_template("login.html", next=request.form.get('next', ''),
+                           error="Incorrect password"), 401
+
+
+@bp.route("/logout", methods=["POST"])
+def logout():
+    session.clear()
+    return redirect(url_for('remote_access.login'))
+
+
+@bp.route("/remote-access/password", methods=["POST"])
+def set_password():
+    """Set or replace the password. Refused on the owner pathway by the gate."""
+    from app import remote_access
+
+    ok, error = remote_access.set_password(request.form.get('password', ''))
+    if not ok:
+        return jsonify({"ok": False, "error": error}), 400
+    return jsonify({"ok": True, "has_password": True})
+
+
+@bp.route("/remote-access/generate", methods=["POST"])
+def generate():
+    """Mint a strong password and return it once.
+
+    Once is all there is: only the hash is stored, so this response is the only
+    time the plaintext exists anywhere. The caller has to show it to the owner
+    then and there.
+    """
+    from app import remote_access
+
+    password = generate_password()
+    ok, error = remote_access.set_password(password)
+    if not ok:
+        return jsonify({"ok": False, "error": error}), 400
+    return jsonify({"ok": True, "password": password, "has_password": True})
+
+
+@bp.route("/remote-access/toggle", methods=["POST"])
+def toggle():
+    """Turn remote access on or off.
+
+    TODO(server): switching this on is what should ask retina-telemetry to call
+    PUT /nodes/tunnel and provision the tunnel, and switching it off is what
+    should tear it down. Neither exists yet, so for now this records the owner's
+    choice and nothing else acts on it. The state file is the interface the
+    telemetry container will read, so wiring that up later changes nothing here.
+    """
+    from app import remote_access
+
+    enabled = str(request.form.get('enabled', '')).lower() in ('1', 'true', 'on', 'yes')
+    ok, error = remote_access.set_enabled(enabled)
+    if not ok:
+        return jsonify({"ok": False, "error": error}), 400
+    return jsonify({"ok": True, **remote_access.status()})
+

--- a/src/routes/remote_access.py
+++ b/src/routes/remote_access.py
@@ -3,7 +3,8 @@
 The login half is reachable from the owner hostname, as it has to be: it is the
 thing standing in front of everything else. The configuration half lives under
 /remote-access, which app.py's gate refuses on that pathway entirely: changing
-the password or the toggle needs someone at the device or on the admin hostname.
+the password or the toggle needs someone on the node's own network, which
+includes an engineer on a Mender port-forward.
 See remote_access.PRESENCE_REQUIRED_PREFIXES.
 """
 
@@ -108,11 +109,14 @@ def generate():
 def toggle():
     """Turn remote access on or off.
 
-    TODO(server): switching this on is what should ask retina-telemetry to call
-    PUT /nodes/tunnel and provision the tunnel, and switching it off is what
-    should tear it down. Neither exists yet, so for now this records the owner's
-    choice and nothing else acts on it. The state file is the interface the
-    telemetry container will read, so wiring that up later changes nothing here.
+    Nothing here talks to a server, and nothing needs to. set_enabled() writes
+    the marker file that owl-os's mender-inventory-retina-remote-access script
+    reports as the `remote_access` inventory attribute; node-infra reads that on
+    its next pass and creates or tears down the tunnel accordingly.
+
+    So this route is the whole of the node's side of provisioning. The owner
+    should expect a delay rather than an immediate result: the marker reaches
+    Mender on the next inventory poll, which owl-os sets to 600 seconds.
     """
     from app import remote_access
 

--- a/src/routes/remote_access.py
+++ b/src/routes/remote_access.py
@@ -105,6 +105,34 @@ def generate():
     return jsonify({"ok": True, "password": password, "has_password": True})
 
 
+@bp.route("/remote-access/shell", methods=["POST"])
+def set_shell():
+    """Record and apply the remote shell agreement.
+
+    Enforced before it is recorded, and the record is skipped if enforcement
+    failed. The reverse order would leave the marker, and therefore the
+    inventory attribute we report upstream, claiming the owner had declined
+    interactive access while mender-connect happily kept serving it.
+
+    Refused on the support pathway by the gate, like everything under
+    /remote-access: the control an owner uses to withdraw our access is not
+    reachable through the access being withdrawn.
+    """
+    from app import mender_connect, remote_access
+
+    allowed = str(request.form.get('allowed', '')).lower() in ('1', 'true', 'on', 'yes')
+
+    ok, error = mender_connect.set_shell_enabled(allowed)
+    if not ok:
+        return jsonify({"ok": False, "error": error}), 400
+
+    ok, error = remote_access.record_shell_allowed(allowed)
+    if not ok:
+        return jsonify({"ok": False, "error": error}), 400
+
+    return jsonify({"ok": True, "shell_allowed": allowed})
+
+
 @bp.route("/remote-access/toggle", methods=["POST"])
 def toggle():
     """Turn remote access on or off.

--- a/src/routes/remote_access.py
+++ b/src/routes/remote_access.py
@@ -1,7 +1,7 @@
 """Login for the owner pathway, and the controls that configure it.
 
-The login half is reachable from the owner hostname (it has to be — it is the
-thing standing in front of everything else). The configuration half lives under
+The login half is reachable from the owner hostname, as it has to be: it is the
+thing standing in front of everything else. The configuration half lives under
 /remote-access, which app.py's gate refuses on that pathway entirely: changing
 the password or the toggle needs someone at the device or on the admin hostname.
 See remote_access.PRESENCE_REQUIRED_PREFIXES.
@@ -63,8 +63,8 @@ def do_login():
         return redirect(target)
 
     # Deliberately says nothing about whether a password is even set. The only
-    # real defence against guessing is the rate limit at Cloudflare's edge —
-    # there is none in this process — so this page gives an attacker no signal
+    # real defence against guessing is the rate limit at Cloudflare's edge, and
+    # there is none in this process, so this page gives an attacker no signal
     # to work with beyond pass or fail.
     return render_template("login.html", next=request.form.get('next', ''),
                            error="Incorrect password"), 401

--- a/src/services.py
+++ b/src/services.py
@@ -38,6 +38,7 @@ from mdns_peers import peer_directory_from_env
 from mender import MenderClient
 from network_manager import NetworkManager
 from node_name import NodeName
+from remote_access import RemoteAccess
 from retina_tracker_client import RetinaTrackerClient
 from ssh_keys import SSHKeyManager
 from telemetry_status import TelemetryStatus
@@ -83,6 +84,13 @@ TELEMETRY_STATUS_PATH = os.environ.get('TELEMETRY_STATUS_PATH',
     else '/data/retina-telemetry/status.json'
 )
 
+# The zone the Cloudflare tunnel publishes this node under. Deliberately not
+# retina.fm: a page served from a node can set a cookie scoped to its parent
+# domain, which the browser would then send to every other host on that domain —
+# including the ingest API. Nodes run in customers' homes on hardware they
+# control, so that separation is not theoretical.
+REMOTE_ACCESS_DOMAIN = os.environ.get('REMOTE_ACCESS_DOMAIN', 'retnode.com')
+
 MENDER_SERVICES = ["mender-authd", "mender-updated", "mender-connect"]
 
 # ── Shared services ────────────────────────────────────────────
@@ -119,6 +127,46 @@ telemetry_status = TelemetryStatus(
 )
 
 node_name = NodeName(os.path.join(DATA_DIR, "node-name"), dev_mode=DEV_MODE)
+
+remote_access = RemoteAccess(os.path.join(DATA_DIR, "remote-access.json"))
+
+
+def secret_key():
+    """Flask's signing key, persisted so sessions survive a restart.
+
+    This used to be `os.urandom(32).hex()` with no fallback to disk, which was
+    harmless while nothing used the session: every restart minted a new key and
+    invalidated cookies nobody held. It stops being harmless the moment remote
+    access exists, because every GUI restart — and every OTA — would then sign
+    the owner out mid-session with no explanation.
+
+    Mode 0600, and never logged. Anyone able to read it can forge a session
+    cookie for the owner pathway.
+    """
+    from_env = os.environ.get('SECRET_KEY')
+    if from_env:
+        return from_env
+
+    key_file = os.path.join(DATA_DIR, "secret-key")
+    try:
+        with open(key_file) as f:
+            key = f.read().strip()
+            if key:
+                return key
+    except OSError:
+        pass
+
+    key = os.urandom(32).hex()
+    try:
+        os.makedirs(DATA_DIR, exist_ok=True)
+        fd = os.open(key_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            f.write(key)
+    except OSError:
+        # An unwritable /data means sessions do not survive this process, which
+        # is a worse GUI rather than a broken one. Everything else still works.
+        pass
+    return key
 
 
 def read_node_id():

--- a/src/services.py
+++ b/src/services.py
@@ -86,7 +86,7 @@ TELEMETRY_STATUS_PATH = os.environ.get('TELEMETRY_STATUS_PATH',
 
 # The zone the Cloudflare tunnel publishes this node under. Deliberately not
 # retina.fm: a page served from a node can set a cookie scoped to its parent
-# domain, which the browser would then send to every other host on that domain —
+# domain, which the browser would then send to every other host on that domain,
 # including the ingest API. Nodes run in customers' homes on hardware they
 # control, so that separation is not theoretical.
 REMOTE_ACCESS_DOMAIN = os.environ.get('REMOTE_ACCESS_DOMAIN', 'retnode.com')
@@ -137,8 +137,8 @@ def secret_key():
     This used to be `os.urandom(32).hex()` with no fallback to disk, which was
     harmless while nothing used the session: every restart minted a new key and
     invalidated cookies nobody held. It stops being harmless the moment remote
-    access exists, because every GUI restart — and every OTA — would then sign
-    the owner out mid-session with no explanation.
+    access exists, because every GUI restart, and every OTA, would then sign the
+    owner out mid-session with no explanation.
 
     Mode 0600, and never logged. Anyone able to read it can forge a session
     cookie for the owner pathway.

--- a/src/services.py
+++ b/src/services.py
@@ -29,6 +29,7 @@ re-exports the names, so `from app import ...` continues to work unchanged.
 
 import os
 
+from access_identity import AccessIdentity
 from apply_service import ApplyService
 from blah2_client import Blah2Client
 from calibrator import Calibrator
@@ -36,6 +37,7 @@ from config_manager import ConfigManager
 from device_state import DeviceState
 from mdns_peers import peer_directory_from_env
 from mender import MenderClient
+from mender_connect import MenderConnect
 from network_manager import NetworkManager
 from node_name import NodeName
 from remote_access import RemoteAccess
@@ -129,6 +131,23 @@ telemetry_status = TelemetryStatus(
 node_name = NodeName(os.path.join(DATA_DIR, "node-name"), dev_mode=DEV_MODE)
 
 remote_access = RemoteAccess(os.path.join(DATA_DIR, "remote-access.json"))
+
+# Enforces the remote shell agreement by editing mender-connect's own config.
+# Separate from RemoteAccess on purpose: that one records what the owner chose,
+# this one makes it true, and keeping them apart is what lets the recording stay
+# testable without a systemd on the other end of it.
+# Verifies Cloudflare Access assertions. Its config (team domain and this
+# node's application audience) is delivered by node-infra beside the tunnel
+# token, so until that arrives it reports "not configured" and refuses
+# everything, which is the safe state to be in while it is unwired.
+access_identity = AccessIdentity(
+    config_path=os.environ.get("ACCESS_CONFIG_PATH", "/data/cloudflared/access.json"),
+)
+
+mender_connect = MenderConnect(
+    conf_path=os.environ.get("MENDER_CONNECT_CONF", "/etc/mender/mender-connect.conf"),
+    dev_mode=DEV_MODE,
+)
 
 
 def secret_key():

--- a/static/common.css
+++ b/static/common.css
@@ -363,6 +363,10 @@ h1, h2, h3, h4, h5, h6 {
     flex-shrink: 0;
 }
 .svc-name { font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; }
+/* Why a card is greyed out over the support tunnel: the service is on a port
+   the tunnel does not route, so it is reachable from the node's own network
+   only. Said on the card rather than left to be discovered by clicking. */
+.svc-remote-note { font-size: 12px; color: var(--ink-3, #888); margin-top: 2px; }
 .svc-arrow { margin-left: auto; color: var(--ink-3); transition: transform .12s, color .12s; }
 .svc-card:hover .svc-arrow { color: var(--ink); transform: translateX(2px); }
 .svc-desc { font-size: 13px; color: var(--ink-2); line-height: 1.5; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,14 @@
         <span>owl-os <span class="mono">{{ owl_os_version or '-' }}</span></span>
         <span>retina-node <span class="mono">{{ retina_node_version or 'Not installed' }}</span></span>
         <div class="foot-spacer"></div>
+        {# Only on the owner pathway: the LAN has no session to end, and an
+           admin's session belongs to Cloudflare Access, not to us. #}
+        {% if pathway == 'owner' %}
+        <form method="post" action="/logout" style="margin:0;">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="ds-btn sm">Sign out</button>
+        </form>
+        {% endif %}
     </footer>
     {% endblock %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,8 +38,8 @@
         <span>owl-os <span class="mono">{{ owl_os_version or '-' }}</span></span>
         <span>retina-node <span class="mono">{{ retina_node_version or 'Not installed' }}</span></span>
         <div class="foot-spacer"></div>
-        {# Only on the owner pathway: the LAN has no session to end, and an
-           admin's session belongs to Cloudflare Access, not to us. #}
+        {# Only on the owner pathway. The LAN has no session to end, whether
+           that is someone at home or an engineer on a Mender port-forward. #}
         {% if pathway == 'owner' %}
         <form method="post" action="/logout" style="margin:0;">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/templates/config.html
+++ b/templates/config.html
@@ -495,8 +495,11 @@
                         <div class="name">Enable remote access</div>
                         <div class="desc" id="remoteToggleStatus">
                             {% if not remote_access.has_password %}Set a password below first.
-                            {% elif remote_access.enabled %}Reachable at <span class="mono">{{ remote_host }}</span>.
-                            {% else %}Off. Nothing outside your network can reach this node.{% endif %}
+                            {% elif not remote_access.enabled %}Off. Nothing outside your network can reach this node.
+                            {% elif remote_tunnel == 'up' %}Reachable at <span class="mono">{{ remote_host }}</span>.
+                            {% elif remote_tunnel == 'waiting' %}Setting up. This can take around 15 minutes, and you can leave this page.
+                            {% elif remote_tunnel == 'down' %}Set up, but not connected right now. It should recover on its own.
+                            {% else %}On. <span class="mono">{{ remote_host }}</span>{% endif %}
                         </div>
                     </div>
                 </div>

--- a/templates/config.html
+++ b/templates/config.html
@@ -541,7 +541,7 @@
         <section id="cloud" class="cfg-section">
             <div class="cfg-section-head">
                 <h2>Cloud services</h2>
-                <span class="desc">Automatic OS &amp; package updates and remote support.</span>
+                <span class="desc">This node's link to Offworld: software updates and registration.</span>
             </div>
             <div class="cfg-body">
                 <div class="toggle-row" style="padding:0;border:0;">
@@ -551,7 +551,7 @@
                     </label>
                     <div class="body">
                         <div class="name">Enable cloud services</div>
-                        <div class="desc" id="cloudServicesStatus">Automatic software updates and remote support.</div>
+                        <div class="desc" id="cloudServicesStatus">Software updates and registration. The Remote support settings above need this too.</div>
                     </div>
                 </div>
             </div>
@@ -703,7 +703,8 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body" style="font-size:13.5px;color:var(--ink-2);">
-                <p>This will stop automatic software updates and disable remote support access.</p>
+                <p>This stops automatic software updates and registration with Offworld.</p>
+                <p>It also switches off everything under Remote support, whatever those two settings say.</p>
                 <p class="mb-0">You can re-enable at any time.</p>
             </div>
             <div class="modal-footer">
@@ -1437,7 +1438,7 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
                     setTimeout(loadCloudStatus, 10000);
                 } else {
                     toggle.disabled = false;
-                    status.textContent = 'Automatic software updates and remote support.';
+                    status.textContent = 'Software updates and registration. The Remote support settings above need this too.';
                 }
             })
             .catch(() => { toggle.checked = true; toggle.disabled = false; });
@@ -1469,7 +1470,7 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         })
         .then(r => r.json().then(data => ({ok: r.ok, data})))
         .then(({ok, data}) => {
-            if (ok && data.success) { status.textContent = 'Settings applied'; setTimeout(() => { status.textContent = 'Automatic software updates and remote support.'; }, 3000); }
+            if (ok && data.success) { status.textContent = 'Settings applied'; setTimeout(() => { status.textContent = 'Software updates and registration. The Remote support settings above need this too.'; }, 3000); }
             else { status.textContent = data.error; toggle.checked = !toggle.checked; }
         })
         .catch(e => { status.textContent = 'Error: ' + e.message; toggle.checked = !toggle.checked; })

--- a/templates/config.html
+++ b/templates/config.html
@@ -505,32 +505,36 @@
                     <div class="label-col">
                         <label for="remotePassword">Password</label>
                         <span class="help" id="remotePasswordState">
-                            {% if remote_access.has_password %}Set. Enter a new one to replace it.
-                            {% else %}Not set.{% endif %}
+                            {% if remote_password_visible %}Set it to whatever you like, and read it back here whenever you need to share it.
+                            {% else %}Only shown on the node&rsquo;s own network.{% endif %}
                         </span>
                     </div>
                     <div>
+                        {% if remote_password_visible %}
                         <div style="display:flex;gap:8px;">
-                            <input type="password" id="remotePassword" class="ds-input mono"
-                                   autocomplete="new-password"
-                                   placeholder="At least {{ remote_password_min }} characters" style="min-width:0;">
+                            {# Plain text, not a password field: this is the phone-hotspot
+                               model, and the whole point is that the owner can read it
+                               back to share it. #}
+                            <input type="text" id="remotePassword" class="ds-input mono"
+                                   value="{{ remote_password }}" autocomplete="off"
+                                   spellcheck="false" placeholder="At least {{ remote_password_min }} characters"
+                                   style="min-width:0;">
                             <button type="button" class="ds-btn primary" id="remotePasswordSave" style="flex-shrink:0;">Save</button>
                             <button type="button" class="ds-btn" id="remotePasswordGenerate" style="flex-shrink:0;">Generate</button>
                         </div>
                         <div id="remotePasswordMsg" style="font-size:12.5px;margin-top:8px;display:none;"></div>
-                        {# Shown once, right after generating. Only the hash is stored,
-                           so there is no second chance to read it. #}
-                        <div id="remotePasswordReveal"
-                             style="display:none;margin-top:10px;padding:10px 12px;border-radius:6px;
-                                    background:rgba(45,91,214,.10);border:1px solid rgba(45,91,214,.35);">
-                            <div style="font-size:12px;opacity:.75;margin-bottom:4px;">Write this down now &mdash; it is not shown again.</div>
-                            <div class="mono" id="remotePasswordValue" style="font-size:15px;letter-spacing:.02em;"></div>
-                        </div>
                         <div class="help" style="margin-top:10px;">
-                            Anyone with this password gets the same control you have here, apart from
-                            SSH keys, software updates and this section &mdash; those need you to be on
-                            the node&rsquo;s own network.
+                            Anyone on this network can read this password, so don&rsquo;t reuse one from
+                            somewhere else. Anyone who has it gets the same control you have here, apart
+                            from SSH keys, software updates and this section &mdash; those need you to be
+                            on the node&rsquo;s own network.
                         </div>
+                        {% else %}
+                        <div class="help">
+                            The password is only shown to someone on the same network as the node.
+                            Open <span class="mono">{{ node_id }}.local</span> from home to see or change it.
+                        </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -2059,16 +2063,9 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
     var toggle = document.getElementById('remoteToggle');
     if (!toggle) return;
 
-    var status   = document.getElementById('remoteToggleStatus');
-    var pw       = document.getElementById('remotePassword');
-    var save     = document.getElementById('remotePasswordSave');
-    var generate = document.getElementById('remotePasswordGenerate');
-    var state    = document.getElementById('remotePasswordState');
-    var msg      = document.getElementById('remotePasswordMsg');
-    var reveal   = document.getElementById('remotePasswordReveal');
-    var value    = document.getElementById('remotePasswordValue');
-    var host     = {{ remote_host | tojson }};
-    var csrf     = document.querySelector('meta[name="csrf-token"]').content;
+    var status = document.getElementById('remoteToggleStatus');
+    var host   = {{ remote_host | tojson }};
+    var csrf   = document.querySelector('meta[name="csrf-token"]').content;
 
     function post(url, body) {
         return fetch(url, {
@@ -2078,50 +2075,53 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         }).then(function (r) { return r.json().then(function (j) { return {ok: r.ok, body: j}; }); });
     }
 
+    toggle.addEventListener('change', function () {
+        var want = toggle.checked;
+        toggle.disabled = true;
+        post('/remote-access/toggle', 'enabled=' + (want ? '1' : '0'))
+            .then(function (r) {
+                if (!r.ok) { toggle.checked = !want; return; }
+                status.innerHTML = r.body.enabled
+                    ? 'Reachable at <span class="mono"></span>'
+                    : 'Off. Nothing outside your network can reach this node.';
+                if (r.body.enabled) status.querySelector('.mono').textContent = host;
+            })
+            .catch(function () { toggle.checked = !want; })
+            .then(function () { toggle.disabled = false; });
+    });
+
+    // The password controls are only rendered on the local network, so
+    // everything below is absent on the owner pathway and must not be assumed.
+    var pw = document.getElementById('remotePassword');
+    if (!pw) return;
+
+    var save     = document.getElementById('remotePasswordSave');
+    var generate = document.getElementById('remotePasswordGenerate');
+    var msg      = document.getElementById('remotePasswordMsg');
+
     function say(text, bad) {
         msg.textContent = text;
         msg.style.color = bad ? 'var(--danger)' : 'var(--ink-3)';
         msg.style.display = text ? 'block' : 'none';
     }
 
-    function passwordIsSet() {
-        state.textContent = 'Set. Enter a new one to replace it.';
-        toggle.disabled = false;
+    function store(password, okText) {
+        return post('/remote-access/password', 'password=' + encodeURIComponent(password))
+            .then(function (r) {
+                if (!r.ok) { say(r.body.error || 'Could not save the password', true); return false; }
+                pw.value = password;
+                // Turning it on needs a password, so the toggle stays disabled
+                // until there is one. Setting one is what releases it.
+                toggle.disabled = false;
+                say(okText);
+                return true;
+            })
+            .catch(function () { say('Could not reach the node', true); return false; });
     }
 
-    toggle.addEventListener('change', function () {
-        var want = toggle.checked;
-        toggle.disabled = true;
-        post('/remote-access/toggle', 'enabled=' + (want ? '1' : '0'))
-            .then(function (r) {
-                if (!r.ok) {
-                    toggle.checked = !want;
-                    say(r.body.error || 'Could not change remote access', true);
-                    return;
-                }
-                say('');
-                status.innerHTML = r.body.enabled
-                    ? 'Reachable at <span class="mono"></span>'
-                    : 'Off. Nothing outside your network can reach this node.';
-                if (r.body.enabled) status.querySelector('.mono').textContent = host;
-            })
-            .catch(function () { toggle.checked = !want; say('Could not reach the node', true); })
-            .then(function () { toggle.disabled = false; });
-    });
-
     save.addEventListener('click', function () {
-        if (!pw.value) { say('Enter a password first', true); return; }
         save.disabled = true;
-        post('/remote-access/password', 'password=' + encodeURIComponent(pw.value))
-            .then(function (r) {
-                if (!r.ok) { say(r.body.error || 'Could not save the password', true); return; }
-                pw.value = '';
-                reveal.style.display = 'none';
-                passwordIsSet();
-                say('Password saved.');
-            })
-            .catch(function () { say('Could not reach the node', true); })
-            .then(function () { save.disabled = false; });
+        store(pw.value, 'Password saved.').then(function () { save.disabled = false; });
     });
 
     generate.addEventListener('click', function () {
@@ -2129,11 +2129,9 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         post('/remote-access/generate', '')
             .then(function (r) {
                 if (!r.ok) { say(r.body.error || 'Could not generate a password', true); return; }
-                value.textContent = r.body.password;
-                reveal.style.display = 'block';
-                pw.value = '';
-                passwordIsSet();
-                say('');
+                pw.value = r.body.password;
+                toggle.disabled = false;
+                say('New password generated and saved.');
             })
             .catch(function () { say('Could not reach the node', true); })
             .then(function () { generate.disabled = false; });

--- a/templates/config.html
+++ b/templates/config.html
@@ -481,7 +481,7 @@
         <section id="remote" class="cfg-section" style="margin-top:12px;">
             <div class="cfg-section-head">
                 <h2>Remote access</h2>
-                <span class="desc">Reach this node from outside your home network, over a Cloudflare tunnel. On your own network you never need a password &mdash; keep using <span class="mono">{{ node_id }}.local</span>.</span>
+                <span class="desc">Reach this node from outside your home network, over a Cloudflare tunnel. On your own network you never need a password. Keep using <span class="mono">{{ node_id }}.local</span>.</span>
             </div>
             <div class="cfg-body">
                 <div class="toggle-row" style="padding:0;border:0;">
@@ -524,10 +524,8 @@
                         </div>
                         <div id="remotePasswordMsg" style="font-size:12.5px;margin-top:8px;display:none;"></div>
                         <div class="help" style="margin-top:10px;">
-                            Anyone on this network can read this password, so don&rsquo;t reuse one from
-                            somewhere else. Anyone who has it gets the same control you have here, apart
-                            from SSH keys, software updates and this section &mdash; those need you to be
-                            on the node&rsquo;s own network.
+                            Anyone with local network access to your device can read this password, so
+                            don&rsquo;t reuse one from somewhere else.
                         </div>
                         {% else %}
                         <div class="help">

--- a/templates/config.html
+++ b/templates/config.html
@@ -477,66 +477,62 @@
             </div>
         </section>
 
-        {# ── Remote access ── #}
+        {# ── Remote support ── #}
         <section id="remote" class="cfg-section" style="margin-top:12px;">
             <div class="cfg-section-head">
-                <h2>Remote access</h2>
-                <span class="desc">Reach this node from outside your home network, over a Cloudflare tunnel. On your own network you never need a password. Keep using <span class="mono">{{ node_id }}.local</span>.</span>
+                <h2>Remote support</h2>
+                <span class="desc">What our support team may do with this node when they are not at your location. Both settings are yours to change at any time, and neither affects how the node works day to day.</span>
             </div>
             <div class="cfg-body">
                 <div class="toggle-row" style="padding:0;border:0;">
                     <label class="ds-switch">
-                        <input type="checkbox" id="remoteToggle"
-                               {% if remote_access.enabled %}checked{% endif %}
-                               {% if not remote_access.has_password %}disabled{% endif %}>
+                        <input type="checkbox" id="remoteToggle" {% if remote_access.enabled %}checked{% endif %}>
                         <span class="ds-switch-track"></span>
                     </label>
                     <div class="body">
-                        <div class="name">Enable remote access</div>
+                        <div class="name">Let support open this node&rsquo;s interface</div>
                         <div class="desc" id="remoteToggleStatus">
-                            {% if not remote_access.has_password %}Set a password below first.
-                            {% elif not remote_access.enabled %}Off. Nothing outside your network can reach this node.
-                            {% elif remote_tunnel == 'up' %}Reachable at <span class="mono">{{ remote_host }}</span>.
-                            {% elif remote_tunnel == 'waiting' %}Setting up. This can take around 15 minutes, and you can leave this page.
-                            {% elif remote_tunnel == 'down' %}Set up, but not connected right now. It should recover on its own.
-                            {% else %}On. <span class="mono">{{ remote_host }}</span>{% endif %}
+                            {% if not remote_access.enabled %}Off. Support can only reach this node from your own network.
+                            {% elif remote_tunnel == 'up' %}On and connected.
+                            {% elif remote_tunnel == 'waiting' %}On. The connection is not live yet.
+                            {% elif remote_tunnel == 'down' %}On, but the connection has dropped. It should recover on its own.
+                            {% else %}On.{% endif %}
                         </div>
                     </div>
                 </div>
+                <div class="help" style="margin:2px 0 16px 52px;">
+                    They see the same pages you see and can change the same settings. They cannot
+                    open a command line or add an SSH key this way.
+                </div>
 
-                <div class="cfg-row" style="margin-top:4px;">
-                    <div class="label-col">
-                        <label for="remotePassword">Password</label>
-                        <span class="help" id="remotePasswordState">
-                            {% if remote_password_visible %}Set it to whatever you like, and read it back here whenever you need to share it.
-                            {% else %}Only shown on the node&rsquo;s own network.{% endif %}
-                        </span>
+                <div class="toggle-row" style="padding:0;border:0;border-top:1px solid var(--line);padding-top:16px;">
+                    <label class="ds-switch">
+                        <input type="checkbox" id="shellToggle" {% if remote_access.shell_allowed %}checked{% endif %}>
+                        <span class="ds-switch-track"></span>
+                    </label>
+                    <div class="body">
+                        <div class="name">Let support open a command line</div>
+                        <div class="desc" id="shellToggleStatus">
+                            {% if shell_enforced is none %}On this node&rsquo;s settings, but we could not confirm it is applied.
+                            {% elif shell_enforced != remote_access.shell_allowed %}Not applied. This node is still set to
+                                {% if shell_enforced %}allow{% else %}refuse{% endif %} sessions. Try again, or ask support.
+                            {% elif remote_access.shell_allowed %}On.
+                            {% else %}Off. No session can be opened, from anywhere.{% endif %}
+                        </div>
                     </div>
-                    <div>
-                        {% if remote_password_visible %}
-                        <div style="display:flex;gap:8px;">
-                            {# Plain text, not a password field: this is the phone-hotspot
-                               model, and the whole point is that the owner can read it
-                               back to share it. #}
-                            <input type="text" id="remotePassword" class="ds-input mono"
-                                   value="{{ remote_password }}" autocomplete="off"
-                                   spellcheck="false" placeholder="At least {{ remote_password_min }} characters"
-                                   style="min-width:0;">
-                            <button type="button" class="ds-btn primary" id="remotePasswordSave" style="flex-shrink:0;">Save</button>
-                            <button type="button" class="ds-btn" id="remotePasswordGenerate" style="flex-shrink:0;">Generate</button>
-                        </div>
-                        <div id="remotePasswordMsg" style="font-size:12.5px;margin-top:8px;display:none;"></div>
-                        <div class="help" style="margin-top:10px;">
-                            Anyone with local network access to your device can read this password, so
-                            don&rsquo;t reuse one from somewhere else.
-                        </div>
-                        {% else %}
-                        <div class="help">
-                            The password is only shown to someone on the same network as the node.
-                            Open <span class="mono">{{ node_id }}.local</span> from home to see or change it.
-                        </div>
-                        {% endif %}
-                    </div>
+                </div>
+                <div class="help" style="margin:2px 0 0 52px;">
+                    This is how we diagnose problems the interface cannot show, and it is the
+                    deepest access anyone can have to your node. Turning it off does not affect
+                    the setting above.
+                </div>
+
+                <div id="remoteMsg" style="font-size:12.5px;margin-top:14px;display:none;"></div>
+
+                <div class="help" style="margin-top:16px;padding-top:14px;border-top:1px solid var(--line);">
+                    Software updates and registration continue whichever way these are set. What
+                    you are choosing here is whether a person can reach the node, not whether it
+                    stays up to date.
                 </div>
             </div>
         </section>
@@ -2058,15 +2054,23 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
 })();
 </script>
 
-{# ── Remote access ── #}
+{# ── Remote support ── #}
 <script>
 (function () {
-    var toggle = document.getElementById('remoteToggle');
-    if (!toggle) return;
+    var support = document.getElementById('remoteToggle');
+    var shell   = document.getElementById('shellToggle');
+    if (!support || !shell) return;
 
-    var status = document.getElementById('remoteToggleStatus');
-    var host   = {{ remote_host | tojson }};
-    var csrf   = document.querySelector('meta[name="csrf-token"]').content;
+    var supportStatus = document.getElementById('remoteToggleStatus');
+    var shellStatus   = document.getElementById('shellToggleStatus');
+    var msg           = document.getElementById('remoteMsg');
+    var csrf          = document.querySelector('meta[name="csrf-token"]').content;
+
+    function say(text, bad) {
+        msg.textContent = text;
+        msg.style.color = bad ? 'var(--danger)' : 'var(--ink-3)';
+        msg.style.display = text ? 'block' : 'none';
+    }
 
     function post(url, body) {
         return fetch(url, {
@@ -2076,66 +2080,45 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
         }).then(function (r) { return r.json().then(function (j) { return {ok: r.ok, body: j}; }); });
     }
 
-    toggle.addEventListener('change', function () {
-        var want = toggle.checked;
-        toggle.disabled = true;
-        post('/remote-access/toggle', 'enabled=' + (want ? '1' : '0'))
-            .then(function (r) {
-                if (!r.ok) { toggle.checked = !want; return; }
-                status.innerHTML = r.body.enabled
-                    ? 'Reachable at <span class="mono"></span>'
-                    : 'Off. Nothing outside your network can reach this node.';
-                if (r.body.enabled) status.querySelector('.mono').textContent = host;
-            })
-            .catch(function () { toggle.checked = !want; })
-            .then(function () { toggle.disabled = false; });
-    });
-
-    // The password controls are only rendered on the local network, so
-    // everything below is absent on the owner pathway and must not be assumed.
-    var pw = document.getElementById('remotePassword');
-    if (!pw) return;
-
-    var save     = document.getElementById('remotePasswordSave');
-    var generate = document.getElementById('remotePasswordGenerate');
-    var msg      = document.getElementById('remotePasswordMsg');
-
-    function say(text, bad) {
-        msg.textContent = text;
-        msg.style.color = bad ? 'var(--danger)' : 'var(--ink-3)';
-        msg.style.display = text ? 'block' : 'none';
+    // Each toggle drives its own endpoint and reverts itself on failure. They
+    // are deliberately not wired together: the whole point of two settings is
+    // that changing one says nothing about the other.
+    function wire(input, url, field, statusEl, describe) {
+        input.addEventListener('change', function () {
+            var want = input.checked;
+            input.disabled = true;
+            say('');
+            post(url, field + '=' + (want ? '1' : '0'))
+                .then(function (r) {
+                    if (!r.ok) {
+                        input.checked = !want;
+                        say(r.body.error || 'Could not change this setting', true);
+                        return;
+                    }
+                    statusEl.textContent = describe(r.body);
+                })
+                .catch(function () {
+                    input.checked = !want;
+                    say('Could not reach the node', true);
+                })
+                .then(function () { input.disabled = false; });
+        });
     }
 
-    function store(password, okText) {
-        return post('/remote-access/password', 'password=' + encodeURIComponent(password))
-            .then(function (r) {
-                if (!r.ok) { say(r.body.error || 'Could not save the password', true); return false; }
-                pw.value = password;
-                // Turning it on needs a password, so the toggle stays disabled
-                // until there is one. Setting one is what releases it.
-                toggle.disabled = false;
-                say(okText);
-                return true;
-            })
-            .catch(function () { say('Could not reach the node', true); return false; });
-    }
-
-    save.addEventListener('click', function () {
-        save.disabled = true;
-        store(pw.value, 'Password saved.').then(function () { save.disabled = false; });
+    wire(support, '/remote-access/toggle', 'enabled', supportStatus, function (b) {
+        // No estimate offered. How long this takes depends on node-infra's
+        // scheduling, which this node has no knowledge of and cannot promise.
+        return b.enabled
+            ? 'On. The connection is not live yet.'
+            : 'Off. Support can only reach this node from your own network.';
     });
 
-    generate.addEventListener('click', function () {
-        generate.disabled = true;
-        post('/remote-access/generate', '')
-            .then(function (r) {
-                if (!r.ok) { say(r.body.error || 'Could not generate a password', true); return; }
-                pw.value = r.body.password;
-                toggle.disabled = false;
-                say('New password generated and saved.');
-            })
-            .catch(function () { say('Could not reach the node', true); })
-            .then(function () { generate.disabled = false; });
+    // Safe to state plainly here: the route enforces before it records and
+    // errors if enforcement failed, so an ok response means the node really is
+    // in this state. The page-load branch cannot assume that and reads the
+    // enforced value back instead.
+    wire(shell, '/remote-access/shell', 'allowed', shellStatus, function (b) {
+        return b.shell_allowed ? 'On.' : 'Off. No session can be opened, from anywhere.';
     });
 })();
 </script>

--- a/templates/config.html
+++ b/templates/config.html
@@ -96,6 +96,7 @@
         <h3>Administration</h3>
         <a href="#this-node">This node</a>
         <a href="#ssh">SSH access</a>
+        <a href="#remote">Remote access</a>
         <a href="#cloud">Cloud services</a>
         <a href="#wizard">Setup wizard</a>
         <a href="#network">Network</a>
@@ -473,6 +474,65 @@
                 {% else %}
                 <p style="color:var(--ink-3);font-size:13px;margin:14px 0 0;">No SSH keys configured.</p>
                 {% endif %}
+            </div>
+        </section>
+
+        {# ── Remote access ── #}
+        <section id="remote" class="cfg-section" style="margin-top:12px;">
+            <div class="cfg-section-head">
+                <h2>Remote access</h2>
+                <span class="desc">Reach this node from outside your home network, over a Cloudflare tunnel. On your own network you never need a password &mdash; keep using <span class="mono">{{ node_id }}.local</span>.</span>
+            </div>
+            <div class="cfg-body">
+                <div class="toggle-row" style="padding:0;border:0;">
+                    <label class="ds-switch">
+                        <input type="checkbox" id="remoteToggle"
+                               {% if remote_access.enabled %}checked{% endif %}
+                               {% if not remote_access.has_password %}disabled{% endif %}>
+                        <span class="ds-switch-track"></span>
+                    </label>
+                    <div class="body">
+                        <div class="name">Enable remote access</div>
+                        <div class="desc" id="remoteToggleStatus">
+                            {% if not remote_access.has_password %}Set a password below first.
+                            {% elif remote_access.enabled %}Reachable at <span class="mono">{{ remote_host }}</span>.
+                            {% else %}Off. Nothing outside your network can reach this node.{% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="cfg-row" style="margin-top:4px;">
+                    <div class="label-col">
+                        <label for="remotePassword">Password</label>
+                        <span class="help" id="remotePasswordState">
+                            {% if remote_access.has_password %}Set. Enter a new one to replace it.
+                            {% else %}Not set.{% endif %}
+                        </span>
+                    </div>
+                    <div>
+                        <div style="display:flex;gap:8px;">
+                            <input type="password" id="remotePassword" class="ds-input mono"
+                                   autocomplete="new-password"
+                                   placeholder="At least {{ remote_password_min }} characters" style="min-width:0;">
+                            <button type="button" class="ds-btn primary" id="remotePasswordSave" style="flex-shrink:0;">Save</button>
+                            <button type="button" class="ds-btn" id="remotePasswordGenerate" style="flex-shrink:0;">Generate</button>
+                        </div>
+                        <div id="remotePasswordMsg" style="font-size:12.5px;margin-top:8px;display:none;"></div>
+                        {# Shown once, right after generating. Only the hash is stored,
+                           so there is no second chance to read it. #}
+                        <div id="remotePasswordReveal"
+                             style="display:none;margin-top:10px;padding:10px 12px;border-radius:6px;
+                                    background:rgba(45,91,214,.10);border:1px solid rgba(45,91,214,.35);">
+                            <div style="font-size:12px;opacity:.75;margin-bottom:4px;">Write this down now &mdash; it is not shown again.</div>
+                            <div class="mono" id="remotePasswordValue" style="font-size:15px;letter-spacing:.02em;"></div>
+                        </div>
+                        <div class="help" style="margin-top:10px;">
+                            Anyone with this password gets the same control you have here, apart from
+                            SSH keys, software updates and this section &mdash; those need you to be on
+                            the node&rsquo;s own network.
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
 
@@ -1990,6 +2050,94 @@ if (discardBtn) discardBtn.addEventListener('click', () => location.reload());
             .then(function() { setTimeout(pollCapturePeak, 1000); });
     }
     pollCapturePeak();
+})();
+</script>
+
+{# ── Remote access ── #}
+<script>
+(function () {
+    var toggle = document.getElementById('remoteToggle');
+    if (!toggle) return;
+
+    var status   = document.getElementById('remoteToggleStatus');
+    var pw       = document.getElementById('remotePassword');
+    var save     = document.getElementById('remotePasswordSave');
+    var generate = document.getElementById('remotePasswordGenerate');
+    var state    = document.getElementById('remotePasswordState');
+    var msg      = document.getElementById('remotePasswordMsg');
+    var reveal   = document.getElementById('remotePasswordReveal');
+    var value    = document.getElementById('remotePasswordValue');
+    var host     = {{ remote_host | tojson }};
+    var csrf     = document.querySelector('meta[name="csrf-token"]').content;
+
+    function post(url, body) {
+        return fetch(url, {
+            method: 'POST',
+            headers: {'X-CSRFToken': csrf, 'Content-Type': 'application/x-www-form-urlencoded'},
+            body: body
+        }).then(function (r) { return r.json().then(function (j) { return {ok: r.ok, body: j}; }); });
+    }
+
+    function say(text, bad) {
+        msg.textContent = text;
+        msg.style.color = bad ? 'var(--danger)' : 'var(--ink-3)';
+        msg.style.display = text ? 'block' : 'none';
+    }
+
+    function passwordIsSet() {
+        state.textContent = 'Set. Enter a new one to replace it.';
+        toggle.disabled = false;
+    }
+
+    toggle.addEventListener('change', function () {
+        var want = toggle.checked;
+        toggle.disabled = true;
+        post('/remote-access/toggle', 'enabled=' + (want ? '1' : '0'))
+            .then(function (r) {
+                if (!r.ok) {
+                    toggle.checked = !want;
+                    say(r.body.error || 'Could not change remote access', true);
+                    return;
+                }
+                say('');
+                status.innerHTML = r.body.enabled
+                    ? 'Reachable at <span class="mono"></span>'
+                    : 'Off. Nothing outside your network can reach this node.';
+                if (r.body.enabled) status.querySelector('.mono').textContent = host;
+            })
+            .catch(function () { toggle.checked = !want; say('Could not reach the node', true); })
+            .then(function () { toggle.disabled = false; });
+    });
+
+    save.addEventListener('click', function () {
+        if (!pw.value) { say('Enter a password first', true); return; }
+        save.disabled = true;
+        post('/remote-access/password', 'password=' + encodeURIComponent(pw.value))
+            .then(function (r) {
+                if (!r.ok) { say(r.body.error || 'Could not save the password', true); return; }
+                pw.value = '';
+                reveal.style.display = 'none';
+                passwordIsSet();
+                say('Password saved.');
+            })
+            .catch(function () { say('Could not reach the node', true); })
+            .then(function () { save.disabled = false; });
+    });
+
+    generate.addEventListener('click', function () {
+        generate.disabled = true;
+        post('/remote-access/generate', '')
+            .then(function (r) {
+                if (!r.ok) { say(r.body.error || 'Could not generate a password', true); return; }
+                value.textContent = r.body.password;
+                reveal.style.display = 'block';
+                pw.value = '';
+                passwordIsSet();
+                say('');
+            })
+            .catch(function () { say('Could not reach the node', true); })
+            .then(function () { generate.disabled = false; });
+    });
 })();
 </script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -144,7 +144,7 @@
         <div class="section-head"><h2>Services</h2></div>
         <div class="svc-grid">
             {% if retina_node_version %}
-            <a class="svc-card" href="#" data-port="49152" target="_blank">
+            <a class="svc-card" href="#" data-port="49152" data-remote-path="/display/map/" target="_blank">
                 <div class="svc-head">
                     <div class="svc-icon">
                         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
@@ -162,7 +162,7 @@
                 </div>
                 <div class="svc-desc">Live radar data.</div>
             </a>
-            <a class="svc-card" href="#" data-port="49152" data-path="/display/maxhold" target="_blank">
+            <a class="svc-card" href="#" data-port="49152" data-path="/display/maxhold" data-remote-path="/display/maxhold/" target="_blank">
                 <div class="svc-head">
                     <div class="svc-icon">
                         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
@@ -179,7 +179,7 @@
                 </div>
                 <div class="svc-desc">~10s rolling peak-hold view.</div>
             </a>
-            <a class="svc-card" href="#" data-port="49152" data-path="/controller/" target="_blank">
+            <a class="svc-card" href="#" data-port="49152" data-path="/controller/" data-remote-path="/controller/" target="_blank">
                 <div class="svc-head">
                     <div class="svc-icon">
                         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
@@ -269,8 +269,34 @@
 <script>
 // Built from the host actually used to get here, so the links stay on this
 // node rather than pointing somewhere the operator did not ask for.
+//
+// Over the support tunnel these ports are not reachable: Cloudflare proxies a
+// fixed set and blah2's are not among them, and an http:// link on an https://
+// page is blocked as mixed content anyway. The tunnel instead routes a few
+// paths on this same hostname straight to those services, so remotely the
+// links are same-origin paths. A card with no remote path has no such route
+// and says so, rather than looking clickable and failing.
+var isRemote = {{ 'true' if is_remote else 'false' }};
 document.querySelectorAll('.svc-card[data-port]').forEach(function(el) {
-    el.href = 'http://' + window.location.hostname + ':' + el.dataset.port + (el.dataset.path || '');
+    if (!isRemote) {
+        el.href = 'http://' + window.location.hostname + ':' + el.dataset.port + (el.dataset.path || '');
+        return;
+    }
+    if (el.dataset.remotePath) {
+        el.href = el.dataset.remotePath;
+        return;
+    }
+    // .disabled already means exactly this on a card, and carries
+    // pointer-events:none, so the link cannot be followed.
+    el.href = '#';
+    el.classList.add('disabled');
+    el.setAttribute('aria-disabled', 'true');
+    var name = el.querySelector('.svc-name');
+    if (name && !el.dataset.remoteNoted) {
+        el.dataset.remoteNoted = '1';
+        name.insertAdjacentHTML('afterend',
+            '<div class="svc-remote-note">Only on this node\u2019s own network</div>');
+    }
 });
 </script>
 {% if mode == 'spectrum' %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,62 @@
+{# Deliberately does not extend base.html.
+
+   base.html renders the fleet bar and the Home/Config tabs, which are links to
+   pages this visitor has not been let into yet. A login page that shows the
+   navigation of the thing it is guarding invites people to click it and collect
+   a redirect back here, which reads as the page being broken. #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Sign in · {{ node_id }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="/static/favicon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link href="/static/common.css" rel="stylesheet">
+    <style>
+        body{
+            min-height:100vh; margin:0; display:flex;
+            align-items:center; justify-content:center; padding:24px;
+            font-family:Inter,system-ui,sans-serif;
+        }
+        .signin{width:100%; max-width:380px;}
+        .signin h1{font-size:20px; font-weight:600; margin:0 0 4px;}
+        .signin .sub{font-size:13px; opacity:.7; margin:0 0 20px;}
+        .signin .node{font-family:"JetBrains Mono",monospace; font-size:12px; opacity:.6;}
+        .signin label{display:block; font-size:13px; font-weight:500; margin-bottom:6px;}
+        .signin input[type=password]{width:100%; margin-bottom:14px;}
+        .signin button{width:100%;}
+        .err{
+            font-size:13px; padding:9px 11px; border-radius:6px; margin-bottom:14px;
+            background:rgba(220,53,69,.12); border:1px solid rgba(220,53,69,.35);
+        }
+        .hint{font-size:12px; opacity:.65; margin-top:18px; line-height:1.5;}
+    </style>
+</head>
+<body>
+<main class="signin">
+    <h1>Sign in</h1>
+    <p class="sub">Enter this node's remote access password.</p>
+
+    {% if error %}<div class="err" role="alert">{{ error }}</div>{% endif %}
+
+    <form method="post" action="/login">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="next" value="{{ next }}">
+        <label for="password">Password</label>
+        {# autofocus so the only control on the page is the one already selected.
+           autocomplete=current-password lets a password manager fill it. #}
+        <input type="password" id="password" name="password" class="ds-input mono"
+               autocomplete="current-password" autofocus required>
+        <button type="submit" class="ds-btn primary">Sign in</button>
+    </form>
+
+    <p class="hint">
+        Set and changed on the node itself, under Configuration &rsaquo; Remote
+        access. Anyone on the node's own network reaches it without a password.
+    </p>
+    <p class="node">{{ node_id }}</p>
+</main>
+</body>
+</html>

--- a/tests/test_access_identity.py
+++ b/tests/test_access_identity.py
@@ -6,6 +6,7 @@ verifies and should not have. A mocked verifier would pass all of them.
 """
 
 import json
+import logging
 import time
 
 import jwt
@@ -219,3 +220,86 @@ def test_small_clock_drift_is_tolerated(verifier, keys):
 
 def test_large_drift_is_not_tolerated(verifier, keys):
     assert verifier.identity(token(keys, exp_delta=-120)) is None
+
+
+# ── explaining refusals ──────────────────────────────────────────
+#
+# Every refusal returns a bare None, which is right for the caller and useless
+# for whoever has to work out why a node stopped admitting anyone. These assert
+# the log makes up the difference, and that it does so without handing out the
+# credential it is describing.
+
+def test_every_refusal_says_why(verifier, keys, caplog):
+    caplog.set_level(logging.WARNING)
+    cases = {
+        "wrong audience": token(keys, aud=OTHER_AUD),
+        "wrong team": token(keys, iss="https://someone-else.cloudflareaccess.com"),
+        "expired": token(keys, exp_delta=-600),
+        "no email": token(keys, email=""),
+        "unknown kid": token(keys, kid="never-published"),
+    }
+    for label, bad in cases.items():
+        caplog.clear()
+        assert verifier.identity(bad) is None, label
+        assert caplog.records, f"{label} was refused silently"
+        assert all(r.levelno >= logging.WARNING for r in caplog.records), label
+
+
+def test_the_token_is_never_logged(verifier, keys, caplog):
+    """A refused assertion is still a live bearer credential for its session.
+    A log that quotes it hands that session to anyone who can read logs, and
+    these lines exist to be read by people debugging."""
+    caplog.set_level(logging.DEBUG)
+    for bad in (token(keys, aud=OTHER_AUD),
+                token(keys, exp_delta=-600),
+                token(keys, kid="never-published")):
+        caplog.clear()
+        verifier.identity(bad)
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        assert bad not in logged
+        # Not even a substantial slice of it. Signatures are the long tail.
+        assert bad.split(".")[2][:24] not in logged
+
+
+def test_a_wrong_audience_names_both(verifier, keys, caplog):
+    """The failure a misconfiguration actually produces, and the one that is
+    invisible from outside: the hostname is up and refuses everybody."""
+    caplog.set_level(logging.WARNING)
+    verifier.identity(token(keys, aud=OTHER_AUD))
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    assert OTHER_AUD[:12] in logged, "does not say what the token claimed"
+    assert AUD[:12] in logged, "does not say what this node expects"
+
+
+def test_unreachable_cloudflare_is_distinguishable_from_a_bad_token(config, keys,
+                                                                    caplog):
+    """An outage and a forgery both return None. Confusing the two sends
+    somebody hunting an attacker during a network problem."""
+    caplog.set_level(logging.WARNING)
+    v = AccessIdentity(config_path=str(config), http=FakeHTTP({}, fail=True))
+    assert v.identity(token(keys)) is None
+    logged = " ".join(r.getMessage() for r in caplog.records).lower()
+    assert "could not reach" in logged
+
+
+def test_missing_config_is_reported_as_such(tmp_path, keys, caplog):
+    caplog.set_level(logging.WARNING)
+    v = AccessIdentity(config_path=str(tmp_path / "absent.json"))
+    assert v.identity(token(keys)) is None
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    assert "absent.json" in logged
+
+
+def test_no_token_at_all_is_not_logged(verifier, caplog):
+    """Unauthenticated requests are ordinary on a public hostname. Logging each
+    one would bury the refusals that mean something."""
+    caplog.set_level(logging.WARNING)
+    assert verifier.identity(None) is None
+    assert verifier.identity("") is None
+    assert not caplog.records
+
+
+def test_a_success_is_not_logged_as_a_refusal(verifier, keys, caplog):
+    caplog.set_level(logging.WARNING)
+    assert verifier.identity(token(keys)) == EMAIL
+    assert not caplog.records

--- a/tests/test_access_identity.py
+++ b/tests/test_access_identity.py
@@ -1,0 +1,221 @@
+"""Tests for verifying Cloudflare Access assertions.
+
+Uses a real RSA keypair and real signed tokens rather than mocking the
+verification, because the failures that matter here are the ones where a token
+verifies and should not have. A mocked verifier would pass all of them.
+"""
+
+import json
+import time
+
+import jwt
+import pytest
+import requests
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from access_identity import AccessIdentity
+
+TEAM = "offworldlab.cloudflareaccess.com"
+ISSUER = f"https://{TEAM}"
+AUD = "b62aeb13c198cd2118bd5d92b350f2af5c42830c703baeab42aad5fa3e01f29a"
+OTHER_AUD = "0000000000000000000000000000000000000000000000000000000000000000"
+EMAIL = "jehan@offworldlab.com"
+
+
+@pytest.fixture(scope="module")
+def keys():
+    """One keypair for the suite. Generating RSA is slow enough to matter."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+def _jwk(public_key, kid):
+    data = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(public_key))
+    data.update({"kid": kid, "alg": "RS256", "use": "sig"})
+    return data
+
+
+class FakeHTTP:
+    """Stands in for requests, counting fetches so caching can be asserted."""
+
+    def __init__(self, jwks, fail=False):
+        self.jwks = jwks
+        self.fail = fail
+        self.calls = 0
+
+    def get(self, url, timeout=None):
+        self.calls += 1
+        if self.fail:
+            raise requests.RequestException("unreachable")
+        payload = self.jwks
+
+        class Response:
+            @staticmethod
+            def raise_for_status():
+                return None
+
+            @staticmethod
+            def json():
+                return payload
+
+        return Response()
+
+
+@pytest.fixture
+def config(tmp_path):
+    path = tmp_path / "access.json"
+    path.write_text(json.dumps({"team_domain": TEAM, "aud": AUD}))
+    return path
+
+
+@pytest.fixture
+def verifier(config, keys):
+    _, public = keys
+    http = FakeHTTP({"keys": [_jwk(public, "kid-1")]})
+    v = AccessIdentity(config_path=str(config), http=http)
+    v.http_fake = http
+    return v
+
+
+def token(keys, *, aud=AUD, iss=ISSUER, email=EMAIL, kid="kid-1",
+          exp_delta=300, key=None, **extra):
+    private, _ = keys
+    claims = {"aud": aud, "iss": iss, "email": email,
+              "exp": int(time.time()) + exp_delta,
+              "iat": int(time.time()) - 10, **extra}
+    return jwt.encode(claims, key or private, algorithm="RS256",
+                      headers={"kid": kid})
+
+
+# ── the happy path ───────────────────────────────────────────────
+
+def test_a_valid_assertion_yields_the_email(verifier, keys):
+    assert verifier.identity(token(keys)) == EMAIL
+
+
+def test_the_key_set_is_cached(verifier, keys):
+    for _ in range(5):
+        verifier.identity(token(keys))
+    assert verifier.http_fake.calls == 1
+
+
+# ── the refusals that matter ─────────────────────────────────────
+
+def test_a_token_for_another_application_is_refused(verifier, keys):
+    """The one most easily left out, because such a token is perfectly signed.
+
+    This team already runs Access on other hostnames, so without the audience
+    check anyone holding a valid session for those would be admitted here.
+    """
+    assert verifier.identity(token(keys, aud=OTHER_AUD)) is None
+
+
+def test_a_token_from_another_team_is_refused(verifier, keys):
+    assert verifier.identity(token(keys, iss="https://someone-else.cloudflareaccess.com")) is None
+
+
+def test_an_expired_assertion_is_refused(verifier, keys):
+    assert verifier.identity(token(keys, exp_delta=-600)) is None
+
+
+def test_a_token_signed_by_someone_else_is_refused(verifier, keys):
+    """Right shape, right claims, wrong key. The signature is the whole point."""
+    impostor = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    assert verifier.identity(token(keys, key=impostor)) is None
+
+
+def test_an_unsigned_token_is_refused(verifier):
+    """alg=none is the classic way to walk past a verifier that trusts the
+    header's own claim about how it was signed."""
+    forged = jwt.encode({"aud": AUD, "iss": ISSUER, "email": EMAIL,
+                         "exp": int(time.time()) + 300},
+                        key="", algorithm="none")
+    assert verifier.identity(forged) is None
+
+
+def test_a_token_naming_nobody_is_refused(verifier, keys):
+    """Verifies, but authenticates no one. Returning something truthy would let
+    a caller believe it had identified a person."""
+    assert verifier.identity(token(keys, email="")) is None
+
+
+def test_a_token_with_no_audience_claim_is_refused(verifier, keys):
+    private, _ = keys
+    claims = {"iss": ISSUER, "email": EMAIL, "exp": int(time.time()) + 300}
+    naked = jwt.encode(claims, private, algorithm="RS256", headers={"kid": "kid-1"})
+    assert verifier.identity(naked) is None
+
+
+def test_rubbish_is_refused(verifier):
+    for value in ("", None, "not-a-token", "a.b.c"):
+        assert verifier.identity(value) is None
+
+
+# ── configuration ────────────────────────────────────────────────
+
+def test_no_config_means_no_identity(tmp_path, keys):
+    """Fails closed. Before node-infra delivers the audience there is nothing to
+    check against, and admitting anyone in the meantime would be the worst
+    possible default."""
+    v = AccessIdentity(config_path=str(tmp_path / "absent.json"))
+    assert v.is_configured() is False
+    assert v.identity(token(keys)) is None
+
+
+def test_a_partial_config_is_treated_as_absent(tmp_path, keys):
+    path = tmp_path / "access.json"
+    path.write_text(json.dumps({"team_domain": TEAM}))
+    v = AccessIdentity(config_path=str(path))
+    assert v.is_configured() is False
+    assert v.identity(token(keys)) is None
+
+
+def test_a_corrupt_config_is_treated_as_absent(tmp_path, keys):
+    path = tmp_path / "access.json"
+    path.write_text("{ not json")
+    assert AccessIdentity(config_path=str(path)).identity(token(keys)) is None
+
+
+# ── key rotation and outages ─────────────────────────────────────
+
+def test_an_unknown_key_id_triggers_one_refetch(config, keys):
+    """A key id we have not seen is either a rotation or a forgery, and one
+    refetch tells them apart."""
+    private, public = keys
+    http = FakeHTTP({"keys": [_jwk(public, "old-kid")]})
+    v = AccessIdentity(config_path=str(config), http=http)
+
+    assert v.identity(token(keys, kid="old-kid")) == EMAIL
+    assert http.calls == 1
+
+    # Cloudflare rotates; the token now carries a kid we have never seen.
+    http.jwks = {"keys": [_jwk(public, "new-kid")]}
+    assert v.identity(token(keys, kid="new-kid")) == EMAIL
+    assert http.calls == 2
+
+
+def test_a_kid_that_never_appears_is_refused_and_does_not_loop(config, keys):
+    private, public = keys
+    http = FakeHTTP({"keys": [_jwk(public, "real-kid")]})
+    v = AccessIdentity(config_path=str(config), http=http)
+
+    assert v.identity(token(keys, kid="invented")) is None
+    assert http.calls <= 2, "must not refetch endlessly for a forged kid"
+
+
+def test_cloudflare_being_unreachable_refuses_rather_than_admits(config, keys):
+    http = FakeHTTP({}, fail=True)
+    v = AccessIdentity(config_path=str(config), http=http)
+    assert v.identity(token(keys)) is None
+
+
+# ── clock drift ──────────────────────────────────────────────────
+
+def test_small_clock_drift_is_tolerated(verifier, keys):
+    """Nodes keep time with chrony but drift while offline. Refusing a token
+    that expired two seconds ago would be a confusing way to fail."""
+    assert verifier.identity(token(keys, exp_delta=-5)) == EMAIL
+
+
+def test_large_drift_is_not_tolerated(verifier, keys):
+    assert verifier.identity(token(keys, exp_delta=-120)) is None

--- a/tests/test_mender_connect.py
+++ b/tests/test_mender_connect.py
@@ -1,0 +1,214 @@
+"""Tests for enforcing the remote shell agreement.
+
+This module is what makes the agreement true rather than merely recorded, so
+the tests that matter are the ones asserting what it must never do: leave the
+two gated features disagreeing, touch file transfer, or invent a config it
+could not read.
+"""
+
+import json
+import os
+import stat
+
+import pytest
+
+from mender_connect import GATED_FEATURES, MenderConnect
+
+# Mirrors what the OS image ships, including the parts that must survive a write.
+SHIPPED_CONF = {
+    "ReconnectIntervalSeconds": 5,
+    "SkipVerify": False,
+    "Limits": {
+        "Enabled": True,
+        "FileTransfer": {
+            "Chroot": "/home/node",
+            "OwnerGet": ["node"],
+            "MaxFileSize": 536870912,
+        },
+    },
+    "FileTransfer": {"Disable": False},
+    "MenderClient": {"Disable": False},
+    "PortForward": {"Disable": False},
+    "ShellCommand": "/usr/bin/bash",
+    "ShellArguments": [],
+    "Sessions": {"ExpireAfterIdle": 3600, "MaxPerUser": 5},
+    "Terminal": {"Disable": False, "Height": 40, "Width": 80},
+    "User": "node",
+}
+
+
+@pytest.fixture
+def conf(tmp_path):
+    path = tmp_path / "mender-connect.conf"
+    path.write_text(json.dumps(SHIPPED_CONF, indent=2))
+    os.chmod(path, 0o644)
+    return path
+
+
+@pytest.fixture
+def connect(conf, monkeypatch):
+    """A real MenderConnect with systemctl stubbed, recording what it was asked."""
+    import mender_connect as module
+
+    calls = []
+
+    class Result:
+        returncode = 0
+        stderr = b""
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return Result()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    mc = MenderConnect(conf_path=str(conf))
+    mc.calls = calls
+    return mc
+
+
+def _load(conf):
+    return json.loads(conf.read_text())
+
+
+# ── reading ──────────────────────────────────────────────────────
+
+def test_shipped_config_reads_as_allowed(connect):
+    assert connect.is_shell_enabled() is True
+
+
+def test_either_feature_disabled_reads_as_declined(conf, connect):
+    """Not "both". A config with one of them off is not honouring the agreement,
+    and reporting it as allowed would hide a half-applied state."""
+    for feature in GATED_FEATURES:
+        data = dict(SHIPPED_CONF)
+        data[feature] = {"Disable": True}
+        conf.write_text(json.dumps(data))
+        assert connect.is_shell_enabled() is False, feature
+
+
+def test_unreadable_config_reads_as_unknown(tmp_path):
+    """None, not False. "We cannot tell" and "the owner declined" are different
+    facts and a boolean would collapse them."""
+    missing = MenderConnect(conf_path=str(tmp_path / "nope.conf"))
+    assert missing.is_shell_enabled() is None
+
+    broken = tmp_path / "broken.conf"
+    broken.write_text("{ not json")
+    assert MenderConnect(conf_path=str(broken)).is_shell_enabled() is None
+
+
+# ── writing ──────────────────────────────────────────────────────
+
+def test_declining_disables_both_features(conf, connect):
+    assert connect.set_shell_enabled(False) == (True, None)
+    data = _load(conf)
+    for feature in GATED_FEATURES:
+        assert data[feature]["Disable"] is True, feature
+
+
+def test_allowing_enables_both_features(conf, connect):
+    connect.set_shell_enabled(False)
+    assert connect.set_shell_enabled(True) == (True, None)
+    data = _load(conf)
+    for feature in GATED_FEATURES:
+        assert data[feature]["Disable"] is False, feature
+
+
+def test_file_transfer_is_never_touched(conf, connect):
+    """The load-bearing one. File transfer delivers the Cloudflare tunnel token,
+    so gating it here would make the two agreements dependent: a node whose
+    owner declined the shell could never receive a support tunnel."""
+    for allowed in (False, True, False):
+        connect.set_shell_enabled(allowed)
+        assert _load(conf)["FileTransfer"] == {"Disable": False}
+
+
+def test_everything_else_survives(conf, connect):
+    """The file carries transfer limits, the shell user and session caps. A
+    write that dropped them would widen or narrow what a session may do, behind
+    a setting that says nothing about either."""
+    connect.set_shell_enabled(False)
+    data = _load(conf)
+    for key in ("Limits", "MenderClient", "ShellCommand", "ShellArguments",
+                "Sessions", "User", "ReconnectIntervalSeconds", "SkipVerify"):
+        assert data[key] == SHIPPED_CONF[key], key
+
+
+def test_a_feature_missing_from_the_config_is_added(conf, connect):
+    data = {k: v for k, v in SHIPPED_CONF.items() if k != "PortForward"}
+    conf.write_text(json.dumps(data))
+    connect.set_shell_enabled(False)
+    assert _load(conf)["PortForward"]["Disable"] is True
+
+
+def test_sibling_keys_within_a_gated_feature_survive(conf, connect):
+    """Terminal carries Height and Width alongside Disable."""
+    connect.set_shell_enabled(False)
+    terminal = _load(conf)["Terminal"]
+    assert terminal["Height"] == 40 and terminal["Width"] == 80
+
+
+def test_the_file_mode_is_preserved(conf, connect):
+    connect.set_shell_enabled(False)
+    assert stat.S_IMODE(os.stat(conf).st_mode) == 0o644
+
+
+def test_the_service_is_restarted(connect):
+    """mender-connect reads its config only at startup, so without this the
+    daemon keeps serving the previous answer while the file claims otherwise."""
+    connect.set_shell_enabled(False)
+    assert connect.calls == [["systemctl", "restart", "mender-connect"]]
+
+
+# ── refusing ─────────────────────────────────────────────────────
+
+def test_a_missing_config_is_refused_not_created(tmp_path, monkeypatch):
+    """Writing a plausible replacement would invent transfer limits and a shell
+    user we have no business reconstructing, and could silently widen access."""
+    import mender_connect as module
+    monkeypatch.setattr(module.subprocess, "run",
+                        lambda *a, **k: pytest.fail("must not restart"))
+
+    path = tmp_path / "absent.conf"
+    ok, error = MenderConnect(conf_path=str(path)).set_shell_enabled(False)
+    assert ok is False
+    assert "missing or unreadable" in error
+    assert not path.exists()
+
+
+def test_an_unparseable_config_is_left_alone(tmp_path, monkeypatch):
+    import mender_connect as module
+    monkeypatch.setattr(module.subprocess, "run",
+                        lambda *a, **k: pytest.fail("must not restart"))
+
+    path = tmp_path / "broken.conf"
+    path.write_text("{ not json")
+    ok, error = MenderConnect(conf_path=str(path)).set_shell_enabled(False)
+    assert ok is False
+    assert path.read_text() == "{ not json"
+
+
+def test_a_failed_restart_is_reported(conf, monkeypatch):
+    """The file is already written at that point, so the caller must not record
+    the choice as applied."""
+    import mender_connect as module
+
+    class Failed:
+        returncode = 1
+        stderr = b"Unit mender-connect.service not found."
+
+    monkeypatch.setattr(module.subprocess, "run", lambda *a, **k: Failed())
+    ok, error = MenderConnect(conf_path=str(conf)).set_shell_enabled(False)
+    assert ok is False
+    assert "not found" in error
+
+
+def test_dev_mode_writes_without_restarting(tmp_path, monkeypatch):
+    import mender_connect as module
+    monkeypatch.setattr(module.subprocess, "run",
+                        lambda *a, **k: pytest.fail("must not restart off-device"))
+
+    path = tmp_path / "dev.conf"
+    mc = MenderConnect(conf_path=str(path), dev_mode=True)
+    assert mc.set_shell_enabled(False) == (True, None)
+    assert mc.is_shell_enabled() is False

--- a/tests/test_mender_connect.py
+++ b/tests/test_mender_connect.py
@@ -212,3 +212,54 @@ def test_dev_mode_writes_without_restarting(tmp_path, monkeypatch):
     mc = MenderConnect(conf_path=str(path), dev_mode=True)
     assert mc.set_shell_enabled(False) == (True, None)
     assert mc.is_shell_enabled() is False
+
+
+# ── surviving an OS update ───────────────────────────────────────
+#
+# The owner's choice lives in /data and survives an update. The enforcement
+# lives on the rootfs and does not: owl-os ships mender-connect.conf with both
+# gated features enabled, so an update silently restores a shell the owner had
+# declined, while the marker, the config page and the inventory attribute all
+# still reported it declined.
+
+def _shipped(conf):
+    """Put the config back exactly as owl-os ships it, which is what an OS
+    update does to the rootfs."""
+    conf.write_text(json.dumps(SHIPPED_CONF, indent=2))
+
+
+def test_startup_reapplies_a_declined_agreement(conf, connect):
+    """The defect, from the owner's side: they declined, an update happened,
+    and without this the daemon would accept sessions again."""
+    connect.set_shell_enabled(False)
+    assert connect.is_shell_enabled() is False
+
+    _shipped(conf)  # the update
+    assert connect.is_shell_enabled() is True, "precondition: update re-enabled it"
+
+    # What startup does: recorded choice wins over whatever is on disk.
+    connect.set_shell_enabled(False)
+    data = _load(conf)
+    for feature in GATED_FEATURES:
+        assert data[feature]["Disable"] is True, feature
+
+
+def test_reapplying_still_leaves_file_transfer_alone(conf, connect):
+    """A repair must not widen or narrow anything the agreement does not cover.
+    File transfer carries the tunnel token, so gating it here would couple the
+    two agreements together through the back door."""
+    _shipped(conf)
+    connect.set_shell_enabled(False)
+    assert _load(conf)["FileTransfer"] == {"Disable": False}
+
+
+def test_reapplying_preserves_what_the_update_shipped(conf, connect):
+    """The update's config is the authority on everything except the two gated
+    features: transfer limits, the shell user, session caps. A repair that
+    reverted those would undo part of the update it is reacting to."""
+    updated = dict(SHIPPED_CONF)
+    updated["Sessions"] = {"ExpireAfterIdle": 7200, "MaxPerUser": 9}
+    conf.write_text(json.dumps(updated))
+
+    connect.set_shell_enabled(False)
+    assert _load(conf)["Sessions"] == {"ExpireAfterIdle": 7200, "MaxPerUser": 9}

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1,0 +1,349 @@
+"""Tests for remote access: the password, and the three request pathways.
+
+The tests that matter most here are the pathway ones. A bug in the storage layer
+is a broken feature; a bug in the gate is a stranger with an SSH key on somebody
+else's node.
+"""
+
+import importlib
+import os
+import stat
+
+import pytest
+
+from remote_access import (
+    ADMIN,
+    LAN,
+    MIN_PASSWORD_LENGTH,
+    OWNER,
+    RemoteAccess,
+    classify_host,
+    generate_password,
+    requires_presence,
+)
+
+NODE_ID = "ret7dd2cb0d"
+DOMAIN = "retnode.com"
+OWNER_URL = f"http://{NODE_ID}.{DOMAIN}"
+ADMIN_URL = f"http://{NODE_ID}.admin.{DOMAIN}"
+LAN_URL = "http://owl.local"
+
+GOOD_PASSWORD = "correct-horse-battery"
+
+
+# ── the store ────────────────────────────────────────────────────
+
+@pytest.fixture
+def store(tmp_path):
+    return RemoteAccess(str(tmp_path / "remote-access.json"))
+
+
+def test_starts_off_with_no_password(store):
+    assert store.is_enabled() is False
+    assert store.has_password() is False
+    assert store.status()["enabled"] is False
+
+
+def test_password_round_trip(store):
+    assert store.set_password(GOOD_PASSWORD) == (True, None)
+    assert store.has_password() is True
+    assert store.verify(GOOD_PASSWORD) is True
+    assert store.verify("something else") is False
+
+
+def test_password_is_not_stored_in_the_clear(store):
+    """The file holds a hash. A password read off disk is the whole feature gone."""
+    store.set_password(GOOD_PASSWORD)
+    with open(store.state_file) as f:
+        assert GOOD_PASSWORD not in f.read()
+
+
+def test_state_file_is_not_world_readable(store):
+    store.set_password(GOOD_PASSWORD)
+    mode = stat.S_IMODE(os.stat(store.state_file).st_mode)
+    assert mode == 0o600, f"expected 0600, got {mode:o}"
+
+
+def test_short_passwords_are_refused(store):
+    ok, error = store.set_password("x" * (MIN_PASSWORD_LENGTH - 1))
+    assert ok is False
+    assert str(MIN_PASSWORD_LENGTH) in error
+    assert store.has_password() is False
+
+
+def test_cannot_enable_without_a_password(store):
+    """An advertised hostname that refuses everyone is the worst of the states."""
+    ok, error = store.set_enabled(True)
+    assert ok is False
+    assert "password" in error.lower()
+    assert store.is_enabled() is False
+
+
+def test_enable_after_setting_a_password(store):
+    store.set_password(GOOD_PASSWORD)
+    assert store.set_enabled(True) == (True, None)
+    assert store.is_enabled() is True
+
+
+def test_disabling_keeps_the_password(store):
+    store.set_password(GOOD_PASSWORD)
+    store.set_enabled(True)
+    store.set_enabled(False)
+    assert store.is_enabled() is False
+    assert store.has_password() is True
+    assert store.verify(GOOD_PASSWORD) is True
+
+
+def test_replacing_the_password_invalidates_the_old_one(store):
+    store.set_password(GOOD_PASSWORD)
+    store.set_password("a-different-password")
+    assert store.verify(GOOD_PASSWORD) is False
+    assert store.verify("a-different-password") is True
+
+
+def test_verify_is_false_when_nothing_is_set(store):
+    assert store.verify("") is False
+    assert store.verify("anything") is False
+
+
+def test_a_corrupt_state_file_reads_as_unset(store):
+    os.makedirs(os.path.dirname(store.state_file), exist_ok=True)
+    with open(store.state_file, "w") as f:
+        f.write("{ not json")
+    assert store.is_enabled() is False
+    assert store.verify("anything") is False
+
+
+def test_generated_passwords_are_long_and_distinct():
+    a, b = generate_password(), generate_password()
+    assert a != b
+    assert len(a.replace("-", "")) >= MIN_PASSWORD_LENGTH
+    # Ambiguous glyphs would be read aloud wrong, which is the normal way this
+    # password gets shared.
+    assert not set("01lIO") & set(a)
+
+
+# ── which pathway a request is on ────────────────────────────────
+
+@pytest.mark.parametrize("host,expected", [
+    ("owl.local", LAN),
+    (f"{NODE_ID}.local", LAN),
+    ("192.168.1.40", LAN),
+    ("localhost:8080", LAN),
+    (f"{NODE_ID}.{DOMAIN}", OWNER),
+    (f"{NODE_ID}.{DOMAIN}:443", OWNER),
+    (f"{NODE_ID}.{DOMAIN}.", OWNER),
+    (f"{NODE_ID}.{DOMAIN}".upper(), OWNER),
+    (f"{NODE_ID}.admin.{DOMAIN}", ADMIN),
+    ("", LAN),
+])
+def test_classify_host(host, expected):
+    assert classify_host(host, NODE_ID, DOMAIN) == expected
+
+
+def test_unknown_names_on_the_remote_domain_fail_closed():
+    """Anything unrecognised under the zone must ask for a password, not be
+    mistaken for the LAN and waved through."""
+    assert classify_host(f"surprise.{DOMAIN}", NODE_ID, DOMAIN) == OWNER
+    assert classify_host(DOMAIN, NODE_ID, DOMAIN) == OWNER
+
+
+def test_another_nodes_admin_name_is_not_our_admin_name():
+    assert classify_host(f"ret9f2b1e44.admin.{DOMAIN}", NODE_ID, DOMAIN) == OWNER
+
+
+def test_an_unreadable_node_id_does_not_open_the_owner_path():
+    """read_node_id() returns 'Unknown' when /data/mender is missing. That must
+    not turn the owner hostname into an unauthenticated one."""
+    assert classify_host(f"{NODE_ID}.{DOMAIN}", "Unknown", DOMAIN) == OWNER
+    assert classify_host(f"{NODE_ID}.admin.{DOMAIN}", "Unknown", DOMAIN) == OWNER
+
+
+@pytest.mark.parametrize("path", [
+    "/ssh-keys", "/ssh-keys/delete",
+    "/remote-access/password", "/remote-access/toggle",
+    "/mender/install",
+])
+def test_presence_required_paths(path):
+    assert requires_presence(path) is True
+
+
+@pytest.mark.parametrize("path", ["/", "/config", "/mender/check", "/login"])
+def test_ordinary_paths_do_not_need_presence(path):
+    assert requires_presence(path) is False
+
+
+# ── the gate, end to end ─────────────────────────────────────────
+
+@pytest.fixture
+def client(temp_dir, config_files, test_manifests_dir):
+    """Like conftest's app_client, but with the session cookie usable over http.
+
+    In production the session only ever exists on the owner pathway, which is
+    HTTPS through the tunnel, so the cookie is Secure and the test client would
+    silently decline to store it.
+    """
+    user_path, merged_path = config_files
+
+    mender_dir = os.path.join(temp_dir, "mender")
+    os.makedirs(mender_dir, exist_ok=True)
+    node_id_file = os.path.join(mender_dir, "node_id")
+    with open(node_id_file, "w") as f:
+        f.write(NODE_ID)
+
+    os.environ["DATA_DIR"] = temp_dir
+    os.environ["USER_CONFIG_PATH"] = user_path
+    os.environ["MERGED_CONFIG_PATH"] = merged_path
+    os.environ["RETINA_NODE_PATH"] = test_manifests_dir
+    os.environ["NODE_ID_FILE"] = node_id_file
+    os.environ["REMOTE_ACCESS_DOMAIN"] = DOMAIN
+    os.environ["SESSION_COOKIE_SECURE"] = "0"
+
+    import services as services_module
+    importlib.reload(services_module)
+    import app as app_module
+    importlib.reload(app_module)
+
+    app_module.app.config["TESTING"] = True
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    with app_module.app.test_client() as c:
+        c.remote_access = services_module.remote_access
+        yield c
+
+    del os.environ["SESSION_COOKIE_SECURE"]
+    del os.environ["REMOTE_ACCESS_DOMAIN"]
+
+
+@pytest.fixture
+def live(client):
+    """A client whose node has remote access switched on."""
+    client.remote_access.set_password(GOOD_PASSWORD)
+    client.remote_access.set_enabled(True)
+    return client
+
+
+def _sign_in(client, password=GOOD_PASSWORD):
+    return client.post("/login", data={"password": password},
+                       base_url=OWNER_URL, follow_redirects=False)
+
+
+def test_lan_never_asks_for_a_password(live):
+    """The LAN is unauthenticated and this change must not alter that."""
+    assert live.get("/", base_url=LAN_URL).status_code == 200
+
+
+def test_admin_pathway_is_not_challenged(live):
+    """Cloudflare Access authenticated them at the edge. Asking again is theatre."""
+    assert live.get("/", base_url=ADMIN_URL).status_code == 200
+
+
+def test_owner_pathway_is_404_while_remote_access_is_off(client):
+    """Nothing should be answering on that name, so do not confirm it exists."""
+    assert client.get("/", base_url=OWNER_URL).status_code == 404
+
+
+def test_owner_pathway_redirects_to_login(live):
+    r = live.get("/config", base_url=OWNER_URL)
+    assert r.status_code == 302
+    assert "/login" in r.headers["Location"]
+
+
+def test_login_page_is_reachable_without_a_session(live):
+    assert live.get("/login", base_url=OWNER_URL).status_code == 200
+
+
+def test_wrong_password_is_refused(live):
+    r = _sign_in(live, "not-the-password")
+    assert r.status_code == 401
+    assert live.get("/", base_url=OWNER_URL).status_code == 302
+
+
+def test_correct_password_grants_access(live):
+    assert _sign_in(live).status_code == 302
+    assert live.get("/", base_url=OWNER_URL).status_code == 200
+
+
+def test_a_post_without_a_session_is_403_not_a_redirect(live):
+    """fetch() callers need a status, not a login page to parse as JSON."""
+    r = live.post("/node-name", data={"name": "x"}, base_url=OWNER_URL)
+    assert r.status_code == 403
+
+
+@pytest.mark.parametrize("path,data", [
+    ("/ssh-keys", {"ssh_key": "ssh-ed25519 AAAAC3Nz"}),
+    ("/ssh-keys/delete", {"ssh_key": "ssh-ed25519 AAAAC3Nz"}),
+    ("/remote-access/password", {"password": "another-password-x"}),
+    ("/remote-access/toggle", {"enabled": "0"}),
+    ("/remote-access/generate", {}),
+    ("/mender/install", {}),
+])
+def test_signed_in_owner_still_cannot_reach_the_presence_tier(live, path, data):
+    """The invariant this whole design rests on.
+
+    The password gets shared. If whoever it was shared with can add an SSH key
+    or change the password, then rotating it no longer revokes anything and the
+    owner's only remedy is reinstalling the node.
+    """
+    _sign_in(live)
+    assert live.post(path, data=data, base_url=OWNER_URL).status_code == 403
+
+
+def test_the_presence_tier_still_works_on_the_lan(live):
+    _sign_in(live)
+    r = live.post("/ssh-keys", data={"ssh_key": "ssh-ed25519 AAAAC3Nz"},
+                  base_url=LAN_URL)
+    assert r.status_code in (200, 302)
+
+
+def test_the_presence_tier_still_works_for_admins(live):
+    r = live.post("/remote-access/toggle", data={"enabled": "0"},
+                  base_url=ADMIN_URL)
+    assert r.status_code == 200
+    assert live.remote_access.is_enabled() is False
+
+
+def test_the_sign_out_control_only_appears_on_the_owner_pathway(live):
+    """It is also the only thing that renders `pathway`, so this is what keeps
+    that template variable honest."""
+    _sign_in(live)
+    assert b"/logout" in live.get("/", base_url=OWNER_URL).data
+    assert b"/logout" not in live.get("/", base_url=LAN_URL).data
+    assert b"/logout" not in live.get("/", base_url=ADMIN_URL).data
+
+
+def test_logout_ends_the_session(live):
+    _sign_in(live)
+    assert live.post("/logout", base_url=OWNER_URL).status_code == 302
+    assert live.get("/", base_url=OWNER_URL).status_code == 302
+
+
+def test_turning_remote_access_off_locks_an_existing_session_out(live):
+    """Revocation must not wait for a cookie to expire."""
+    _sign_in(live)
+    assert live.get("/", base_url=OWNER_URL).status_code == 200
+    live.remote_access.set_enabled(False)
+    assert live.get("/", base_url=OWNER_URL).status_code == 404
+
+
+def test_login_does_not_redirect_off_site(live):
+    """`next` comes from the query string, so it is attacker-supplied."""
+    r = live.post("/login", data={"password": GOOD_PASSWORD, "next": "//evil.test/x"},
+                  base_url=OWNER_URL)
+    assert r.headers["Location"] in ("/", f"{OWNER_URL}/")
+
+
+def test_generate_returns_a_working_password_once(live):
+    r = live.post("/remote-access/generate", base_url=LAN_URL)
+    assert r.status_code == 200
+    password = r.get_json()["password"]
+    assert live.remote_access.verify(password) is True
+
+
+def test_secret_key_survives_a_restart(client, temp_dir):
+    """Otherwise every GUI restart and every OTA signs the owner out."""
+    import services as services_module
+    first = services_module.secret_key()
+    importlib.reload(services_module)
+    assert services_module.secret_key() == first
+    key_file = os.path.join(temp_dir, "secret-key")
+    assert stat.S_IMODE(os.stat(key_file).st_mode) == 0o600

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -6,6 +6,7 @@ else's node.
 """
 
 import importlib
+import json
 import os
 import stat
 
@@ -156,6 +157,53 @@ def test_generated_passwords_are_long_and_distinct():
     # Ambiguous glyphs would be read aloud wrong, which is the normal way this
     # password gets shared.
     assert not set("01lIO") & set(a)
+
+
+# ── the remote shell agreement ───────────────────────────────────
+#
+# Recorded by its exception, unlike support access, because it defaults ON.
+# Every node in the fleet already has interactive access, so an untouched node
+# must keep it, and an unwritable /data must not silently revoke it.
+
+def test_shell_is_allowed_by_default(store):
+    assert store.is_shell_allowed() is True
+
+
+def test_declining_shell_is_recorded(store):
+    assert store.record_shell_allowed(False) == (True, None)
+    assert store.is_shell_allowed() is False
+
+
+def test_shell_can_be_allowed_again(store):
+    store.record_shell_allowed(False)
+    assert store.record_shell_allowed(True) == (True, None)
+    assert store.is_shell_allowed() is True
+
+
+def test_allowing_shell_twice_is_harmless(store):
+    assert store.record_shell_allowed(True) == (True, None)
+    assert store.record_shell_allowed(True) == (True, None)
+    assert store.is_shell_allowed() is True
+
+
+def test_the_two_agreements_are_independent(store):
+    """The whole point of two settings. Neither may move the other."""
+    store.set_password(GOOD_PASSWORD)
+    store.set_enabled(True)
+    store.record_shell_allowed(False)
+    assert store.is_enabled() is True
+    assert store.is_shell_allowed() is False
+
+    store.set_enabled(False)
+    assert store.is_shell_allowed() is False
+    store.record_shell_allowed(True)
+    assert store.is_enabled() is False
+    assert store.is_shell_allowed() is True
+
+
+def test_shell_state_reaches_the_status(store):
+    store.record_shell_allowed(False)
+    assert store.status()["shell_allowed"] is False
 
 
 # ── the inventory marker ─────────────────────────────────────────
@@ -323,6 +371,109 @@ def test_ordinary_paths_do_not_need_presence(path):
     assert requires_presence(path) is False
 
 
+# ── Cloudflare Access at the gate ────────────────────────────────
+#
+# Support access is gated by Access at the edge; the node verifies the assertion
+# rather than trusting it, so a deleted or misconfigured Access application
+# cannot silently leave a node open.
+
+ACCESS_TEAM = "offworldlab.cloudflareaccess.com"
+ACCESS_AUD = "b62aeb13c198cd2118bd5d92b350f2af5c42830c703baeab42aad5fa3e01f29a"
+ENGINEER = "jehan@offworldlab.com"
+
+
+@pytest.fixture(scope="module")
+def access_keys():
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+def _arm_access(client, temp_dir, access_keys):
+    """Point the node's verifier at a key set we control, as Cloudflare would."""
+    import jwt as pyjwt
+
+    _, public = access_keys
+    jwk = json.loads(pyjwt.algorithms.RSAAlgorithm.to_jwk(public))
+    jwk.update({"kid": "kid-1", "alg": "RS256", "use": "sig"})
+
+    with open(os.path.join(temp_dir, "access.json"), "w") as f:
+        json.dump({"team_domain": ACCESS_TEAM, "aud": ACCESS_AUD}, f)
+
+    class HTTP:
+        @staticmethod
+        def get(url, timeout=None):
+            class R:
+                @staticmethod
+                def raise_for_status():
+                    return None
+
+                @staticmethod
+                def json():
+                    return {"keys": [jwk]}
+            return R()
+
+    client.access_identity.http = HTTP()
+
+
+def _assertion(access_keys, *, aud=ACCESS_AUD, email=ENGINEER):
+    import time as _time
+
+    import jwt as pyjwt
+    private, _ = access_keys
+    return pyjwt.encode(
+        {"aud": aud, "iss": f"https://{ACCESS_TEAM}", "email": email,
+         "exp": int(_time.time()) + 300},
+        private, algorithm="RS256", headers={"kid": "kid-1"})
+
+
+def test_a_verified_access_assertion_needs_no_password(live, temp_dir, access_keys):
+    _arm_access(live, temp_dir, access_keys)
+    r = live.get("/", base_url=OWNER_URL,
+                 headers={"Cf-Access-Jwt-Assertion": _assertion(access_keys)})
+    assert r.status_code == 200
+
+
+def test_an_assertion_for_another_application_is_not_accepted(live, temp_dir, access_keys):
+    """This team runs Access on other hostnames. A session for one of those is
+    perfectly signed and must not open a node."""
+    _arm_access(live, temp_dir, access_keys)
+    r = live.get("/", base_url=OWNER_URL,
+                 headers={"Cf-Access-Jwt-Assertion": _assertion(access_keys, aud="other")})
+    assert r.status_code == 302
+
+
+def test_a_forged_header_is_not_accepted(live, temp_dir, access_keys):
+    _arm_access(live, temp_dir, access_keys)
+    r = live.get("/", base_url=OWNER_URL,
+                 headers={"Cf-Access-Jwt-Assertion": "not-a-token"})
+    assert r.status_code == 302
+
+
+def test_an_assertion_does_not_lift_the_presence_tier(live, temp_dir, access_keys):
+    """The invariant the two owner agreements rest on.
+
+    An engineer authenticated by Access still cannot add an SSH key through the
+    browser. If they could, support access would be a route to shell access and
+    an owner who declined the shell would not actually have declined it.
+    """
+    _arm_access(live, temp_dir, access_keys)
+    headers = {"Cf-Access-Jwt-Assertion": _assertion(access_keys)}
+    assert live.get("/", base_url=OWNER_URL, headers=headers).status_code == 200
+    for path in ("/ssh-keys", "/remote-access/shell", "/mender/install"):
+        r = live.post(path, data={"x": "1"}, base_url=OWNER_URL, headers=headers)
+        assert r.status_code == 403, path
+
+
+def test_an_unconfigured_verifier_refuses_every_assertion(live, access_keys):
+    """Before node-infra delivers the audience there is nothing to check
+    against, and admitting anyone meanwhile would be the worst default."""
+    assert live.access_identity.is_configured() is False
+    r = live.get("/", base_url=OWNER_URL,
+                 headers={"Cf-Access-Jwt-Assertion": _assertion(access_keys)})
+    assert r.status_code == 302
+
+
 # ── the gate, end to end ─────────────────────────────────────────
 
 @pytest.fixture
@@ -348,6 +499,8 @@ def client(temp_dir, config_files, test_manifests_dir):
     os.environ["NODE_ID_FILE"] = node_id_file
     os.environ["REMOTE_ACCESS_DOMAIN"] = DOMAIN
     os.environ["SESSION_COOKIE_SECURE"] = "0"
+    os.environ["MENDER_CONNECT_CONF"] = os.path.join(temp_dir, "mender-connect.conf")
+    os.environ["ACCESS_CONFIG_PATH"] = os.path.join(temp_dir, "access.json")
 
     import services as services_module
     importlib.reload(services_module)
@@ -358,10 +511,13 @@ def client(temp_dir, config_files, test_manifests_dir):
     app_module.app.config["WTF_CSRF_ENABLED"] = False
     with app_module.app.test_client() as c:
         c.remote_access = services_module.remote_access
+        c.access_identity = services_module.access_identity
         yield c
 
     del os.environ["SESSION_COOKIE_SECURE"]
     del os.environ["REMOTE_ACCESS_DOMAIN"]
+    del os.environ["MENDER_CONNECT_CONF"]
+    del os.environ["ACCESS_CONFIG_PATH"]
 
 
 @pytest.fixture
@@ -462,18 +618,64 @@ def test_the_sign_out_control_only_appears_on_the_owner_pathway(live):
     assert b"/logout" not in live.get("/", base_url=PORT_FORWARD_URL).data
 
 
-def test_the_password_is_shown_on_the_lan(live):
-    live.remote_access.set_password("kitchen radar")
-    assert b"kitchen radar" in live.get("/config", base_url=LAN_URL).data
-
-
-def test_the_password_is_withheld_on_the_owner_pathway(live):
-    """Otherwise "only people on your network can see it" would be false: whoever
-    the password was shared with could read it straight back off the page."""
+def test_the_password_is_never_rendered(live):
+    """Support access is gated by Cloudflare Access, so the node password is not
+    part of the owner-facing design and must not leak onto a page on any path."""
     live.remote_access.set_password("kitchen radar")
     _sign_in(live, "kitchen radar")
-    body = live.get("/config", base_url=OWNER_URL).data
-    assert b"kitchen radar" not in body
+    for url in (LAN_URL, OWNER_URL, PORT_FORWARD_URL):
+        assert b"kitchen radar" not in live.get("/config", base_url=url).data
+
+
+def _write_connect_conf(temp_dir, shell_enabled):
+    with open(os.path.join(temp_dir, "mender-connect.conf"), "w") as f:
+        json.dump({"Terminal": {"Disable": not shell_enabled},
+                   "PortForward": {"Disable": not shell_enabled},
+                   "FileTransfer": {"Disable": False}}, f)
+
+
+def test_page_warns_when_the_setting_was_not_applied(live, temp_dir):
+    """The page must show what the node is doing, not what we recorded.
+
+    Without this the owner sees their own choice reflected back while
+    mender-connect carries on serving the opposite, which for a setting whose
+    entire job is stating what we can and cannot do is the wrong way to fail.
+    """
+    _write_connect_conf(temp_dir, shell_enabled=True)   # node still allows it
+    live.remote_access.record_shell_allowed(False)      # but we recorded declined
+    body = live.get("/config", base_url=LAN_URL).data
+    assert b"Not applied" in body
+
+
+def test_page_is_plain_when_record_and_node_agree(live, temp_dir):
+    _write_connect_conf(temp_dir, shell_enabled=False)
+    live.remote_access.record_shell_allowed(False)
+    body = live.get("/config", base_url=LAN_URL).data
+    assert b"Not applied" not in body
+    assert b"No session can be opened" in body
+
+
+def test_page_says_so_when_the_node_cannot_be_read(live, temp_dir):
+    """No mender-connect.conf at all, which is every dev machine and any node
+    where the file has gone missing."""
+    path = os.path.join(temp_dir, "mender-connect.conf")
+    if os.path.exists(path):
+        os.remove(path)
+    body = live.get("/config", base_url=LAN_URL).data
+    assert b"could not confirm" in body
+
+
+def test_no_estimate_is_promised_for_the_connection(live):
+    """The old copy quoted 15 minutes, a figure that depends on node-infra's
+    timer, which this node has no knowledge of and cannot promise."""
+    body = live.get("/config", base_url=LAN_URL).data
+    assert b"15 minutes" not in body
+
+
+def test_both_agreements_appear_on_the_config_page(live):
+    body = live.get("/config", base_url=LAN_URL).data
+    assert b'id="remoteToggle"' in body
+    assert b'id="shellToggle"' in body
 
 
 def test_logout_ends_the_session(live):

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -92,16 +92,11 @@ def test_short_passwords_are_refused(store):
     assert store.has_password() is False
 
 
-def test_cannot_enable_without_a_password(store):
-    """An advertised hostname that refuses everyone is the worst of the states."""
-    ok, error = store.set_enabled(True)
-    assert ok is False
-    assert "password" in error.lower()
-    assert store.is_enabled() is False
-
-
-def test_enable_after_setting_a_password(store):
-    store.set_password(GOOD_PASSWORD)
+def test_support_access_needs_no_password(store):
+    """Cloudflare Access gates the support path, and the page offers no way to
+    set a password. Requiring one made the setting impossible to turn on, which
+    is how it shipped broken and why this test exists."""
+    assert store.has_password() is False
     assert store.set_enabled(True) == (True, None)
     assert store.is_enabled() is True
 

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -12,7 +12,7 @@ import stat
 import pytest
 
 from remote_access import (
-    ADMIN,
+    ENABLED_MARKER,
     LAN,
     MIN_PASSWORD_LENGTH,
     OWNER,
@@ -20,13 +20,16 @@ from remote_access import (
     classify_host,
     generate_password,
     requires_presence,
+    tunnel_status,
 )
 
 NODE_ID = "ret7dd2cb0d"
 DOMAIN = "retnode.com"
 OWNER_URL = f"http://{NODE_ID}.{DOMAIN}"
-ADMIN_URL = f"http://{NODE_ID}.admin.{DOMAIN}"
 LAN_URL = "http://owl.local"
+# What a Mender port-forward looks like from inside the GUI. Staff reach nodes
+# this way instead of through a hostname of their own, so it must be LAN.
+PORT_FORWARD_URL = "http://localhost:8080"
 
 GOOD_PASSWORD = "correct-horse-battery"
 
@@ -155,6 +158,112 @@ def test_generated_passwords_are_long_and_distinct():
     assert not set("01lIO") & set(a)
 
 
+# ── the inventory marker ─────────────────────────────────────────
+#
+# This file is the entire node-to-server channel. owl-os's
+# mender-inventory-retina-remote-access tests for it and reports remote_access
+# up to Mender; node-infra reads that and decides whether a tunnel exists. If it
+# stops tracking is_enabled(), nodes silently stop getting tunnels, or keep them
+# after being switched off.
+
+def _marker(store):
+    return os.path.join(os.path.dirname(store.state_file), ENABLED_MARKER)
+
+
+def test_no_marker_before_anything_is_set(store):
+    store.set_password(GOOD_PASSWORD)
+    assert not os.path.exists(_marker(store))
+
+
+def test_marker_appears_when_enabled(store):
+    store.set_password(GOOD_PASSWORD)
+    store.set_enabled(True)
+    assert os.path.exists(_marker(store))
+
+
+def test_marker_goes_away_when_disabled(store):
+    store.set_password(GOOD_PASSWORD)
+    store.set_enabled(True)
+    store.set_enabled(False)
+    assert not os.path.exists(_marker(store))
+
+
+def test_marker_survives_a_password_change(store):
+    """Both inputs are written by different methods, which is why the marker is
+    recomputed after every write rather than set at the toggle."""
+    store.set_password(GOOD_PASSWORD)
+    store.set_enabled(True)
+    store.set_password("kitchen radar")
+    assert os.path.exists(_marker(store))
+
+
+def test_marker_is_readable_by_the_inventory_script(store):
+    """mender-authd runs the inventory scripts, and there is nothing in the
+    marker to protect. The state file beside it stays 0600."""
+    store.set_password(GOOD_PASSWORD)
+    store.set_enabled(True)
+    assert stat.S_IMODE(os.stat(_marker(store)).st_mode) == 0o644
+
+
+def test_the_marker_holds_no_secrets(store):
+    store.set_password(GOOD_PASSWORD)
+    store.set_enabled(True)
+    with open(_marker(store)) as f:
+        assert GOOD_PASSWORD not in f.read()
+
+
+# ── is the tunnel actually up ────────────────────────────────────
+
+def _fake_systemctl(monkeypatch, returncode):
+    import remote_access as module
+
+    def fake_run(*args, **kwargs):
+        class R:
+            pass
+        r = R()
+        r.returncode = returncode
+        return r
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+
+def test_tunnel_waiting_when_no_token_has_arrived(tmp_path):
+    assert tunnel_status(token_path=str(tmp_path / "nope")) == "waiting"
+
+
+def test_tunnel_waiting_when_the_token_is_empty(tmp_path):
+    token = tmp_path / "tunnel-token"
+    token.write_text("")
+    assert tunnel_status(token_path=str(token)) == "waiting"
+
+
+def test_tunnel_up_when_the_connector_is_running(tmp_path, monkeypatch):
+    token = tmp_path / "tunnel-token"
+    token.write_text("eyJhIjoi")
+    _fake_systemctl(monkeypatch, 0)
+    assert tunnel_status(token_path=str(token)) == "up"
+
+
+def test_tunnel_down_when_the_connector_is_not(tmp_path, monkeypatch):
+    token = tmp_path / "tunnel-token"
+    token.write_text("eyJhIjoi")
+    _fake_systemctl(monkeypatch, 3)
+    assert tunnel_status(token_path=str(token)) == "down"
+
+
+def test_tunnel_unknown_off_a_node(tmp_path, monkeypatch):
+    """A dev machine has no systemctl, and that is not a tunnel being down."""
+    import remote_access as module
+    token = tmp_path / "tunnel-token"
+    token.write_text("eyJhIjoi")
+
+    def boom(*args, **kwargs):
+        raise FileNotFoundError("systemctl")
+
+    monkeypatch.setattr(module.subprocess, "run", boom)
+    assert tunnel_status(token_path=str(token)) == "unknown"
+
+
 # ── which pathway a request is on ────────────────────────────────
 
 @pytest.mark.parametrize("host,expected", [
@@ -166,7 +275,7 @@ def test_generated_passwords_are_long_and_distinct():
     (f"{NODE_ID}.{DOMAIN}:443", OWNER),
     (f"{NODE_ID}.{DOMAIN}.", OWNER),
     (f"{NODE_ID}.{DOMAIN}".upper(), OWNER),
-    (f"{NODE_ID}.admin.{DOMAIN}", ADMIN),
+    (f"{NODE_ID}.admin.{DOMAIN}", OWNER),
     ("", LAN),
 ])
 def test_classify_host(host, expected):
@@ -180,15 +289,24 @@ def test_unknown_names_on_the_remote_domain_fail_closed():
     assert classify_host(DOMAIN, NODE_ID, DOMAIN) == OWNER
 
 
-def test_another_nodes_admin_name_is_not_our_admin_name():
-    assert classify_host(f"ret9f2b1e44.admin.{DOMAIN}", NODE_ID, DOMAIN) == OWNER
+def test_every_name_under_the_zone_needs_the_password():
+    """There is no staff hostname any more, so nothing under the zone is exempt."""
+    for host in (f"ret9f2b1e44.{DOMAIN}", f"anything.{DOMAIN}",
+                 f"{NODE_ID}.admin.{DOMAIN}"):
+        assert classify_host(host, NODE_ID, DOMAIN) == OWNER
 
 
 def test_an_unreadable_node_id_does_not_open_the_owner_path():
     """read_node_id() returns 'Unknown' when /data/mender is missing. That must
-    not turn the owner hostname into an unauthenticated one."""
+    not turn the tunnel hostname into an unauthenticated one."""
     assert classify_host(f"{NODE_ID}.{DOMAIN}", "Unknown", DOMAIN) == OWNER
-    assert classify_host(f"{NODE_ID}.admin.{DOMAIN}", "Unknown", DOMAIN) == OWNER
+
+
+def test_a_mender_port_forward_counts_as_local():
+    """This is the whole of the staff access story. If it ever stops being LAN,
+    engineers are locked out of every node at once."""
+    assert classify_host("localhost:8080", NODE_ID, DOMAIN) == LAN
+    assert classify_host("127.0.0.1:8080", NODE_ID, DOMAIN) == LAN
 
 
 @pytest.mark.parametrize("path", [
@@ -264,9 +382,9 @@ def test_lan_never_asks_for_a_password(live):
     assert live.get("/", base_url=LAN_URL).status_code == 200
 
 
-def test_admin_pathway_is_not_challenged(live):
-    """Cloudflare Access authenticated them at the edge. Asking again is theatre."""
-    assert live.get("/", base_url=ADMIN_URL).status_code == 200
+def test_a_mender_port_forward_is_not_challenged(live):
+    """How Offworld engineers reach a node. Mender already authenticated them."""
+    assert live.get("/", base_url=PORT_FORWARD_URL).status_code == 200
 
 
 def test_owner_pathway_is_404_while_remote_access_is_off(client):
@@ -327,9 +445,10 @@ def test_the_presence_tier_still_works_on_the_lan(live):
     assert r.status_code in (200, 302)
 
 
-def test_the_presence_tier_still_works_for_admins(live):
+def test_the_presence_tier_still_works_over_a_port_forward(live):
+    """An engineer on a port-forward gets the same reach as someone at home."""
     r = live.post("/remote-access/toggle", data={"enabled": "0"},
-                  base_url=ADMIN_URL)
+                  base_url=PORT_FORWARD_URL)
     assert r.status_code == 200
     assert live.remote_access.is_enabled() is False
 
@@ -340,7 +459,7 @@ def test_the_sign_out_control_only_appears_on_the_owner_pathway(live):
     _sign_in(live)
     assert b"/logout" in live.get("/", base_url=OWNER_URL).data
     assert b"/logout" not in live.get("/", base_url=LAN_URL).data
-    assert b"/logout" not in live.get("/", base_url=ADMIN_URL).data
+    assert b"/logout" not in live.get("/", base_url=PORT_FORWARD_URL).data
 
 
 def test_the_password_is_shown_on_the_lan(live):

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -42,10 +42,12 @@ def store(tmp_path):
     return RemoteAccess(str(tmp_path / "remote-access.json"))
 
 
-def test_starts_off_with_no_password(store):
-    assert store.is_enabled() is False
+def test_starts_on_with_no_password(store):
+    """TEMPORARY: support access defaults ON. See is_enabled() and the revert
+    ticket in Deployment Issues & Improvements."""
+    assert store.is_enabled() is True
     assert store.has_password() is False
-    assert store.status()["enabled"] is False
+    assert store.status()["enabled"] is True
 
 
 def test_password_round_trip(store):
@@ -137,11 +139,17 @@ def test_verify_is_false_when_nothing_is_set(store):
     assert store.verify("anything") is False
 
 
-def test_a_corrupt_state_file_reads_as_unset(store):
+def test_a_corrupt_state_file_reads_as_the_default(store):
+    """Unreadable state means no recorded choice, so the default applies.
+
+    Worth being explicit that while the default is ON, this fails *open*: a
+    corrupt file gets a tunnel rather than losing one. That is the default doing
+    what it says rather than a separate decision, and the hostname is still
+    Access-gated either way, but it reverses with the default."""
     os.makedirs(os.path.dirname(store.state_file), exist_ok=True)
     with open(store.state_file, "w") as f:
         f.write("{ not json")
-    assert store.is_enabled() is False
+    assert store.is_enabled() is True
     assert store.verify("anything") is False
 
 
@@ -213,9 +221,22 @@ def _marker(store):
     return os.path.join(os.path.dirname(store.state_file), ENABLED_MARKER)
 
 
-def test_no_marker_before_anything_is_set(store):
+def test_the_marker_follows_the_default(store):
+    """The marker is the whole node-to-server channel, so it has to agree with
+    is_enabled() rather than with whether anyone has touched the setting."""
     store.set_password(GOOD_PASSWORD)
+    assert os.path.exists(_marker(store))
+
+    store.set_enabled(False)
     assert not os.path.exists(_marker(store))
+
+
+def test_a_node_nobody_has_touched_publishes_the_marker(store):
+    """Without this the default would be inert: node-infra reads the file, not
+    is_enabled(), and a fresh node has never had one written."""
+    assert not os.path.exists(_marker(store))
+    store.publish_marker()
+    assert os.path.exists(_marker(store))
 
 
 def test_marker_appears_when_enabled(store):
@@ -581,7 +602,11 @@ def test_a_mender_port_forward_is_not_challenged(live):
 
 
 def test_owner_pathway_is_404_while_remote_access_is_off(client):
-    """Nothing should be answering on that name, so do not confirm it exists."""
+    """Nothing should be answering on that name, so do not confirm it exists.
+
+    Turned off explicitly now that the default is on, which is the point: this
+    protects the refusal, not the default."""
+    client.remote_access.set_enabled(False)
     assert client.get("/", base_url=OWNER_URL).status_code == 404
 
 

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -51,11 +51,28 @@ def test_password_round_trip(store):
     assert store.verify("something else") is False
 
 
-def test_password_is_not_stored_in_the_clear(store):
-    """The file holds a hash. A password read off disk is the whole feature gone."""
+def test_password_is_stored_in_the_clear_deliberately(store):
+    """This is the hotspot model: the owner reads it back to share it.
+
+    Pinned as a test rather than left implicit, so switching to a hash later is
+    a decision someone argues for rather than a refactor that quietly breaks
+    the config page's ability to show the password.
+    """
     store.set_password(GOOD_PASSWORD)
     with open(store.state_file) as f:
-        assert GOOD_PASSWORD not in f.read()
+        assert GOOD_PASSWORD in f.read()
+    assert store.get_password() == GOOD_PASSWORD
+
+
+def test_get_password_is_empty_when_unset(store):
+    assert store.get_password() == ""
+
+
+def test_status_never_carries_the_password(store):
+    """status() reaches the template on every pathway and the toggle response as
+    JSON. The password travels by its own method or not at all."""
+    store.set_password(GOOD_PASSWORD)
+    assert GOOD_PASSWORD not in repr(store.status())
 
 
 def test_state_file_is_not_world_readable(store):
@@ -99,6 +116,21 @@ def test_replacing_the_password_invalidates_the_old_one(store):
     store.set_password("a-different-password")
     assert store.verify(GOOD_PASSWORD) is False
     assert store.verify("a-different-password") is True
+    assert store.get_password() == "a-different-password"
+
+
+def test_a_memorable_password_is_allowed(store):
+    """The point of the change: the owner picks something they can say aloud."""
+    assert store.set_password("kitchen radar") == (True, None)
+    assert store.verify("kitchen radar") is True
+    assert store.get_password() == "kitchen radar"
+
+
+def test_non_ascii_passwords_work(store):
+    """compare_digest refuses non-ASCII str, so verify() encodes first."""
+    assert store.set_password("cafe\u0301-radar-8") == (True, None)
+    assert store.verify("cafe\u0301-radar-8") is True
+    assert store.verify("cafe-radar-8") is False
 
 
 def test_verify_is_false_when_nothing_is_set(store):
@@ -309,6 +341,20 @@ def test_the_sign_out_control_only_appears_on_the_owner_pathway(live):
     assert b"/logout" in live.get("/", base_url=OWNER_URL).data
     assert b"/logout" not in live.get("/", base_url=LAN_URL).data
     assert b"/logout" not in live.get("/", base_url=ADMIN_URL).data
+
+
+def test_the_password_is_shown_on_the_lan(live):
+    live.remote_access.set_password("kitchen radar")
+    assert b"kitchen radar" in live.get("/config", base_url=LAN_URL).data
+
+
+def test_the_password_is_withheld_on_the_owner_pathway(live):
+    """Otherwise "only people on your network can see it" would be false: whoever
+    the password was shared with could read it straight back off the page."""
+    live.remote_access.set_password("kitchen radar")
+    _sign_in(live, "kitchen radar")
+    body = live.get("/config", base_url=OWNER_URL).data
+    assert b"kitchen radar" not in body
 
 
 def test_logout_ends_the_session(live):

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -763,3 +763,70 @@ def test_secret_key_survives_a_restart(client, temp_dir):
     with open(key_file) as f:
         assert f.read().strip() == first
     assert stat.S_IMODE(os.stat(key_file).st_mode) == 0o600
+
+
+# ── service cards, per pathway ───────────────────────────────────
+#
+# On the LAN these link to other ports on this node. Over the tunnel those
+# ports are not reachable at all: Cloudflare proxies a fixed set and 49152 is
+# not among them, and an http:// link on an https:// page is blocked as mixed
+# content regardless. The tunnel routes a few paths on the same hostname to
+# those services instead, so remotely the links must be same-origin paths.
+
+@pytest.fixture
+def home(live, monkeypatch):
+    """The home page with its service cards rendered.
+
+    They are gated on `retina_node_version`, which is empty in a bare fixture,
+    so without this the cards are simply absent and every assertion below
+    passes vacuously.
+    """
+    import app as app_module
+    monkeypatch.setattr(app_module.mender, "get_versions",
+                        lambda: ("v1.2.3", "v0.4.4.0"))
+
+    def get(base_url=LAN_URL, **kw):
+        return live.get("/", base_url=base_url, **kw).get_data(as_text=True)
+    return get
+
+
+def _cards(html):
+    """Every service card's data attributes, keyed by its visible name."""
+    import re
+    out = {}
+    for tag, rest in re.findall(r'<a class="svc-card"([^>]*)>(.*?)</a>', html, re.S):
+        name = re.search(r'<div class="svc-name">([^<]*)</div>', rest)
+        if name:
+            out[name.group(1).strip()] = dict(re.findall(r'data-([a-z-]+)="([^"]*)"', tag))
+    return out
+
+
+def test_the_three_supported_views_have_a_remote_path(home):
+    """Passive Radar, Max-Hold and Controller are the views support asked for,
+    and the tunnel has ingress rules for exactly these paths."""
+    cards = _cards(home())
+    assert cards, "no service cards rendered"
+    for name, path in {
+        "Passive Radar": "/display/map/",
+        "Max-Hold": "/display/maxhold/",
+        "Controller": "/controller/",
+    }.items():
+        assert name in cards, f"{name} card missing"
+        assert cards[name].get("remote-path") == path, name
+
+
+def test_a_card_without_ingress_has_no_remote_path(home):
+    """Anything the tunnel does not route must not claim a remote path, or it
+    becomes a link that looks fine and cannot possibly work."""
+    routed = {"Passive Radar", "Max-Hold", "Controller"}
+    for name, attrs in _cards(home()).items():
+        if name not in routed:
+            assert "remote-path" not in attrs, f"{name} claims a remote path"
+
+
+def test_the_lan_still_builds_port_links(home):
+    """LAN behaviour must not change. blah2's own JS switches on is_localhost,
+    so it still expects the cross-origin port URLs there."""
+    body = home()
+    assert "var isRemote = false;" in body
+    assert "window.location.hostname + \':\' + el.dataset.port" in body

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -465,6 +465,48 @@ def test_an_assertion_does_not_lift_the_presence_tier(live, temp_dir, access_key
         assert r.status_code == 403, path
 
 
+def test_no_email_is_ever_written_to_the_device(live, temp_dir, access_keys):
+    """Nothing identifying a person may persist on a customer's node.
+
+    Access assertions carry an email, and Cloudflare adds a plain
+    Cf-Access-Authenticated-User-Email header alongside. Both are read in
+    memory for the duration of a request and neither is stored, logged or
+    rendered. Who may access a node lives in the Access policy, in Cloudflare,
+    not on the node.
+
+    Pinned here because it is the kind of property that is true until somebody
+    adds a log line meaning well.
+    """
+    _arm_access(live, temp_dir, access_keys)
+    headers = {"Cf-Access-Jwt-Assertion": _assertion(access_keys),
+               "Cf-Access-Authenticated-User-Email": ENGINEER}
+
+    for url in (OWNER_URL, LAN_URL):
+        body = live.get("/config", base_url=url, headers=headers).data
+        assert ENGINEER.encode() not in body, f"email rendered into a page on {url}"
+
+    written = []
+    for root, _dirs, files in os.walk(temp_dir):
+        for name in files:
+            path = os.path.join(root, name)
+            try:
+                with open(path, "rb") as f:
+                    if ENGINEER.encode() in f.read():
+                        written.append(path)
+            except OSError:
+                pass
+    assert not written, f"email persisted to {written}"
+
+
+def test_the_access_config_holds_nothing_personal(live, temp_dir, access_keys):
+    """What node-infra delivers is a team domain and an opaque application id."""
+    _arm_access(live, temp_dir, access_keys)
+    with open(os.path.join(temp_dir, "access.json")) as f:
+        config = json.load(f)
+    assert set(config) == {"team_domain", "aud"}
+    assert "@" not in json.dumps(config)
+
+
 def test_an_unconfigured_verifier_refuses_every_assertion(live, access_keys):
     """Before node-infra delivers the audience there is nothing to check
     against, and admitting anyone meanwhile would be the worst default."""

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -386,10 +386,22 @@ def test_generate_returns_a_working_password_once(live):
 
 
 def test_secret_key_survives_a_restart(client, temp_dir):
-    """Otherwise every GUI restart and every OTA signs the owner out."""
+    """Otherwise every GUI restart and every OTA signs the owner out.
+
+    Deliberately does not reload services to simulate the restart. secret_key()
+    reads the file on every call, so the persistence being tested is the file
+    itself, and asserting its contents proves it without touching module state.
+    An earlier version did reload, which left app.py's singletons bound to the
+    previous services objects and broke TestSharedServiceSingletons for whatever
+    ran next. The alphabetical suite order hid that.
+    """
     import services as services_module
+
     first = services_module.secret_key()
-    importlib.reload(services_module)
+    assert first
     assert services_module.secret_key() == first
+
     key_file = os.path.join(temp_dir, "secret-key")
+    with open(key_file) as f:
+        assert f.read().strip() == first
     assert stat.S_IMODE(os.stat(key_file).st_mode) == 0o600

--- a/tests/test_session_cookie.py
+++ b/tests/test_session_cookie.py
@@ -1,0 +1,158 @@
+"""The session cookie's flags, which differ per pathway.
+
+These run with SESSION_COOKIE_SECURE on, as a node does, because that is the
+only configuration where the bug they exist for can appear. The rest of the
+suite turns it off so the test client can hold a cookie at all, which is exactly
+why nothing caught this: a Secure cookie is silently dropped by the client that
+would have noticed.
+
+The bug: the cookie was Secure and `__Host-` prefixed on every response,
+including the LAN's plain HTTP. Browsers discard a Secure cookie delivered over
+HTTP, so the LAN held no session, and CSRFProtect keeps its token in the
+session. Every POST an owner made from their own network was refused with 400.
+"""
+
+import importlib
+import json
+import os
+
+import pytest
+
+NODE_ID = "ret7dd2cb0d"
+DOMAIN = "retnode.com"
+LAN_URL = "http://owl.local"
+OWNER_URL = f"http://{NODE_ID}.{DOMAIN}"
+PORT_FORWARD_URL = "http://localhost:8080"
+
+
+@pytest.fixture
+def client(temp_dir, config_files, test_manifests_dir):
+    """A node-like app: Secure cookies permitted, CSRF enforced."""
+    user_path, merged_path = config_files
+
+    mender_dir = os.path.join(temp_dir, "mender")
+    os.makedirs(mender_dir, exist_ok=True)
+    node_id_file = os.path.join(mender_dir, "node_id")
+    with open(node_id_file, "w") as f:
+        f.write(NODE_ID)
+
+    saved = {k: os.environ.get(k) for k in
+             ("DATA_DIR", "USER_CONFIG_PATH", "MERGED_CONFIG_PATH",
+              "RETINA_NODE_PATH", "NODE_ID_FILE", "REMOTE_ACCESS_DOMAIN",
+              "SESSION_COOKIE_SECURE", "MENDER_CONNECT_CONF",
+              "ACCESS_CONFIG_PATH")}
+
+    os.environ.update({
+        "DATA_DIR": temp_dir,
+        "USER_CONFIG_PATH": user_path,
+        "MERGED_CONFIG_PATH": merged_path,
+        "RETINA_NODE_PATH": test_manifests_dir,
+        "NODE_ID_FILE": node_id_file,
+        "REMOTE_ACCESS_DOMAIN": DOMAIN,
+        # The whole point: as a node runs.
+        "SESSION_COOKIE_SECURE": "1",
+        "MENDER_CONNECT_CONF": os.path.join(temp_dir, "mender-connect.conf"),
+        "ACCESS_CONFIG_PATH": os.path.join(temp_dir, "access.json"),
+    })
+
+    import services as services_module
+    importlib.reload(services_module)
+    import app as app_module
+    importlib.reload(app_module)
+
+    app_module.app.config["TESTING"] = True
+    with app_module.app.test_client() as c:
+        c.remote_access = services_module.remote_access
+        yield c
+
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _set_cookie(response):
+    return " ".join(response.headers.getlist("Set-Cookie"))
+
+
+def _drop_secure_cookies(client, response):
+    """Discard cookies a browser would have refused over plain HTTP.
+
+    The test client, like curl, happily stores a Secure cookie delivered over
+    http and sends it back. A browser does not. That difference is precisely
+    what hid this bug: every automated check passed while every real browser
+    was left without a session.
+
+    So the rule is applied here rather than assumed away.
+    """
+    for header in response.headers.getlist("Set-Cookie"):
+        if "secure" not in header.lower():
+            continue
+        name = header.split("=", 1)[0].strip()
+        try:
+            client.delete_cookie(name, domain="owl.local")
+            client.delete_cookie(name, domain="localhost")
+        except TypeError:  # older werkzeug signature
+            client.delete_cookie("owl.local", name)
+
+
+# ── the flags ────────────────────────────────────────────────────
+
+def test_the_lan_cookie_is_not_secure(client):
+    """The regression. A Secure cookie over plain HTTP is discarded by the
+    browser, leaving the LAN with no session to keep a CSRF token in."""
+    header = _set_cookie(client.get("/", base_url=LAN_URL))
+    assert "Secure" not in header
+    assert "__Host-" not in header
+
+
+def test_a_port_forward_is_treated_as_lan(client):
+    """Mender port-forwards arrive as localhost over plain HTTP too."""
+    header = _set_cookie(client.get("/", base_url=PORT_FORWARD_URL))
+    assert "Secure" not in header
+
+
+def test_the_remote_cookie_keeps_secure_and_the_host_prefix(client):
+    """Every node is a sibling under one registrable domain, so without the
+    prefix one node could set a `.retnode.com` cookie shadowing another's."""
+    client.remote_access.set_enabled(True)
+    header = _set_cookie(client.get("/login", base_url=OWNER_URL))
+    if header:
+        assert "Secure" in header
+        assert "__Host-session" in header
+
+
+# ── what the flags were breaking ─────────────────────────────────
+
+def test_an_owner_can_post_from_the_lan(client):
+    """The failure as it actually presented: every POST from an owner's own
+    network refused with 400, so no toggle, no config change, no setup wizard.
+
+    Driven through CSRF rather than around it, because the cookie was only ever
+    a problem via the token CSRFProtect keeps inside the session.
+    """
+    page = client.get("/config", base_url=LAN_URL)
+    assert page.status_code == 200
+    # As a browser would: anything Secure never made it into the jar.
+    _drop_secure_cookies(client, page)
+
+    body = page.get_data(as_text=True)
+    marker = 'name="csrf-token" content="'
+    assert marker in body, "config page carries no CSRF token to test with"
+    token = body.split(marker, 1)[1].split('"', 1)[0]
+
+    r = client.post("/remote-access/toggle", data={"enabled": "1"},
+                    headers={"X-CSRFToken": token}, base_url=LAN_URL)
+    assert r.status_code == 200, f"LAN POST refused with {r.status_code}"
+    assert json.loads(r.get_data(as_text=True))["ok"] is True
+
+
+def test_the_session_survives_across_requests_on_the_lan(client):
+    """A cookie the client declines to store shows up as a session that resets
+    every request, which is the shape the CSRF failure actually took."""
+    client.get("/config", base_url=LAN_URL)
+    header = _set_cookie(client.get("/config", base_url=LAN_URL))
+    # Either the cookie was kept (nothing re-set) or it was re-set unsecured,
+    # but it must never be re-set with Secure on a plain HTTP pathway.
+    assert "Secure" not in header

--- a/tests/test_startup_shell_agreement.py
+++ b/tests/test_startup_shell_agreement.py
@@ -1,0 +1,121 @@
+"""Re-applying the remote shell agreement when the GUI starts.
+
+The owner's choice lives in /data and survives an OS update. The enforcement
+lives in /etc/mender/mender-connect.conf on the A/B rootfs and does not: an
+update restores owl-os's template, where both gated features are enabled.
+
+Before this ran at startup, an owner who declined a shell had it silently
+restored by the next update, while the marker, the config page and the
+`remote_shell` inventory attribute all still said declined.
+"""
+
+import pytest
+
+import app as app_module
+
+
+class FakeRemoteAccess:
+    def __init__(self, allowed):
+        self._allowed = allowed
+
+    def is_shell_allowed(self):
+        return self._allowed
+
+
+class FakeMenderConnect:
+    """Records what startup asked of it."""
+
+    def __init__(self, enabled, ok=True, error=None):
+        self._enabled = enabled
+        self.ok = ok
+        self.error = error
+        self.calls = []
+
+    def is_shell_enabled(self):
+        return self._enabled
+
+    def set_shell_enabled(self, enabled):
+        self.calls.append(enabled)
+        return (self.ok, self.error)
+
+
+@pytest.fixture
+def startup(monkeypatch):
+    """Runs _reapply_shell_agreement against fakes, as a node would."""
+    def run(*, recorded, on_disk, ok=True, error=None):
+        mc = FakeMenderConnect(on_disk, ok=ok, error=error)
+        monkeypatch.setattr(app_module, "DEV_MODE", False)
+        monkeypatch.setattr(app_module, "remote_access", FakeRemoteAccess(recorded))
+        monkeypatch.setattr(app_module, "mender_connect", mc)
+        app_module._reapply_shell_agreement()
+        return mc
+    return run
+
+
+# ── the repair ───────────────────────────────────────────────────
+
+def test_an_update_that_re_enabled_the_shell_is_repaired(startup):
+    """The defect this exists for: owner declined, update reverted it."""
+    mc = startup(recorded=False, on_disk=True)
+    assert mc.calls == [False]
+
+
+def test_the_reverse_mismatch_is_also_repaired(startup):
+    """Less likely, but the marker is the authority in both directions. A node
+    refusing sessions its owner allows is a support call nobody can diagnose."""
+    mc = startup(recorded=True, on_disk=False)
+    assert mc.calls == [True]
+
+
+# ── leaving well alone ───────────────────────────────────────────
+
+def test_a_config_that_already_agrees_is_not_rewritten(startup):
+    """Writing anyway would restart mender-connect on every boot, dropping any
+    live session, to change nothing."""
+    assert startup(recorded=True, on_disk=True).calls == []
+    assert startup(recorded=False, on_disk=False).calls == []
+
+
+def test_an_unreadable_config_is_not_replaced(startup):
+    """None means we could not read it. mender_connect deliberately refuses to
+    invent a replacement, and startup must not talk it into one: a reconstructed
+    config would carry transfer limits and a shell user we have no basis for."""
+    assert startup(recorded=False, on_disk=None).calls == []
+
+
+def test_dev_mode_does_nothing(monkeypatch):
+    mc = FakeMenderConnect(True)
+    monkeypatch.setattr(app_module, "DEV_MODE", True)
+    monkeypatch.setattr(app_module, "remote_access", FakeRemoteAccess(False))
+    monkeypatch.setattr(app_module, "mender_connect", mc)
+    app_module._reapply_shell_agreement()
+    assert mc.calls == []
+
+
+# ── never breaking the boot ──────────────────────────────────────
+
+def test_a_failed_repair_is_logged_not_raised(startup, caplog):
+    """The GUI must still come up. A node that will not serve its own config
+    page is worse than one whose shell setting needs a click."""
+    mc = startup(recorded=False, on_disk=True, ok=False, error="unit not found")
+    assert mc.calls == [False]
+    assert any("Could not re-apply" in r.getMessage() for r in caplog.records)
+
+
+def test_an_exception_does_not_stop_startup(monkeypatch):
+    class Exploding:
+        def is_shell_allowed(self):
+            raise RuntimeError("disk gone")
+
+    monkeypatch.setattr(app_module, "DEV_MODE", False)
+    monkeypatch.setattr(app_module, "remote_access", Exploding())
+    monkeypatch.setattr(app_module, "mender_connect", FakeMenderConnect(True))
+    app_module._reapply_shell_agreement()  # must not raise
+
+
+def test_a_repair_says_so_in_the_log(startup, caplog):
+    """Silent repairs hide a real event: this only happens after an update
+    reverted somebody's choice, and that is worth a line in the journal."""
+    startup(recorded=False, on_disk=True)
+    assert any("Re-applied the remote shell agreement" in r.getMessage()
+               for r in caplog.records)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -24,6 +24,20 @@ _ = type("_", (), {})()
 #   src/app.py:44
 csrf
 
+# Flask's session machinery calls these on the interface it is given; nothing in
+# this codebase calls them directly. They decide the cookie's flags per request,
+# which is why they are overridden at all.
+#   src/app.py  (_PathwaySessionInterface)
+get_cookie_secure
+get_cookie_name
+# Flask reads app.session_interface when it opens and saves a session. Assigning
+# it is the whole mechanism, so vulture sees a write with no read.
+session_interface
+# flask.session.permanent, set to extend the signed-in lifetime past the browser
+# session. Read by Flask when it serialises the cookie.
+#   src/routes/remote_access.py:63
+permanent
+
 # ── UNREVIEWED: appears dead, needs a decision (delete, or finish wiring) ──────
 # TODO: config field: parsed but no reader found — wire it up or drop it
 #   src/config_schema.py:161  (unused variable)


### PR DESCRIPTION
Lets an Offworld engineer open any node's interface in a browser from anywhere, so they can help onboard and service users without being at their work machine. Gated by two agreements the owner controls independently.

Depends on **offworldlabs/owl-os#[branch `20260830-remote-access`]** for the inventory scripts that publish the owner's choice. Without it no node publishes anything and this is inert. node-infra's half is already on main.

## The two agreements

| setting | default | stored as |
| --- | --- | --- |
| Let support open this node's interface | **on, temporarily** | marker present means wanted |
| Let support open a command line | on | marker records only the exception |

They are separate because the risks are not the same. Over a shell you can replace the software a node runs and feed fabricated detections upstream, which threatens the authenticity of our data. Reaching the interface cannot. Collapsing them would mean an owner who wants help with their config has to grant the deeper access too.

**Always on regardless of either setting: enrolment, OTA and inventory.** Only `mender-connect` is gated; `mender-updated` and `mender-authd` are untouched, verified on hardware to share no process or dependency.

## Temporary, and tracked

The last commit (`TEMPORARY: default support access on`) makes a node nobody has touched publish `remote_access=true` and receive a tunnel without anyone opting in. That is deliberate for the rollout and meant to be reverted: the revert is one word, and it is tracked at https://app.clickup.com/t/123zgec0m8k

## How it works

The node states what its owner wants by writing a marker; mender carries it up as an inventory attribute; node-infra reconciles Cloudflare to match. **There is no node-facing endpoint anywhere in this**, so there is nothing to authenticate and nothing to attack. Intent is three-state: absent is not false, because absent means the node's OS predates the feature.

The node **verifies the Cloudflare Access assertion itself** rather than trusting the header: signature against Cloudflare's published keys, audience against its own application, issuer, expiry. If an Access application were ever deleted or misconfigured the hostname would be open, and this is the only thing that would notice.

Service cards point at tunnel paths when remote, since those ports are not proxied and an `http://` link on an `https://` page is blocked regardless. Cards with no route say so rather than looking clickable.

## Three defects found by testing, not review

**An OS update silently re-enabled a declined shell.** The choice lives in `/data` and survives; the enforcement lives in `/etc/mender/mender-connect.conf` on the A/B rootfs and does not. Nothing re-applied it, so the marker, the config page and the inventory attribute all said declined while the daemon accepted sessions. Now re-applied at startup.

**Every POST from an owner's own LAN returned 400.** The session cookie was `Secure` on all responses; browsers discard those over plain HTTP, and CSRFProtect keeps its token in the session. Nothing caught it because curl and the Flask test client keep the cookie where a browser will not.

**`status()` disagreed with `is_enabled()`**, so the page could show "off" on a node reporting `true` to Mender.

## Verified on hardware

Two nodes, both directions, driven by the droplet timer with nobody in the loop:

```
UP    flip on  -> Mender t+460s -> provisioned t+494s
DOWN  flip off -> Mender t+399s -> torn down   t+433s
```

Also: node-side revocation is immediate (404 on the remote path the moment it is toggled, while the tunnel is still up); teardown with the node deliberately offline still revokes; shell enforcement refuses Terminal and PortForward with a live control node accepting both, while file transfer and inventory keep working; the three blah2 views load over the tunnel and retina-gui's own `/api` routes still answer.

**822 tests passing.**

## Still open

* A real OTA landing on a node that has declined the shell agreement. The mechanism is evidenced without it, so this is confirmation rather than a blocker.
* Access config absent or stale, on hardware. Unit-tested thoroughly for failing closed; never exercised on a device.
* The node's own `/login` password page is vestigial: no password can be set, so it can only refuse. Left intact because the deferred owner-access work needs it.

Full context: https://app.clickup.com/t/123zgebzz9e

🤖 Generated with [Claude Code](https://claude.com/claude-code)