### PR TITLE
20260902 - Fill the Summary page with node cards

### DIFF
--- a/src/mdns_peers.py
+++ b/src/mdns_peers.py
@@ -245,6 +245,10 @@ class PeerDirectory:
                 # that just appeared is almost always real.
                 "alive": True,
                 "failures": 0,
+                # The peer's last good /healthz body. Filled by the prober, and
+                # the only channel by which anything a node holds on its own
+                # disk reaches another node's page.
+                "healthz": None,
                 "is_self": event["node_id"] == own,
             })
             peer["sources"].add((event["interface"], event["protocol"]))
@@ -280,6 +284,7 @@ class PeerDirectory:
                     "sources": {("fixture", "IPv4")},
                     "alive": entry.get("alive", True),
                     "failures": 0,
+                    "healthz": entry.get("healthz"),
                     "is_self": node_id == own,
                 }
 
@@ -303,7 +308,10 @@ class PeerDirectory:
         for name, address, is_self in targets:
             # No point probing ourselves over the network to find out we are
             # up: this process is what would be answering.
-            reachable = True if is_self else self._reachable(address)
+            if is_self:
+                reachable, payload = True, None
+            else:
+                reachable, payload = self._probe_peer(address)
             with self._lock:
                 peer = self._peers.get(name)
                 if not peer:
@@ -311,25 +319,43 @@ class PeerDirectory:
                 if reachable:
                     peer["failures"] = 0
                     peer["alive"] = True
+                    # Only when the answer parsed. A node that redirects or
+                    # errors is still present, and its last good answer beats
+                    # blanking the card it feeds.
+                    if payload is not None:
+                        peer["healthz"] = payload
                 else:
                     peer["failures"] += 1
                     if peer["failures"] >= FAILURES_BEFORE_GONE:
                         peer["alive"] = False
 
     @staticmethod
-    def _reachable(address):
+    def _probe_peer(address):
+        """Ask a peer whether it is there, and keep what it says.
+
+        Returns `(reachable, payload)`, and the two are deliberately
+        independent. Reachable is any answer at all, not a 200 carrying valid
+        JSON: a node mid-calibration redirects most GETs, and one returning 500
+        is still a node the operator should be able to reach and look at. Only
+        the payload needs a clean answer, and a node that cannot give one is
+        just a card with less on it.
+
+        This is also why the Summary page costs nothing. The request happens
+        every 20 seconds regardless, to keep the banner honest. Until now the
+        body was read and thrown away.
+        """
         if not address:
-            return False
+            return False, None
         try:
-            http_requests.get(f"http://{address}/healthz",
-                              timeout=PROBE_TIMEOUT_SECONDS)
+            response = http_requests.get(f"http://{address}/healthz",
+                                         timeout=PROBE_TIMEOUT_SECONDS)
         except http_requests.RequestException:
-            return False
-        # Any answer at all means something is serving. Deliberately not a
-        # 200 check: a node mid-calibration redirects most GETs, and one
-        # returning 500 is still a node the operator should be able to reach
-        # and look at.
-        return True
+            return False, None
+        try:
+            payload = response.json()
+        except ValueError:
+            return True, None
+        return True, payload if isinstance(payload, dict) else None
 
 
 def peer_directory_from_env(own_node_id_fn, dev_mode):

--- a/src/mdns_peers.py
+++ b/src/mdns_peers.py
@@ -30,6 +30,7 @@ failures are required before it drops off, so that a marginal WiFi link cannot
 flip the page between its one-node and many-node forms on every refresh.
 """
 
+import ipaddress
 import json
 import os
 import re
@@ -77,6 +78,22 @@ _TXT = re.compile(r'"((?:[^"\\]|\\.)*)"')
 
 def _unescape(value):
     return _ESCAPE.sub(lambda m: chr(int(m.group(1))), value)
+
+
+def _is_ipv4(address):
+    """Whether this address can be dropped into a URL as it stands.
+
+    Judged from the address itself rather than from avahi's protocol column,
+    which describes the socket an announcement arrived on and not what was
+    resolved. An `IPv4` resolve line has been observed in the field carrying an
+    IPv6 link-local address, and taking that column at its word is what made a
+    healthy node vanish from every other node's banner 40 seconds after it
+    appeared.
+    """
+    try:
+        return isinstance(ipaddress.ip_address(address), ipaddress.IPv4Address)
+    except ValueError:
+        return False
 
 
 def parse_txt(blob):
@@ -237,7 +254,9 @@ class PeerDirectory:
                 "node_id": event["node_id"],
                 "friendly_name": event["friendly_name"],
                 "hostname": event["hostname"],
-                "address": event["address"],
+                # Only ever an address we can use. See _is_ipv4, and the note
+                # further down where a later resolve may fill this in.
+                "address": event["address"] if _is_ipv4(event["address"]) else "",
                 "port": event["port"],
                 "sources": set(),
                 # Assumed present on first sight. The prober demotes it if that
@@ -256,9 +275,13 @@ class PeerDirectory:
             peer["friendly_name"] = event["friendly_name"]
             peer["hostname"] = event["hostname"]
             peer["is_self"] = event["node_id"] == own
-            # Prefer IPv4: it is what every client here can reach, and it is
-            # what the card offers as the by-address fallback.
-            if event["protocol"] == "IPv4" or not peer["address"]:
+            # Keep an address only when it is one anything can actually
+            # reach. A link-local needs a zone index to be usable, so it fails
+            # every probe, and it is worse than useless to an owner reading it
+            # off a card as the fallback for when the name will not resolve.
+            # Better to hold no address at all: the hostname still serves both
+            # the prober and the browser, and a later resolve fills this in.
+            if _is_ipv4(event["address"]):
                 peer["address"] = event["address"]
                 peer["port"] = event["port"]
 
@@ -302,16 +325,20 @@ class PeerDirectory:
         if self._fixture_path:
             return
         with self._lock:
-            targets = [(name, p["address"], p["is_self"])
+            targets = [(name, p["address"], p["hostname"], p["is_self"])
                        for name, p in self._peers.items()]
 
-        for name, address, is_self in targets:
+        for name, address, hostname, is_self in targets:
             # No point probing ourselves over the network to find out we are
             # up: this process is what would be answering.
             if is_self:
                 reachable, payload = True, None
             else:
-                reachable, payload = self._probe_peer(address)
+                # By name when no usable address has been seen yet. mDNS
+                # resolution is how every other client here reaches a node, so
+                # this keeps one whose A record has not arrived from being
+                # declared gone while it is running perfectly well.
+                reachable, payload = self._probe_peer(address or hostname)
             with self._lock:
                 peer = self._peers.get(name)
                 if not peer:

--- a/src/routes/fleet.py
+++ b/src/routes/fleet.py
@@ -1,4 +1,4 @@
-"""Fleet data for the banner, and the endpoint peers use to probe this node.
+"""Fleet data for the banner, the Summary page, and the endpoint peers probe.
 
 Every node on the network gets a tab in the banner at the top of every page
 (see `templates/_fleet_bar.html`), and each tab is a plain link to that node's
@@ -9,11 +9,30 @@ That is why nothing here decides *what* `owl.local` shows. It is answered by
 whichever node replies first, and that node serves its own Home exactly as it
 would under its own name. The only thing the shared alias costs you is that the
 URL is ambiguous until you click a tab, which is why every tab is absolute.
+
+## Where the Summary page gets its data
+
+Nowhere new. The names, addresses and node IDs come from the mDNS browse the
+banner needs anyway, and each peer's telemetry arrives on the `/healthz` probe
+that already runs every 20 seconds whether or not anyone has the page open.
+Rendering the page is a dict read and some local file reads. It is a
+nice-to-have, and a nice-to-have that polls the fleet would not be worth
+having.
 """
 
 from flask import Blueprint, jsonify, render_template
 
 bp = Blueprint("fleet", __name__)
