### PR TITLE
Scope the remote pathway to this node's own hostname

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-from flask import Flask, abort, g, jsonify, redirect, request, session, url_for
+from flask import Flask, abort, g, jsonify, redirect, render_template, request, session, url_for
 from flask.sessions import SecureCookieSessionInterface
 from flask_wtf.csrf import CSRFError, CSRFProtect
 
@@ -387,10 +387,24 @@ def _gate_the_remote_pathways():
 
     if not (identity or session.get('remote_authed')):
         if request.method == 'GET':
-            # full_path always appends '?', even with no query string, which
-            # would send people to '/config?' after signing in.
-            wanted = request.full_path.rstrip('?') or '/'
-            return redirect(url_for('remote_access.login', next=wanted))
+            # Only offer the password form when a password exists to give.
+            #
+            # This used to redirect unconditionally, and that turned every
+            # verification failure into a dead end: no password can be set from
+            # the support pathway, and the page offers no way to set one, so the
+            # form could only ever refuse. Somebody whose Access assertion did
+            # not verify was shown a login box instead of the reason, and had
+            # nothing to do but guess.
+            #
+            # The form still exists for the deferred owner-password design, and
+            # still works the moment a password is set. It is simply no longer
+            # where failures land.
+            if remote_access.has_password():
+                # full_path always appends '?', even with no query string, which
+                # would send people to '/config?' after signing in.
+                wanted = request.full_path.rstrip('?') or '/'
+                return redirect(url_for('remote_access.login', next=wanted))
+            return render_template('remote_denied.html'), 403
         # A POST from a page whose session expired. 403 rather than a redirect,
         # so fetch() callers get a status they can act on instead of an HTML
         # login page parsed as JSON.

--- a/src/remote_access.py
+++ b/src/remote_access.py
@@ -58,6 +58,7 @@ the full interface.
 
 import json
 import os
+import re
 import secrets
 import subprocess
 import tempfile
@@ -383,6 +384,12 @@ LAN = "lan"
 OWNER = "owner"
 
 
+#: What a node id looks like. Matched rather than trusting any non-empty string,
+#: because read_node_id() reports "Unknown" rather than failing, and that must
+#: not be mistaken for an id we could compare a hostname against.
+_NODE_ID_RE = re.compile(r"^ret[0-9a-f]{8}$")
+
+
 def classify_host(host, node_id, domain):
     """Return LAN or OWNER for the Host header of a request.
 
@@ -397,25 +404,44 @@ def classify_host(host, node_id, domain):
     why no second hostname, Cloudflare Access application or fleet-wide staff
     password is needed anywhere in this design.
 
-    Fails closed on the remote domain. Anything under it is treated as OWNER, so
-    a hostname this node does not expect (a stale DNS record, a provisioning
-    bug, a domain-wide wildcard someone added) demands a password rather than
-    being mistaken for the LAN and waved through. Only names with no
-    relationship to the remote domain are LAN.
+    OWNER is **this node's own** support hostname and nothing else. That is the
+    single name node-infra provisions, puts an Access application in front of,
+    and points at this node; it is the only name this gate has any business
+    challenging.
 
-    node_id is unused now that there is only one remote name to recognise. It
-    stays in the signature because the caller has it and a future scheme that
-    varies by node would want it back.
+    It used to be every name under the remote domain, to fail closed against a
+    stale record or a stray wildcard. That assumed the only name on the domain
+    reaching a node's port 80 would be its own. Untrue: hand-built hostnames
+    predate this feature and serve exactly that. They were swept into the remote
+    pathway, asked for a Cloudflare Access assertion no Access application
+    exists to issue, and sent to a password page that cannot be satisfied
+    because no password can be set. Locked out with no way back.
+
+    The old reasoning also overstated the danger. A name under the remote domain
+    is one *we* created, in our own zone; it is our mistake to make, not an
+    attacker's to exploit. Treating an unrecognised one as LAN restores exactly
+    the behaviour it had before this feature existed.
+
+    Still fails closed where it genuinely cannot tell: with no node_id there is
+    no way to recognise our own hostname, so the old domain-wide rule applies
+    rather than waving the real support hostname through unauthenticated.
     """
     host = (host or "").split(":")[0].strip().rstrip(".").lower()
     domain = (domain or "").strip().rstrip(".").lower()
     if not host or not domain:
         return LAN
 