+
+# Where "Add another node" sends an owner with only one. A stand-in: there is
+# no store URL anywhere in the codebase yet, so this goes where the banner's
+# Server button goes until the real one is known.
+BUY_URL = "https://map.retina.fm"
+
+# The one telemetry state with nothing to say for itself. Everything else gets
+# a chip, including states retina-telemetry grows later: an unfamiliar state
+# showing up on a card is the right failure, and silence is not.
+HEALTHY_STATE = "streaming"
 
 
 def node_url(peer):
@@ -39,41 +58,156 @@ def peer_view(peer):
     }
 
 
-def banner_nodes():
-    """The tabs to draw, guaranteed to include this node.
+def discovered_nodes():
+    """Every node believed present, guaranteed to include this one.
 
     Discovery is a background browse that takes a second or two to populate,
     and it can come back empty on a network that blocks multicast. Neither is a
-    reason to render a banner with no tabs at all: this node is self-evidently
-    present, whatever mDNS believes. So if the peer list does not already carry
-    us, put us at the front.
+    reason to draw a banner with no tabs or a Summary with no cards: this node
+    is self-evidently present, whatever mDNS believes. So if the peer list does
+    not already carry us, put us at the front.
+
+    Shared by the banner and the cards deliberately. Two answers to "which
+    nodes are there" would disagree during exactly the seconds after boot when
+    someone is most likely to be looking.
     """
     from app import peers, read_node_id
 
-    nodes = [peer_view(p) for p in peers.peers()]
+    nodes = list(peers.peers())
     if any(n["is_self"] for n in nodes):
         return nodes
 
     node_id = read_node_id()
     return [{
         "node_id": node_id,
-        "name": node_id,
-        "has_friendly_name": False,
-        "address": "",
+        "friendly_name": "",
         "hostname": f"{node_id}.local",
-        "url": f"http://{node_id}.local/",
+        "address": "",
+        "port": "80",
+        "healthz": None,
         "is_self": True,
     }] + nodes
 
 
+def banner_nodes():
+    """The tabs to draw."""
+    return [peer_view(p) for p in discovered_nodes()]
+
+
+# ── Telemetry, as a card needs it ──────────────────────────────
+
+def telemetry_payload():
+    """This node's telemetry reduced to what a card draws, or None if absent.
+
+    Local file reads only, and that is a constraint rather than an
+    implementation detail: this goes out over /healthz, which is how every
+    other node decides whether this one still exists. Anything here that could
+    block or fail slowly would make a busy node look absent to its peers.
+    """
+    from app import telemetry_status
+
+    status = telemetry_status.read()
+    if status is None:
+        return None
+    return {
+        "node_ref": status["node_ref"],
+        "state": status["state"],
+        "stale": status["stale"],
+    }
+
+
+def _in_words(state):
+    """`awaiting_config` as `Awaiting config`.
+
+    Only the first character moves. `capitalize` lowercases the remainder,
+    which is wrong the moment a state name carries an acronym.
+    """
+    if not state:
+        return "Unknown"
+    words = state.replace("_", " ")
+    return words[0].upper() + words[1:]
+
+
+def telemetry_view(payload):
+    """The telemetry line for one card, or None to say nothing at all.
+
+    Three silences, deliberately told apart:
+
+        no payload      We have not heard from this node yet, or it runs a
+                        build whose /healthz predates this field. We do not
+                        know, so the card omits the row rather than inventing
+                        an answer. Self-correcting: the next probe fills it.
+        telemetry null  We asked, and the node has no telemetry package. That
+                        is ordinary rather than a fault, so it is stated
+                        plainly and not flagged.
+        healthy         Registered and streaming. The identifier alone, no
+                        chip, because a working node has nothing to report.
+    """
+    if payload is None or "telemetry" not in payload:
+        return None
+
+    status = payload["telemetry"]
+    if status is None:
+        return {"node_ref": None, "label": "Not installed", "kind": "muted"}
+
+    node_ref = status.get("node_ref")
+
+    # Staleness outranks state: a document too old to believe describes a
+    # service that is no longer running, whatever it last claimed to be doing.
+    if status.get("stale"):
+        return {"node_ref": node_ref, "label": "Not reporting", "kind": "warn"}
+
+    if status.get("state") == HEALTHY_STATE:
+        # A healthy node can carry node_ref null for up to a heartbeat after
+        # its container restarts, because telemetry holds it in memory. Say
+        # something rather than drawing an empty row.
+        return {
+            "node_ref": node_ref,
+            "label": None if node_ref else "Registered",
+            "kind": None,
+        }
+
+    # An identifier and an unhappy state are independent, and both are worth
+    # having: the state alone throws away the reference support asks for, and
+    # the reference alone hides that the node is not currently registered.
+    return {
+        "node_ref": node_ref,
+        "label": _in_words(status.get("state")),
+        "kind": "warn",
+    }
+
+
+def card_view(peer):
+    """One node's worth of Summary card.
+
+    Separate from peer_view because the banner renders on every page and needs
+    none of this. A tab is a name and a link; it should not pay for a file read
+    or carry a state it never draws.
+    """
+    card = peer_view(peer)
+    # The prober deliberately skips this node, since this process is what would
+    # be answering, so our own telemetry is read here rather than arriving over
+    # the network from ourselves.
+    payload = ({"telemetry": telemetry_payload()} if peer["is_self"]
+               else peer.get("healthz"))
+    card["telemetry"] = telemetry_view(payload)
+    return card
+
+
+# ── Routes ─────────────────────────────────────────────────────
+
 @bp.route("/summary")
 def summary():
-    """Fleet-scope information page.
+    """The fleet, as cards.
 
-    Placeholder content for now. Deliberately not a node list: the banner above
-    it already is one, and two views of the same thing would drift apart.
+    Deliberately not a second node list competing with the banner above it:
+    the banner answers "which node am I looking at", and this answers "what do
+    I have, and is any of it unwell".
     """
-    return render_template("summary.html", active_page="summary")
+    return render_template("summary.html",
+                           active_page="summary",
+                           cards=[card_view(p) for p in discovered_nodes()],
+                           buy_url=BUY_URL)
 
 
 @bp.route("/api/fleet/peers")
@@ -92,7 +226,17 @@ def healthz():
     serving on this address", which is the only question a peer needs to ask,
     not whether the radar is healthy, which is what the node's own page is for.
     Anything heavier here would make a busy node look absent.
+
+    `telemetry` rides along because this probe is the only regular contact
+    between nodes, and a card on someone else's Summary page has no other way
+    to learn an identifier that lives on this node's disk. It stays inside the
+    rule above: local file reads, nothing over a socket. A blah2 call here to
+    report the radar would break it, which is why the radar is not here.
     """
     from app import read_node_id
 
-    return jsonify({"ok": True, "node_id": read_node_id()})
+    return jsonify({
+        "ok": True,
+        "node_id": read_node_id(),
+        "telemetry": telemetry_payload(),
+    })

--- a/static/common.css
+++ b/static/common.css
@@ -1018,3 +1018,110 @@ h1, h2, h3, h4, h5, h6 {
     .foot  { padding: 8px 16px; gap: 8px; font-size: 11px; }
     .shell { padding: 20px 16px 36px; }
 }
+
+/* ══════════════════════════════════════════════
+   Fleet summary: node cards
+   ══════════════════════════════════════════════ */
+
+.node-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(272px, 1fr));
+    gap: 14px;
+}
+
+.node-card {
+    display: block;
+    padding: 15px 16px 13px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    box-shadow: var(--shadow-sm);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color .12s, box-shadow .12s;
+}
+.node-card:hover { border-color: var(--accent-edge); box-shadow: var(--shadow-md); }
+
+/* The node serving the page. A wash and a filled pill rather than an accent
+   rail: the rail is the first thing that stops reading as meaningful once
+   there are half a dozen cards. */
+.node-card.self { background: var(--accent-soft); border-color: var(--accent-edge); }
+
+.node-head { display: flex; align-items: flex-start; gap: 9px; }
+.node-mark { color: var(--ink-3); flex: none; margin-top: 2px; }
+.node-card.self .node-mark { color: var(--accent); }
+.node-heading { flex: 1; min-width: 0; }
+.node-name {
+    font-size: 15.5px; font-weight: 600; letter-spacing: -0.005em;
+    color: var(--ink);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* A node ID standing in for a name is an identifier, not a word, so it is set
+   as one. */
+.node-name.unnamed { font-family: var(--font-mono); font-size: 14px; font-weight: 500; }
+.node-id { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3); margin-top: 1px; }
+
+.node-here {
+    flex: none;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: #fff;
+    font-size: 11px; font-weight: 600;
+    white-space: nowrap;
+}
+
+.node-rows {
+    margin-top: 13px;
+    padding-top: 11px;
+    border-top: 1px solid var(--line-2);
+    display: flex; flex-direction: column; gap: 7px;
+}
+.node-card.self .node-rows { border-top-color: var(--accent-edge); }
+.node-row { display: flex; align-items: baseline; gap: 10px; font-size: 12.5px; }
+.node-row-label { flex: none; width: 74px; color: var(--ink-3); }
+.node-row-body { display: flex; align-items: baseline; gap: 7px; flex-wrap: wrap; min-width: 0; }
+.node-value {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--ink-3);
+    font-variant-numeric: tabular-nums;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.node-value.ident { color: var(--ink); font-weight: 500; }
+/* A state with no identifier to qualify is the value itself, so it reads as
+   prose rather than as a chip attached to nothing. */
+.node-value.absent { font-family: var(--font-body); font-size: 12.5px; }
+
+.node-chip {
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-size: 10.5px; font-weight: 600;
+    white-space: nowrap;
+}
+.node-chip.warn { background: var(--warn-soft); color: oklch(0.50 0.11 75); border: 1px solid oklch(0.87 0.06 75); }
+/* Muted, not amber: "Not installed" is a fact about a node, not a fault in it. */
+.node-chip.muted { background: var(--surface-2); color: var(--ink-3); border: 1px solid var(--line); }
+
+.node-card.invite {
+    display: flex; align-items: center; gap: 12px;
+    border-style: dashed;
+    background: transparent;
+    box-shadow: none;
+}
+.node-invite-plus {
+    width: 32px; height: 32px; flex: none;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    display: grid; place-items: center;
+    color: var(--ink-3);
+    transition: border-color .12s, color .12s;
+}
+.node-card.invite:hover .node-invite-plus { border-color: var(--accent-edge); color: var(--accent); }
+.node-invite-text { min-width: 0; }
+.node-invite-title {
+    display: flex; align-items: center; gap: 5px;
+    font-size: 14px; font-weight: 600; color: var(--ink);
+}
+.node-invite-sub { display: block; font-size: 12.5px; color: var(--ink-3); margin-top: 1px; }

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -8,16 +8,95 @@
 {% block subnav %}{% endblock %}
 
 {% block content %}
-{#
-   Deliberately empty.
-
-   This page is the fleet-scope slot in the banner and is left as a blank
-   slate for the UX and setup teams to design into. It renders the banner and
-   nothing else on purpose, so anything that appears here later is theirs
-   rather than a developer's placeholder that has to be argued out of the way.
-
-   Add page content inside <main class="main"> below.
-#}
 <main class="main">
+    <div class="section-head"><h2>Nodes on this network</h2></div>
+
+    <div class="node-grid">
+        {% for card in cards %}
+        {# The whole card is the link, exactly as a banner tab is. A card that
+           only looked clickable would be the odd one out on this page. #}
+        <a class="node-card{% if card.is_self %} self{% endif %}" href="{{ card.url }}">
+            <div class="node-head">
+                {# The same antenna mark the tabs and the "listening on" row
+                   use, so a card reads as a node without a label saying so. #}
+                <svg class="node-mark" viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="12" cy="12" r="2"></circle>
+                    <path d="M8.5 8.5a5 5 0 0 1 7 0"></path>
+                    <path d="M5.5 5.5a9 9 0 0 1 13 0"></path>
+                    <path d="M12 14v8"></path>
+                </svg>
+                <div class="node-heading">
+                    <div class="node-name{% if not card.has_friendly_name %} unnamed{% endif %}">{{ card.name }}</div>
+                    {# The node ID is the identifier support asks for, so it is
+                       always on the card. When there is no name it has already
+                       been promoted to the title, and the line below says why. #}
+                    <div class="node-id">{% if card.has_friendly_name %}{{ card.node_id }}{% else %}Not yet named{% endif %}</div>
+                </div>
+                {% if card.is_self %}<span class="node-here">This node</span>{% endif %}
+            </div>
+
+            {# Omitted whole rather than left as a divider with nothing under
+               it: a node can legitimately have neither row, being one we have
+               not heard from yet and whose address has not resolved. #}
+            {% if card.telemetry or card.address %}
+            <div class="node-rows">
+                {# Absent entirely until this node has answered a probe, so that
+                   "not heard from yet" is not drawn as "has no telemetry".
+                   See telemetry_view() in routes/fleet.py. #}
+                {% if card.telemetry %}
+                <div class="node-row">
+                    <span class="node-row-label">Telemetry</span>
+                    <span class="node-row-body">
+                        {% if card.telemetry.node_ref %}
+                        <span class="node-value ident">{{ card.telemetry.node_ref }}</span>
+                        {# Only when something is wrong. A registered, streaming
+                           node shows its identifier and nothing else. #}
+                        {% if card.telemetry.label %}
+                        <span class="node-chip {{ card.telemetry.kind or 'muted' }}">{{ card.telemetry.label }}</span>
+                        {% endif %}
+                        {% else %}
+                        {# No identifier to qualify, so the state is the value
+                           itself and reads as prose rather than as a chip. #}
+                        <span class="node-value absent">{{ card.telemetry.label }}</span>
+                        {% endif %}
+                    </span>
+                </div>
+                {% endif %}
+
+                {% if card.address %}
+                <div class="node-row">
+                    <span class="node-row-label">Address</span>
+                    <span class="node-row-body"><span class="node-value">{{ card.address }}</span></span>
+                </div>
+                {% endif %}
+            </div>
+            {% endif %}
+        </a>
+        {% endfor %}
+
+        {# Only when this node is the whole fleet. One card in a grid built for
+           several reads as a page that half loaded, and an owner with one node
+           is the common case rather than the edge one. #}
+        {% if cards|length == 1 %}
+        <a class="node-card invite" href="{{ buy_url }}" target="_blank" rel="noopener">
+            <span class="node-invite-plus">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" aria-hidden="true">
+                    <path d="M12 5v14"></path><path d="M5 12h14"></path>
+                </svg>
+            </span>
+            <span class="node-invite-text">
+                <span class="node-invite-title">
+                    Add another node
+                    {# It leaves the app, so it carries the same outbound arrow
+                       the banner's Server and Dashboard buttons do. #}
+                    <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M14 3h7v7"></path><path d="M21 3l-9 9"></path><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"></path>
+                    </svg>
+                </span>
+                <span class="node-invite-sub">See the range</span>
+            </span>
+        </a>
+        {% endif %}
+    </div>
 </main>
 {% endblock %}

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -23,10 +23,34 @@ class FakePeers:
         return len(self._nodes)
 
 
-def node(node_id, address="192.168.1.57", friendly="", is_self=False):
+def node(node_id, address="192.168.1.57", friendly="", is_self=False,
+         healthz=None):
     return {"node_id": node_id, "friendly_name": friendly,
             "hostname": f"{node_id}.local", "address": address,
-            "port": "80", "is_self": is_self}
+            "port": "80", "is_self": is_self, "healthz": healthz}
+
+
+def probe(node_ref=None, state="streaming", stale=False, installed=True):
+    """A /healthz body, as a peer's last answer to this node's prober."""
+    telemetry = (None if not installed
+                 else {"node_ref": node_ref, "state": state, "stale": stale})
+    return {"ok": True, "node_id": "ret0", "telemetry": telemetry}
+
+
+def local_status(node_ref=None, state="streaming", stale=False):
+    """What telemetry_status.read() returns on this node."""
+    return {"state": state, "detail": None, "node_ref": node_ref,
+            "node_id": "", "stale": stale, "last_report": None}
+
+
+class FakeTelemetry:
+    """Stands in for the reader of retina-telemetry's status document."""
+
+    def __init__(self, status):
+        self._status = status
+
+    def read(self):
+        return self._status
 
 
 SELF = "ret7dd2cb0d"      # the node_id the app_client fixture writes