-    suffix = "." + domain
-    if host == domain or host.endswith(suffix):
-        return OWNER
-    return LAN
+    # Validated by shape, not merely by being non-empty. read_node_id() returns
+    # the string "Unknown" when /data/mender cannot be read, which is truthy: a
+    # bare emptiness check would take that as a real id, fail to match the
+    # hostname, and hand the actual support hostname out as LAN, unauthenticated.
+    node_id = (node_id or "").strip().rstrip(".").lower()
+    if not _NODE_ID_RE.match(node_id):
+        # Cannot identify our own hostname, so fall back to the blunt rule
+        # rather than risk serving the support hostname to anyone who asks.
+        return OWNER if host == domain or host.endswith("." + domain) else LAN
+
+    return OWNER if host == f"{node_id}.{domain}" else LAN
 
 
 def requires_presence(path):

--- a/templates/remote_denied.html
+++ b/templates/remote_denied.html
@@ -1,0 +1,62 @@
+{# Shown when a request reaches this node's support hostname without an Access
+   assertion this node could verify.
+
+   Deliberately does not extend base.html, for the same reason login.html does
+   not: the fleet bar and the Home/Config tabs are links to pages this visitor
+   has not been let into, and offering them invites a click that lands straight
+   back here, which reads as the node being broken.
+
+   This page exists because the gate used to redirect here to login.html
+   instead. No password can be set from the support pathway and the page offers
+   no way to set one, so that form could only ever refuse: somebody whose
+   assertion failed to verify was shown a password box rather than the reason,
+   with nothing to do but guess. Say what happened instead. #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Not verified · {{ node_id }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="/static/favicon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link href="/static/common.css" rel="stylesheet">
+    <style>
+        body{
+            min-height:100vh; margin:0; display:flex;
+            align-items:center; justify-content:center; padding:24px;
+            font-family:Inter,system-ui,sans-serif;
+        }
+        .denied{width:100%; max-width:440px;}
+        .denied h1{font-size:20px; font-weight:600; margin:0 0 4px;}
+        .denied .sub{font-size:13px; opacity:.7; margin:0 0 18px;}
+        .denied .node{font-family:"JetBrains Mono",monospace; font-size:12px; opacity:.6;}
+        .denied ul{font-size:13px; opacity:.8; line-height:1.6; padding-left:18px; margin:0 0 18px;}
+        .denied .hint{font-size:12.5px; opacity:.65; line-height:1.6;}
+        .denied code{font-family:"JetBrains Mono",monospace; font-size:12px;}
+    </style>
+</head>
+<body>
+<div class="denied">
+    <h1>This node could not verify you</h1>
+    <p class="sub">The request reached the node, but it carried no Cloudflare
+       Access assertion this node was able to check.</p>
+
+    <ul>
+        <li>If you signed in and still see this, the node may not yet have its
+            Access configuration, which arrives shortly after support access is
+            switched on.</li>
+        <li>If the node has been offline or its network is unsettled, it may not
+            have been able to fetch Cloudflare's signing keys.</li>
+        <li>Anyone on this node's own network can reach it directly, without
+            any of this.</li>
+    </ul>
+
+    <p class="hint">The node records the reason it refused. On the node:
+       <code>journalctl -u retina-gui | grep "Refusing an Access assertion"</code>
+    </p>
+
+    <p class="node">{{ node_id }}</p>
+</div>
+</body>
+</html>

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -339,31 +339,43 @@ def test_tunnel_unknown_off_a_node(tmp_path, monkeypatch):
     (f"{NODE_ID}.{DOMAIN}:443", OWNER),
     (f"{NODE_ID}.{DOMAIN}.", OWNER),
     (f"{NODE_ID}.{DOMAIN}".upper(), OWNER),
-    (f"{NODE_ID}.admin.{DOMAIN}", OWNER),
+    # Under the zone but not our own name, so no longer ours to challenge.
+    (f"{NODE_ID}.admin.{DOMAIN}", LAN),
     ("", LAN),
 ])
 def test_classify_host(host, expected):
     assert classify_host(host, NODE_ID, DOMAIN) == expected
 
 