@@ -158,13 +182,15 @@ def test_summary_renders_and_marks_its_own_tab(app_client, fleet):
     assert 'href="/summary"' in active_tab(response.data.decode())
 
 
-def test_summary_is_deliberately_blank(app_client, fleet):
-    """Held empty for the UX and setup teams to design into. If this fails,
-    something has been added here that should have been theirs to decide."""
-    fleet(node(SELF, is_self=True))
-    body = app_client.get("/summary").data.decode()
-    content = body.split('<main class="main">')[1].split("</main>")[0]
-    assert content.strip() == "", f"summary page is no longer blank: {content[:200]!r}"
+def card_strip(body):
+    """The card grid, as a list of raw <a> fragments."""
+    grid = body.split('<div class="node-grid">')[1].split("</main>")[0]
+    return ["<a" + frag for frag in grid.split("<a")[1:]]
+
+
+def node_cards(body):
+    """The cards that stand for a node, excluding the invitation to buy one."""
+    return [c for c in card_strip(body) if "node-card invite" not in c]
 
 
 # ── The setup wizard ───────────────────────────────────────────
@@ -235,7 +261,8 @@ def test_the_url_falls_back_to_the_node_id_without_a_hostname():
 
 
 def test_healthz_answers_with_this_node_s_id(app_client):
-    assert app_client.get("/healthz").get_json() == {"ok": True, "node_id": SELF}
+    body = app_client.get("/healthz").get_json()
+    assert body["ok"] is True and body["node_id"] == SELF
 
 
 # ── Interaction with a running calibration ─────────────────────
@@ -267,3 +294,182 @@ def test_a_calibration_still_holds_the_node_s_own_pages(app_client, monkeypatch)
     response = app_client.get("/", headers={"Host": f"{SELF}.local"})
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/config")
+
+
+# ── The cards ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def telemetry(monkeypatch):
+    """Control what this node believes about its own telemetry."""
+    import app as app_module
+
+    def set_status(status):
+        monkeypatch.setattr(app_module, "telemetry_status", FakeTelemetry(status))
+
+    set_status(None)
+    return set_status
+
+
+def test_this_node_gets_a_card_even_before_discovery_has_run(app_client, fleet,
+                                                            telemetry):
+    """The banner already guarantees itself a tab in this window. A page of
+    cards that disagreed with the banner directly above it would be worse than
+    either answer on its own."""
+    fleet()
+    cards = node_cards(app_client.get("/summary").data.decode())
+    assert len(cards) == 1 and SELF in cards[0]
+
+
+def test_a_card_per_discovered_node(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True), node(OTHER, "192.168.1.58"))
+    cards = node_cards(app_client.get("/summary").data.decode())
+    assert len(cards) == 2
+
+
+def test_a_card_is_a_link_to_that_node(app_client, fleet, telemetry):
+    """Same as the banner tab above it. A card that only looked clickable
+    would be the odd one out on this page."""
+    fleet(node(SELF, is_self=True), node(OTHER, "192.168.1.58"))
+    cards = node_cards(app_client.get("/summary").data.decode())
+    assert f'href="http://{OTHER}.local/"' in cards[1]
+
+
+def test_the_serving_node_is_marked_and_comes_first(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True), node(OTHER, "192.168.1.58"))
+    cards = node_cards(app_client.get("/summary").data.decode())
+    assert "This node" in cards[0] and "This node" not in cards[1]
+
+
+def test_a_named_node_still_shows_its_node_id(app_client, fleet, telemetry):
+    """It is the identifier support asks for, so a name never replaces it."""
+    fleet(node(SELF, friendly="Garage", is_self=True))
+    card = node_cards(app_client.get("/summary").data.decode())[0]
+    assert "Garage" in card and SELF in card
+
+
+def test_an_unnamed_node_is_titled_by_its_id(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True))
+    card = node_cards(app_client.get("/summary").data.decode())[0]
+    assert SELF in card and "Not yet named" in card
+
+
+def test_the_address_is_shown(app_client, fleet, telemetry):
+    """The by-IP fallback for when the mDNS name will not resolve. It had
+    nowhere to live between the node-list page being deleted and this one."""
+    fleet(node(SELF, address="192.168.0.144", is_self=True))
+    card = node_cards(app_client.get("/summary").data.decode())[0]
+    assert "192.168.0.144" in card
+
+
+# ── Telemetry on a card ────────────────────────────────────────
+
+
+def test_a_peers_telemetry_comes_from_its_last_probe(app_client, fleet, telemetry):
+    """No fetch of any kind happens when this page is rendered: the answer
+    arrived on the /healthz probe that runs every 20 seconds anyway."""
+    fleet(node(SELF, is_self=True),
+          node(OTHER, "192.168.1.58", healthz=probe(node_ref="ndabc123")))
+    card = node_cards(app_client.get("/summary").data.decode())[1]
+    assert "ndabc123" in card
+
+
+def test_a_healthy_node_shows_its_id_and_no_chip(app_client, fleet, telemetry):
+    """A working node has nothing to report about itself."""
+    telemetry(local_status(node_ref="ndabc123", state="streaming"))
+    fleet(node(SELF, is_self=True))
+    card = node_cards(app_client.get("/summary").data.decode())[0]
+    assert "ndabc123" in card
+    assert "node-chip" not in card
+
+
+def test_an_unregistered_node_keeps_its_identifier(app_client, fleet, telemetry):
+    """The two are independent, and a node can hold a node_ref from a past
+    registration while the server currently refuses it. Showing only the state
+    would throw away the reference support asks for; showing only the
+    reference would hide the fault."""
+    telemetry(local_status(node_ref="ndabc123", state="unregistered"))
+    fleet(node(SELF, is_self=True))
+    card = node_cards(app_client.get("/summary").data.decode())[0]
+    assert "ndabc123" in card and "Unregistered" in card
+
+
+def test_a_state_name_is_made_readable(app_client, fleet, telemetry):
+    telemetry(local_status(node_ref="ndabc123", state="awaiting_config"))
+    fleet(node(SELF, is_self=True))
+    card = node_cards(app_client.get("/summary").data.decode())[0]
+    assert "Awaiting config" in card
+
+
+def test_a_stale_document_reads_as_not_reporting(app_client, fleet, telemetry):
+    """Whatever state it last claimed, a document too old to believe describes
+    a service that is no longer running."""
+    telemetry(local_status(node_ref="ndabc123", state="streaming", stale=True))
+    fleet(node(SELF, is_self=True))
+    card = node_cards(app_client.get("/summary").data.decode())[0]
+    assert "Not reporting" in card
+
+
+def test_a_node_without_the_telemetry_package_says_so(app_client, fleet, telemetry):
+    telemetry(None)
+    fleet(node(SELF, is_self=True))
+    card = node_cards(app_client.get("/summary").data.decode())[0]
+    assert "Not installed" in card
+
+
+def test_a_peer_not_yet_heard_from_has_no_telemetry_row(app_client, fleet, telemetry):
+    """Distinct from having no telemetry. We have not asked yet, so the card
+    omits the row rather than asserting something we do not know."""
+    fleet(node(SELF, is_self=True), node(OTHER, "192.168.1.58"))
+    card = node_cards(app_client.get("/summary").data.decode())[1]
+    assert "Telemetry" not in card
+
+
+def test_a_peer_on_an_older_build_has_no_telemetry_row(app_client, fleet, telemetry):
+    """Its /healthz predates the field. The card is quieter, not wrong."""
+    fleet(node(SELF, is_self=True),
+          node(OTHER, "192.168.1.58", healthz={"ok": True, "node_id": OTHER}))
+    card = node_cards(app_client.get("/summary").data.decode())[1]
+    assert "Telemetry" not in card
+
+
+# ── A fleet of one ─────────────────────────────────────────────
+
+
+def test_a_lone_node_is_offered_a_second(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True))
+    body = app_client.get("/summary").data.decode()
+    assert "Add another node" in body
+
+
+def test_the_offer_goes_once_there_are_two(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True), node(OTHER, "192.168.1.58"))
+    body = app_client.get("/summary").data.decode()
+    assert "Add another node" not in body
+
+
+# ── What a peer is told ────────────────────────────────────────
+
+
+def test_healthz_carries_this_nodes_telemetry(app_client, telemetry):
+    """The only channel by which an identifier held on this node's disk
+    reaches a card on someone else's Summary page."""
+    telemetry(local_status(node_ref="ndabc123", state="streaming"))
+    body = app_client.get("/healthz").get_json()
+    assert body["telemetry"] == {"node_ref": "ndabc123",
+                                 "state": "streaming", "stale": False}
+
+
+def test_healthz_says_null_when_telemetry_is_absent(app_client, telemetry):
+    telemetry(None)
+    assert app_client.get("/healthz").get_json()["telemetry"] is None
+
+
+
+def test_a_card_with_nothing_to_say_has_no_divider(app_client, fleet, telemetry):
+    """A peer can legitimately have neither row: not heard from yet, and no
+    address resolved. An empty rows block leaves a rule across the card with
+    nothing beneath it."""
+    fleet(node(SELF, is_self=True), node(OTHER, address=""))
+    card = node_cards(app_client.get("/summary").data.decode())[1]
+    assert "node-rows" not in card