-def test_unknown_names_on_the_remote_domain_fail_closed():
-    """Anything unrecognised under the zone must ask for a password, not be
-    mistaken for the LAN and waved through."""
-    assert classify_host(f"surprise.{DOMAIN}", NODE_ID, DOMAIN) == OWNER
-    assert classify_host(DOMAIN, NODE_ID, DOMAIN) == OWNER
+def test_unknown_names_on_the_remote_domain_are_not_ours():
+    """Narrowed deliberately. These used to be gated, which swept up hostnames
+    we built by hand and have served unauthenticated for months: they were asked
+    for an Access assertion no application exists to issue, and sent to a
+    password page that cannot be satisfied.
+
+    A name under this zone is one *we* created, in our own zone. It is our
+    mistake to make rather than an attacker's to exploit, and treating it as LAN
+    restores exactly what it did before this feature existed."""
+    assert classify_host(f"surprise.{DOMAIN}", NODE_ID, DOMAIN) == LAN
+    assert classify_host(DOMAIN, NODE_ID, DOMAIN) == LAN
 
 
-def test_every_name_under_the_zone_needs_the_password():
-    """There is no staff hostname any more, so nothing under the zone is exempt."""
+def test_only_our_own_hostname_is_the_remote_pathway():
+    """Including another node's: reaching us on a sibling's name is not us, and
+    challenging for an audience we can never match helps nobody."""
     for host in (f"ret9f2b1e44.{DOMAIN}", f"anything.{DOMAIN}",
-                 f"{NODE_ID}.admin.{DOMAIN}"):
-        assert classify_host(host, NODE_ID, DOMAIN) == OWNER
+                 f"{NODE_ID}.admin.{DOMAIN}", f"{NODE_ID}-ui.{DOMAIN}"):
+        assert classify_host(host, NODE_ID, DOMAIN) == LAN, host
+    assert classify_host(f"{NODE_ID}.{DOMAIN}", NODE_ID, DOMAIN) == OWNER
 
 
 def test_an_unreadable_node_id_does_not_open_the_owner_path():
     """read_node_id() returns 'Unknown' when /data/mender is missing. That must
     not turn the tunnel hostname into an unauthenticated one."""
     assert classify_host(f"{NODE_ID}.{DOMAIN}", "Unknown", DOMAIN) == OWNER
+    # And anything else that is not a node id: empty, None, junk.
+    for bad in ("", None, "not-a-node-id", "ret123"):
+        assert classify_host(f"{NODE_ID}.{DOMAIN}", bad, DOMAIN) == OWNER, bad
 
 
 def test_a_mender_port_forward_counts_as_local():
@@ -855,3 +867,68 @@ def test_the_lan_still_builds_port_links(home):
     body = home()
     assert "var isRemote = false;" in body
     assert "window.location.hostname + \':\' + el.dataset.port" in body