--- a/tests/test_mdns_peers.py
+++ b/tests/test_mdns_peers.py
@@ -278,3 +278,46 @@ def test_a_node_just_discovered_has_no_answer_yet():
     d = directory()
     d._apply(resolve("ret1", "192.168.1.57"))
     assert d.peers()[0]["healthz"] is None
+
+
+# ── Addresses that cannot be used ──────────────────────────────
+#
+# Observed in the field: avahi labelling a resolve line IPv4 while the address
+# on it is an IPv6 link-local. Trusting the label stored an address nothing
+# could reach, so the node failed both its probes and left the banner 40
+# seconds after appearing, while serving pages perfectly well the whole time.
+
+
+def test_a_link_local_is_not_kept_as_an_address():
+    d = directory()
+    d._apply(resolve("ret1", "fe80::1f69:be26:cc20:2f18"))
+    assert d.peers()[0]["address"] == ""
+
+
+def test_a_usable_address_fills_in_later():
+    d = directory()
+    d._apply(resolve("ret1", "fe80::1f69:be26:cc20:2f18"))
+    d._apply(resolve("ret1", "192.168.1.57"))
+    assert d.peers()[0]["address"] == "192.168.1.57"
+
+
+def test_a_link_local_never_replaces_a_usable_address():
+    d = directory()
+    d._apply(resolve("ret1", "192.168.1.57"))
+    d._apply(resolve("ret1", "fe80::1f69:be26:cc20:2f18", protocol="IPv6"))
+    assert d.peers()[0]["address"] == "192.168.1.57"
+
+
+def test_a_node_with_no_usable_address_is_probed_by_name(monkeypatch):
+    """It is how every other client here reaches the node, and it is the
+    difference between a card missing its address row and a node that is
+    declared gone while running."""
+    probed = []
+    monkeypatch.setattr(PeerDirectory, "_probe_peer",
+                        staticmethod(lambda a: (probed.append(a) or True, None)))
+    d = directory()
+    d._apply(resolve("ret1", "fe80::1f69:be26:cc20:2f18"))
+    d._probe_once()
+
+    assert probed == ["ret1.local"]
+    assert d.count() == 1

--- a/tests/test_mdns_peers.py
+++ b/tests/test_mdns_peers.py
@@ -147,7 +147,7 @@ def test_one_failed_probe_does_not_remove_a_node(monkeypatch):
     """The hysteresis that stops a marginal link flipping the page."""
     d = directory()
     d._apply(resolve("ret1", "192.168.1.57"))
-    monkeypatch.setattr(PeerDirectory, "_reachable", staticmethod(lambda a: False))
+    monkeypatch.setattr(PeerDirectory, "_probe_peer", staticmethod(lambda a: (False, None)))
 
     d._probe_once()
     assert d.count() == 1, "one miss is not evidence a node is gone"
@@ -159,12 +159,12 @@ def test_one_failed_probe_does_not_remove_a_node(monkeypatch):
 def test_a_node_comes_back_when_it_answers_again(monkeypatch):
     d = directory()
     d._apply(resolve("ret1", "192.168.1.57"))
-    monkeypatch.setattr(PeerDirectory, "_reachable", staticmethod(lambda a: False))
+    monkeypatch.setattr(PeerDirectory, "_probe_peer", staticmethod(lambda a: (False, None)))
     d._probe_once()
     d._probe_once()
     assert d.count() == 0
 
-    monkeypatch.setattr(PeerDirectory, "_reachable", staticmethod(lambda a: True))
+    monkeypatch.setattr(PeerDirectory, "_probe_peer", staticmethod(lambda a: (True, None)))
     d._probe_once()
     assert d.count() == 1
 
@@ -173,11 +173,11 @@ def test_a_recovered_node_gets_a_full_allowance_again(monkeypatch):
     """A success must reset the counter, not leave it one miss from death."""
     d = directory()
     d._apply(resolve("ret1", "192.168.1.57"))
-    monkeypatch.setattr(PeerDirectory, "_reachable", staticmethod(lambda a: False))
+    monkeypatch.setattr(PeerDirectory, "_probe_peer", staticmethod(lambda a: (False, None)))
     d._probe_once()
-    monkeypatch.setattr(PeerDirectory, "_reachable", staticmethod(lambda a: True))
+    monkeypatch.setattr(PeerDirectory, "_probe_peer", staticmethod(lambda a: (True, None)))
     d._probe_once()
-    monkeypatch.setattr(PeerDirectory, "_reachable", staticmethod(lambda a: False))
+    monkeypatch.setattr(PeerDirectory, "_probe_peer", staticmethod(lambda a: (False, None)))
     d._probe_once()
     assert d.count() == 1
 
@@ -185,8 +185,8 @@ def test_a_recovered_node_gets_a_full_allowance_again(monkeypatch):
 def test_this_node_is_never_probed_over_the_network(monkeypatch):
     """It is the thing that would be answering; asking proves nothing."""
     probed = []
-    monkeypatch.setattr(PeerDirectory, "_reachable",
-                        staticmethod(lambda a: probed.append(a) or False))
+    monkeypatch.setattr(PeerDirectory, "_probe_peer",
+                        staticmethod(lambda a: (probed.append(a) or False, None)))
     d = directory()
     d._apply(resolve("retself", "192.168.1.10"))
     d._probe_once()
@@ -196,21 +196,25 @@ def test_this_node_is_never_probed_over_the_network(monkeypatch):
 
 
 def test_a_peer_with_no_address_is_not_reachable():
-    assert PeerDirectory._reachable("") is False
-    assert PeerDirectory._reachable(None) is False
+    assert PeerDirectory._probe_peer("") == (False, None)
+    assert PeerDirectory._probe_peer(None) == (False, None)
 
 
 def test_a_probe_that_answers_at_all_counts_as_alive(monkeypatch):
     """Not a 200 check: a calibrating node redirects, and a broken one 500s.
 
-    Both are nodes the operator should still be able to open and look at.
+    Both are nodes the operator should still be able to open and look at, so
+    both are alive. Neither carries a body worth keeping.
     """
     class Response:
         status_code = 302
 