+
+
+# ── which names are the remote pathway ───────────────────────────
+#
+# Only this node's own support hostname. It used to be every name under the
+# remote domain, which swept up hand-built hostnames that predate the feature:
+# they were gated, asked for an Access assertion no application exists to issue,
+# and sent to a password page that cannot be satisfied.
+
+def test_this_nodes_own_hostname_is_the_remote_pathway():
+    assert classify_host(f"{NODE_ID}.{DOMAIN}", NODE_ID, DOMAIN) == OWNER
+
+
+def test_another_name_on_the_domain_is_not_gated():
+    """The regression. These are hostnames we built by hand and have served
+    unauthenticated for months; the feature must not claim them."""
+    for host in (f"{NODE_ID}-ui.{DOMAIN}", "jonathan-node-1-ui." + DOMAIN,
+                 "jonathan-node-1." + DOMAIN, DOMAIN):
+        assert classify_host(host, NODE_ID, DOMAIN) == LAN, host
+
+
+def test_another_nodes_hostname_is_not_our_remote_pathway():
+    """Reaching us on a sibling's name is not us. Treating it as OWNER would
+    have this node challenge for an audience it can never match."""
+    assert classify_host(f"ret00000000.{DOMAIN}", NODE_ID, DOMAIN) == LAN
+
+
+def test_the_lan_is_unchanged():
+    for host in ("owl.local", f"{NODE_ID}.local", "localhost", "192.168.0.10"):
+        assert classify_host(host, NODE_ID, DOMAIN) == LAN, host
+
+
+def test_without_a_node_id_it_falls_back_to_the_blunt_rule():
+    """Fail closed where it genuinely cannot tell. With no node_id there is no
+    way to recognise our own hostname, and serving the real support hostname
+    unauthenticated would be far worse than over-challenging."""
+    assert classify_host(f"{NODE_ID}.{DOMAIN}", "", DOMAIN) == OWNER
+    assert classify_host(f"anything.{DOMAIN}", None, DOMAIN) == OWNER
+    assert classify_host("owl.local", "", DOMAIN) == LAN
+
+
+# ── where a failed verification lands ────────────────────────────
+
+def test_a_failed_verification_explains_itself(client):
+    """Not the password form. No password can be set from this pathway and the
+    page offers no way to set one, so redirecting there could only ever refuse
+    and told the visitor nothing.
+
+    Uses `client`, not `live`: the live fixture sets a password, which is the
+    one case where the form is still the right destination."""
+    client.remote_access.set_enabled(True)
+    r = client.get("/", base_url=OWNER_URL)
+    assert r.status_code == 403
+    body = r.get_data(as_text=True)
+    assert "could not verify you" in body
+    assert "password" not in body.lower()
+
+
+def test_the_password_form_is_still_offered_once_one_exists(live):
+    """The deferred owner-password design still works the moment a password is
+    set (the live fixture sets one). It is simply no longer where failures
+    land."""
+    r = live.get("/", base_url=OWNER_URL)
+    assert r.status_code == 302
+    assert "/login" in r.headers["Location"]


### PR DESCRIPTION
Two fixes for one bug, found when hand-built hostnames stopped working after remote support access shipped in `owl-os-pi5-v0.16.1`.

## What broke

`jonathan-node-1-ui.retnode.com` and `-2-ui` serve the GUI on port 80 and have done for months, unauthenticated. There is no Cloudflare Access application in front of them and never was.

`classify_host` treated **every** name under the remote domain as the remote pathway, so those hostnames were gated, asked for an Access assertion nothing exists to issue, and redirected to the password page. That page cannot be satisfied: no password can be set from that pathway, and the UI offers no way to set one. The result was a login box, no explanation, and no way through.

## Fix 1: only our own hostname is the remote pathway

OWNER is now `<node_id>.<domain>` and nothing else, which is the one name node-infra provisions, puts an Access application in front of, and points at this node. Everything else under the domain behaves exactly as it did before the feature existed.

The old rule existed to fail closed against a stale record or a stray wildcard, and it overstated the danger: a name under this zone is one **we** created, in our own zone. It is our mistake to make rather than an attacker's to exploit.

**It still fails closed where it genuinely cannot tell.** `node_id` is validated by shape rather than by being non-empty, because `read_node_id()` returns the string `"Unknown"` when `/data/mender` cannot be read. A bare emptiness check would take that as a real id, fail to match the hostname, and hand the actual support hostname out as LAN — unauthenticated. An existing test caught precisely that while I was writing this, which is the best argument for the test that I can offer.

## Fix 2: a failed verification no longer lands on the password form

Redirecting there could only ever refuse, and told the visitor nothing about what had happened. It now renders a page saying the assertion could not be verified, the usual causes, and where the node records the reason (`journalctl -u retina-gui | grep "Refusing an Access assertion"`).

The form is still offered the moment a password exists, so the deferred owner-password design is untouched and works as before.

## Worth knowing

The login page has always been reachable on the LAN too. `http://owl.local/login` returns 200 today, and `POST /remote-access/password` from the LAN returns 200 as well. Nothing surfaces either, so nobody finds them. That is unchanged by this PR, but it is the argument for eventually removing the form altogether rather than leaving a password path nothing exposes. Raised separately; not decided.

## Testing

856 tests passing. New coverage for which names are the remote pathway, the fallback when the node id is unreadable, and where a failed verification lands. Four existing tests encoded the old broad rule and were rewritten to the new intent rather than deleted, since what they were protecting still matters in the fallback case.

Deployed live to both affected nodes ahead of this PR to unblock development; both `-ui` hostnames now return 200 while the support hostnames still redirect to Access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)