+        def json(self):
+            raise ValueError("not JSON")
+
     monkeypatch.setattr(mdns_peers.http_requests, "get",
                         lambda *a, **k: Response())
-    assert PeerDirectory._reachable("192.168.1.57") is True
+    assert PeerDirectory._probe_peer("192.168.1.57") == (True, None)
 
 
 def test_a_connection_error_is_not_alive(monkeypatch):
@@ -218,4 +222,59 @@ def test_a_connection_error_is_not_alive(monkeypatch):
         raise mdns_peers.http_requests.ConnectionError("refused")
 
     monkeypatch.setattr(mdns_peers.http_requests, "get", boom)
-    assert PeerDirectory._reachable("192.168.1.57") is False
+    assert PeerDirectory._probe_peer("192.168.1.57") == (False, None)
+
+
+def test_a_json_answer_comes_back_with_the_verdict(monkeypatch):
+    """The body is the whole point: it is what a peer's card is drawn from."""
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return {"ok": True, "node_id": "ret1"}
+
+    monkeypatch.setattr(mdns_peers.http_requests, "get",
+                        lambda *a, **k: Response())
+    assert PeerDirectory._probe_peer("192.168.1.57") == (
+        True, {"ok": True, "node_id": "ret1"})
+
+
+# ── What the probe brings back ─────────────────────────────────
+#
+# The Summary card for a peer is drawn from whatever its last good /healthz
+# said, because that request is the only regular contact between two nodes.
+
+
+def test_a_good_answer_is_kept_for_the_card(monkeypatch):
+    body = {"ok": True, "node_id": "ret1", "telemetry": {"node_ref": "ndabc"}}
+    monkeypatch.setattr(PeerDirectory, "_probe_peer",
+                        staticmethod(lambda a: (True, body)))
+    d = directory()
+    d._apply(resolve("ret1", "192.168.1.57"))
+    d._probe_once()
+
+    assert d.peers()[0]["healthz"] == body
+
+
+def test_a_bad_answer_does_not_wipe_the_last_good_one(monkeypatch):
+    """Better a card a few seconds out of date than one that empties itself
+    every time a peer happens to be busy."""
+    body = {"ok": True, "telemetry": {"node_ref": "ndabc"}}
+    monkeypatch.setattr(PeerDirectory, "_probe_peer",
+                        staticmethod(lambda a: (True, body)))
+    d = directory()
+    d._apply(resolve("ret1", "192.168.1.57"))
+    d._probe_once()
+
+    monkeypatch.setattr(PeerDirectory, "_probe_peer",
+                        staticmethod(lambda a: (True, None)))
+    d._probe_once()
+
+    assert d.peers()[0]["healthz"] == body
+
+
+def test_a_node_just_discovered_has_no_answer_yet():
+    """So a card can tell "not heard from yet" apart from "has no telemetry"."""
+    d = directory()
+    d._apply(resolve("ret1", "192.168.1.57"))
+    assert d.peers()[0]["healthz"] is None


### PR DESCRIPTION
Summary has been deliberately blank since the banner replaced the node-list page, held that way by a test, waiting for the UX team to decide what belongs there. This ships the first thing they asked for, so a release does not go out with an empty tab in it.

## Node cards

One card per node: the owner's name for it, the node ID support asks for, the telemetry identifier, and the address. The node serving the page is marked and sorted first. The whole card is a link to that node, matching the banner tab above it.

**The identifier and the state are shown together**, not one or the other. They can disagree: the test node holds a valid `node_ref` issued in August while the server has refused its registration 38 times since. Showing only the state throws away the reference support asks for; showing only the reference hides that the node is not currently registered. The state chip appears only when something is wrong, so a healthy node shows an identifier and says nothing else.

**Opening the page costs nothing.** Names and addresses come from the mDNS browse the banner needs anyway. A peer's telemetry rides in on the `/healthz` probe that has always run every 20 seconds, and whose body was previously read and thrown away. Rendering is a dict read. That constraint is also why the radar is not on a card: the config page polls blah2 once a second, which is right where you are tuning one node and wrong for a fleet page.

`/healthz` gains a `telemetry` object and stays trivial otherwise: local file reads, nothing over a socket. It is how every other node decides whether this one still exists, so anything that could block would make a busy node look absent.

## The mDNS fix

Found while live-testing, and older than the cards. A node that was up and serving would appear in every other node's banner and vanish about 40 seconds later, repeatedly.

`avahi-browse` on the test node:

```
=;wlan0;IPv4;ret824685c9;...;192.168.0.144;80;"node_id=ret824685c9"
=;wlan0;IPv4;ret4c844c20;...;fe80::1f69:be26:cc20:2f18;80;"name=..."
```

The second line says IPv4 and carries an IPv6 link-local. That column describes the socket the announcement arrived on, not what was resolved. The peer's address became a link-local, which cannot be reached without a zone index, so both probes failed and the hysteresis declared the node gone. It was also being drawn on a card, where `fe80::...` is worse than nothing.

Addresses are now judged by what they are rather than what avahi labels them. A node with no usable address is probed by hostname instead, and the address fills in when a resolve carries a usable one.

## Testing

838 tests pass locally, ruff clean. Both commits pass on their own, so the fix is reviewable without the feature.

Live on a node throughout. After the fix, the peer survived three probe cycles where it had previously been dropped after two, held an empty address while being probed by name, then filled in its real address on its own.

## Deliberately not in here

The Resources section, the passive-radar primer text, and an interactive diagram are all built or drafted but held back pending UX sign-off. This is the node cards only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)