### PR TITLE
20260903 - Highlight the location field that failed validation

### DIFF
--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -181,11 +181,12 @@ def _location_errors(location_flat):
     if not missing or len(missing) == len(LOCATION_COORDINATE_FIELDS):
         return {}
 
-    # Form-level rather than per-field: the location block in config.html is
-    # hand-rendered and does not look up config_errors, so per-field keys would
-    # re-render the page with nothing highlighted and no explanation. It also
-    # reads better as one sentence than as five lit-up boxes, because the rule
-    # is about the group.
+    # Form-level rather than per-field, and now a choice rather than a
+    # constraint. The location inputs do consult config_errors since the
+    # highlight fix, so per-field keys would mark the right boxes if we sent
+    # them. They are not sent because the rule is about the group: one sentence
+    # naming what is missing says it better than up to five separately lit
+    # fields each repeating the same all-or-nothing complaint.
     return {"_form": (
         "A location needs all six coordinates or none. Missing: "
         + ", ".join(f.replace("_", " ") for f in missing)

--- a/src/routes/towers.py
+++ b/src/routes/towers.py
@@ -15,6 +15,53 @@ bp = Blueprint('towers', __name__, url_prefix='/towers')
 MAX_CACHED_TOWERS = 5
 
 
+def _cacheable_towers(towers):
+    """Screen finder results before they back /config's preset picker.
+
+    Picking a preset assigns straight into the location inputs with
+    `el.value = ...`. maxlength does not constrain a programmatic assignment
+    and the validity flag it would otherwise raise is ignored because the form
+    is novalidate, so an over-long or out-of-range tower lands in the form
+    intact and the save then fails on a field the owner never touched. Manual
+    adds are already screened in cache_add; this is the same screen on the
+    search path, which until now cached whatever the service returned.
+
+    Auto-Calibrate reads the same cache as its alternate-tower list, and a
+    tower whose coordinates cannot be a position is no use to either caller.
+    """
+    from app import app
+
+    kept = []
+    for tower in towers:
+        if not isinstance(tower, dict):
+            continue
+        try:
+            latitude = float(tower.get("latitude"))
+            longitude = float(tower.get("longitude"))
+        except (TypeError, ValueError):
+            continue
+        if not (-90 <= latitude <= 90) or not (-180 <= longitude <= 180):
+            continue
+        # Names are trimmed rather than dropped: TX_NAME_MAX_LENGTH is
+        # retina-telemetry's tx_callsign limit, not a reason to lose an
+        # otherwise usable tower. Both keys are trimmed because the picker
+        # falls back callsign -> name, and a facility name runs long far more
+        # readily than a callsign does.
+        trimmed = dict(tower)
+        for key in ("callsign", "name"):
+            value = trimmed.get(key)
+            if isinstance(value, str) and len(value) > TX_NAME_MAX_LENGTH:
+                trimmed[key] = value[:TX_NAME_MAX_LENGTH]
+        kept.append(trimmed)
+
+    if len(kept) != len(towers):
+        app.logger.warning(
+            f"Dropped {len(towers) - len(kept)} tower search result(s) with "
+            "unusable coordinates before caching"
+        )
+    return kept
+
+
 @bp.route("/search", methods=["POST"])
 def search():
     """Proxy RF-profile tower search to retina-server API."""
@@ -68,7 +115,7 @@ def search():
             )
         resp.raise_for_status()
         result = resp.json()
-        towers = result.get("towers") or []
+        towers = _cacheable_towers(result.get("towers") or [])
         if towers:
             try:
                 device_state.save_towers_cache(body["lat"], body["lon"], towers[:MAX_CACHED_TOWERS])

--- a/static/common.css
+++ b/static/common.css
@@ -437,6 +437,18 @@ h1, h2, h3, h4, h5, h6 {
 }
 .ds-input.mono { font-family: var(--font-mono); }
 
+/* Invalid state. Bootstrap's own .is-invalid rules are all scoped to
+   .form-control / .form-select / .form-check-input, so the class the config
+   page sets on its .ds-input boxes drew nothing at all and "Please fix the
+   highlighted fields below" pointed at an unmarked form. */
+.ds-input.is-invalid, .ds-select.is-invalid, .ds-textarea.is-invalid {
+    border-color: var(--danger);
+}
+.ds-input.is-invalid:focus, .ds-select.is-invalid:focus, .ds-textarea.is-invalid:focus {
+    border-color: var(--danger);
+    box-shadow: 0 0 0 3px oklch(0.62 0.20 25 / 0.14);
+}
+
 /* ══════════════════════════════════════════════
    SWITCH
    ══════════════════════════════════════════════ */

--- a/templates/config.html
+++ b/templates/config.html
@@ -217,28 +217,54 @@
                 <span class="desc">Receiver and transmitter coordinates used by the geometry solver.</span>
             </div>
             <div class="cfg-body" {% if not retina_installed %}style="opacity:.5;pointer-events:none;"{% endif %}>
+                {# This section is hand-built rather than rendered through the
+                   render_field macro, so every input has to look config_errors
+                   up itself. Without that the banner above claims the bad
+                   fields are highlighted and none of them are. All eight are
+                   wired, not just the five that can fail today, so a future
+                   constraint cannot reintroduce the invisibility silently. #}
+                {% set rx_name_err = config_errors.get('location.rx_name') if config_errors else none %}
+                {% set rx_lat_err  = config_errors.get('location.rx_latitude') if config_errors else none %}
+                {% set rx_lon_err  = config_errors.get('location.rx_longitude') if config_errors else none %}
+                {% set rx_alt_err  = config_errors.get('location.rx_altitude') if config_errors else none %}
+                {% set tx_name_err = config_errors.get('location.tx_name') if config_errors else none %}
+                {% set tx_lat_err  = config_errors.get('location.tx_latitude') if config_errors else none %}
+                {% set tx_lon_err  = config_errors.get('location.tx_longitude') if config_errors else none %}
+                {% set tx_alt_err  = config_errors.get('location.tx_altitude') if config_errors else none %}
                 <div class="ds-label-micro" style="margin-bottom:10px;">Receiver</div>
                 <div class="cfg-grid" style="margin-bottom:0;">
                     <div style="grid-column:1/-1;" class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Name</label><span class="help">{{ loc.rx_name.description if loc.rx_name else '' }}</span></div>
-                        <div><input type="text" name="location.rx_name" class="ds-input" value="{{ loc.rx_name.value or '' if loc.rx_name else '' }}"></div>
+                        <div>
+                            <input type="text" name="location.rx_name" class="ds-input{% if rx_name_err %} is-invalid{% endif %}" value="{{ loc.rx_name.value or '' if loc.rx_name else '' }}">
+                            {% if rx_name_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ rx_name_err }}</div>{% endif %}
+                        </div>
                     </div>
                     {% if loc.rx_latitude %}
                     <div class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Latitude</label><span class="help">{{ loc.rx_latitude.description }}</span></div>
-                        <div><input type="number" name="location.rx_latitude" class="ds-input mono" step="any" min="-90" max="90" value="{{ loc.rx_latitude.value if loc.rx_latitude.value is not none else '' }}"></div>
+                        <div>
+                            <input type="number" name="location.rx_latitude" class="ds-input mono{% if rx_lat_err %} is-invalid{% endif %}" step="any" min="-90" max="90" value="{{ loc.rx_latitude.value if loc.rx_latitude.value is not none else '' }}">
+                            {% if rx_lat_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ rx_lat_err }}</div>{% endif %}
+                        </div>
                     </div>
                     {% endif %}
                     {% if loc.rx_longitude %}
                     <div class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Longitude</label><span class="help">{{ loc.rx_longitude.description }}</span></div>
-                        <div><input type="number" name="location.rx_longitude" class="ds-input mono" step="any" min="-180" max="180" value="{{ loc.rx_longitude.value if loc.rx_longitude.value is not none else '' }}"></div>
+                        <div>
+                            <input type="number" name="location.rx_longitude" class="ds-input mono{% if rx_lon_err %} is-invalid{% endif %}" step="any" min="-180" max="180" value="{{ loc.rx_longitude.value if loc.rx_longitude.value is not none else '' }}">
+                            {% if rx_lon_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ rx_lon_err }}</div>{% endif %}
+                        </div>
                     </div>
                     {% endif %}
                     {% if loc.rx_altitude %}
                     <div class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Altitude</label><span class="help">{{ loc.rx_altitude.description }}</span></div>
-                        <div class="cfg-input-row"><input type="number" name="location.rx_altitude" class="ds-input mono" step="any" value="{{ loc.rx_altitude.value if loc.rx_altitude.value is not none else '' }}"><span class="unit">m</span></div>
+                        <div>
+                            <div class="cfg-input-row"><input type="number" name="location.rx_altitude" class="ds-input mono{% if rx_alt_err %} is-invalid{% endif %}" step="any" value="{{ loc.rx_altitude.value if loc.rx_altitude.value is not none else '' }}"><span class="unit">m</span></div>
+                            {% if rx_alt_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ rx_alt_err }}</div>{% endif %}
+                        </div>
                     </div>
                     {% endif %}
                 </div>
@@ -249,24 +275,36 @@
                 <div class="cfg-grid">
                     <div style="grid-column:1/-1;" class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Name</label><span class="help">{{ loc.tx_name.description if loc.tx_name else '' }}</span></div>
-                        <div><input type="text" name="location.tx_name" class="ds-input" maxlength="32" value="{{ loc.tx_name.value or '' if loc.tx_name else '' }}"></div>
+                        <div>
+                            <input type="text" name="location.tx_name" class="ds-input{% if tx_name_err %} is-invalid{% endif %}" maxlength="32" value="{{ loc.tx_name.value or '' if loc.tx_name else '' }}">
+                            {% if tx_name_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ tx_name_err }}</div>{% endif %}
+                        </div>
                     </div>
                     {% if loc.tx_latitude %}
                     <div class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Latitude</label><span class="help">{{ loc.tx_latitude.description }}</span></div>
-                        <div><input type="number" name="location.tx_latitude" class="ds-input mono" step="any" min="-90" max="90" value="{{ loc.tx_latitude.value if loc.tx_latitude.value is not none else '' }}"></div>
+                        <div>
+                            <input type="number" name="location.tx_latitude" class="ds-input mono{% if tx_lat_err %} is-invalid{% endif %}" step="any" min="-90" max="90" value="{{ loc.tx_latitude.value if loc.tx_latitude.value is not none else '' }}">
+                            {% if tx_lat_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ tx_lat_err }}</div>{% endif %}
+                        </div>
                     </div>
                     {% endif %}
                     {% if loc.tx_longitude %}
                     <div class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Longitude</label><span class="help">{{ loc.tx_longitude.description }}</span></div>
-                        <div><input type="number" name="location.tx_longitude" class="ds-input mono" step="any" min="-180" max="180" value="{{ loc.tx_longitude.value if loc.tx_longitude.value is not none else '' }}"></div>
+                        <div>
+                            <input type="number" name="location.tx_longitude" class="ds-input mono{% if tx_lon_err %} is-invalid{% endif %}" step="any" min="-180" max="180" value="{{ loc.tx_longitude.value if loc.tx_longitude.value is not none else '' }}">
+                            {% if tx_lon_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ tx_lon_err }}</div>{% endif %}
+                        </div>
                     </div>
                     {% endif %}
                     {% if loc.tx_altitude %}
                     <div class="cfg-row" style="padding:0;border:0;">
                         <div class="label-col"><label>Altitude</label><span class="help">{{ loc.tx_altitude.description }}</span></div>
-                        <div class="cfg-input-row"><input type="number" name="location.tx_altitude" class="ds-input mono" step="any" value="{{ loc.tx_altitude.value if loc.tx_altitude.value is not none else '' }}"><span class="unit">m</span></div>
+                        <div>
+                            <div class="cfg-input-row"><input type="number" name="location.tx_altitude" class="ds-input mono{% if tx_alt_err %} is-invalid{% endif %}" step="any" value="{{ loc.tx_altitude.value if loc.tx_altitude.value is not none else '' }}"><span class="unit">m</span></div>
+                            {% if tx_alt_err %}<div style="color:var(--danger);font-size:12px;margin-top:4px;">{{ tx_alt_err }}</div>{% endif %}
+                        </div>
                     </div>
                     {% endif %}
                 </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -417,7 +417,12 @@ class TestLocationSave:
         assert saved['location']['rx']['name'] == 'NYC'
 
     def test_save_invalid_latitude(self, app_client):
-        """Invalid latitude should show error banner."""
+        """An out-of-range latitude marks its own box and says why.
+
+        Asserting only the banner is what let this go unnoticed: the location
+        block never consulted config_errors, so the page came back telling the
+        owner to fix the highlighted fields with nothing highlighted anywhere.
+        """
         response = app_client.post('/config/save', data={
             'location.rx_latitude': '100',  # Invalid > 90
             'location.rx_longitude': '-74.0',
@@ -430,9 +435,13 @@ class TestLocationSave:
         })
         assert response.status_code == 200
         assert b'Please fix the highlighted fields below' in response.data
+        assert b'name="location.rx_latitude" class="ds-input mono is-invalid"' in response.data
+        assert b'less than or equal to 90' in response.data
+        # Only the offending box, not a blanket highlight over the section.
+        assert b'name="location.rx_longitude" class="ds-input mono is-invalid"' not in response.data
 
     def test_save_invalid_longitude(self, app_client):
-        """Invalid longitude should show error banner."""
+        """An out-of-range longitude marks its own box and says why."""
         response = app_client.post('/config/save', data={
             'location.rx_latitude': '40.0',
             'location.rx_longitude': '200',  # Invalid > 180
@@ -445,6 +454,47 @@ class TestLocationSave:
         })
         assert response.status_code == 200
         assert b'Please fix the highlighted fields below' in response.data
+        assert b'name="location.rx_longitude" class="ds-input mono is-invalid"' in response.data
+        assert b'less than or equal to 180' in response.data
+        assert b'name="location.rx_latitude" class="ds-input mono is-invalid"' not in response.data
+
+    def test_save_overlong_transmitter_name(self, app_client):
+        """An over-length transmitter name marks its own box.
+
+        maxlength on the input constrains typing, not the programmatic
+        assignment the Tower preset picker makes, and the form is novalidate,
+        so this arrives without the owner having typed anything wrong.
+        """
+        response = app_client.post('/config/save', data={
+            'location.rx_latitude': '40.0',
+            'location.rx_longitude': '-74.0',
+            'location.rx_altitude': '10',
+            'location.rx_name': 'Test',
+            'location.tx_latitude': '40.0',
+            'location.tx_longitude': '-74.0',
+            'location.tx_altitude': '100',
+            'location.tx_name': 'A' * 33,
+        })
+        assert response.status_code == 200
+        assert b'Please fix the highlighted fields below' in response.data
+        assert b'name="location.tx_name" class="ds-input is-invalid"' in response.data
+        assert b'at most 32 characters' in response.data
+
+    def test_save_invalid_transmitter_coordinates_are_highlighted(self, app_client):
+        """The transmitter half of the section is wired up too."""
+        response = app_client.post('/config/save', data={
+            'location.rx_latitude': '40.0',
+            'location.rx_longitude': '-74.0',
+            'location.rx_altitude': '10',
+            'location.rx_name': 'Test',
+            'location.tx_latitude': '442.2',
+            'location.tx_longitude': '-74.0',
+            'location.tx_altitude': '100',
+            'location.tx_name': 'Transmitter',
+        })
+        assert response.status_code == 200
+        assert b'name="location.tx_latitude" class="ds-input mono is-invalid"' in response.data
+        assert b'less than or equal to 90' in response.data
 
 
 class TestTar1090Save:

--- a/tests/test_towers.py
+++ b/tests/test_towers.py
@@ -167,6 +167,92 @@ class TestTowerSearch:
         assert len(cached['towers']) == 5
         assert [t['callsign'] for t in cached['towers']] == ['T0', 'T1', 'T2', 'T3', 'T4']
 
+    @patch('routes.towers.http_requests.get')
+    def test_search_trims_an_overlong_name_before_caching(self, mock_get, app_client):
+        """Picking a preset assigns straight into location.tx_name, which
+        maxlength does not constrain and novalidate does not catch, so an
+        over-long finder result would fail the save with no user mistake."""
+        import app as app_module
+        from config_schema import TX_NAME_MAX_LENGTH
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"towers": [{
+            "callsign": "C" * 40,
+            "name": "Some Very Long Broadcast Facility Name Indeed",
+            "frequency_mhz": 177.5,
+            "latitude": -33.82,
+            "longitude": 151.185,
+        }], "count": 1}
+        mock_get.return_value = mock_resp
+
+        app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
+
+        cached = app_module.device_state.get_towers_cache()['towers'][0]
+        assert cached['callsign'] == 'C' * TX_NAME_MAX_LENGTH
+        # Trimmed too: the picker falls back callsign -> name, and a facility
+        # name runs long far more readily than a callsign does.
+        assert len(cached['name']) == TX_NAME_MAX_LENGTH
+
+    @patch('routes.towers.http_requests.get')
+    def test_search_drops_towers_with_unusable_coordinates(self, mock_get, app_client):
+        """A tower whose position cannot be a position is no use to the preset
+        picker or to Auto-Calibrate's alternate-tower list."""
+        import app as app_module
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"towers": [
+            {"callsign": "BAD_LAT", "frequency_mhz": 100.0, "latitude": 442.2, "longitude": 151.0},
+            {"callsign": "BAD_LON", "frequency_mhz": 101.0, "latitude": -33.8, "longitude": 999.0},
+            {"callsign": "NO_POS", "frequency_mhz": 102.0},
+            {"callsign": "GOOD", "frequency_mhz": 103.0, "latitude": -33.8, "longitude": 151.0},
+        ], "count": 4}
+        mock_get.return_value = mock_resp
+
+        resp = app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
+
+        # The wizard's own response is untouched; only the cache is screened.
+        assert len(resp.get_json()['towers']) == 4
+
+        cached = app_module.device_state.get_towers_cache()
+        assert [t['callsign'] for t in cached['towers']] == ['GOOD']
+
+    @patch('routes.towers.http_requests.get')
+    def test_search_keeps_the_best_few_after_screening(self, mock_get, app_client):
+        """Screening runs before the cap, so a dropped result does not cost a
+        slot in the picker."""
+        import app as app_module
+        towers = [{"callsign": "BAD", "frequency_mhz": 99.0, "latitude": 442.2, "longitude": 0}]
+        towers += [{"callsign": f"T{i}", "frequency_mhz": 100.0 + i, "latitude": 0, "longitude": 0}
+                   for i in range(10)]
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"towers": towers, "count": len(towers)}
+        mock_get.return_value = mock_resp
+
+        app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
+
+        cached = app_module.device_state.get_towers_cache()
+        assert [t['callsign'] for t in cached['towers']] == ['T0', 'T1', 'T2', 'T3', 'T4']
+
+    @patch('routes.towers.http_requests.get')
+    def test_search_does_not_clear_the_cache_when_nothing_survives(self, mock_get, app_client):
+        """Same rule as an empty response: a stale cache beats no cache."""
+        import app as app_module
+        app_module.device_state.save_towers_cache(0, 0, [
+            {"callsign": "KEEP", "frequency_mhz": 100.0, "latitude": 0, "longitude": 0},
+        ])
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"towers": [
+            {"callsign": "BAD", "frequency_mhz": 99.0, "latitude": 442.2, "longitude": 0},
+        ], "count": 1}
+        mock_get.return_value = mock_resp
+
+        app_client.post('/towers/search', json={'lat': -33.8688, 'lon': 151.2093})
+
+        cached = app_module.device_state.get_towers_cache()
+        assert [t['callsign'] for t in cached['towers']] == ['KEEP']
+
 
 class TestTowerCacheAdd:
     """Tests for POST /towers/cache/add route."""


### PR DESCRIPTION
Closes ClickUp [86cb9dnfq](https://app.clickup.com/t/86cb9dnfq).

Submitting an out-of-range coordinate in the Location section of `/config` came back as "Please fix the highlighted fields below" with nothing highlighted anywhere on the page, and the bad value still sitting in its box. Same defect class as the tar1090 one fixed in #69, in the section that PR deliberately left alone.

## What changed

**1. The location inputs read `config_errors`.** The block is hand-built markup rather than the `render_field` macro, so it never consulted the errors `save_config` was building and passing all along. All eight fields are wired, not just the five that can fail today, so a future constraint cannot reintroduce the invisibility silently.

**2. `.is-invalid` now actually draws something.** Bootstrap 5.3's rules for that class are all scoped to `.form-control` / `.form-select` / `.form-check-input`, and these boxes are `.ds-input`, so the class every section has set since the macro was written has never marked a border. The inline red message was doing all the work. This is broader than the ticket: it affects capture, truth, tar1090 and tracker failures too, which are more commonly hit than a coordinate typo. The banner can now promise a highlight and be telling the truth.

**3. Tower search results are screened before they reach the cache** backing `/config`'s preset picker. Names are trimmed to `TX_NAME_MAX_LENGTH` and unusable coordinates dropped, matching the screen `cache_add` has always had. Screening runs before the `MAX_CACHED_TOWERS` cap so a dropped result does not cost a slot, and nothing is written when nothing survives, on the same reasoning as an empty response.

Being straight about item 3: I sampled 452 real towers from the live finder across every supported region (AU, US; CA returns no data, UK is out of region) and **every one has a callsign, the longest 9 characters, none over 32**. The `callsign || name` fallback this guards does not fire against live data. It is insurance against the finder's data changing or a new region landing, not a fix for something happening today. Kept because it is inert when data is clean and it closes the one path into this failure that needs no user mistake at all.

## Live verification on a node

Tested on owl-ded9 (identity confirmed by wlan0 MAC, not hostname). Production install untouched throughout: `/opt/retina-gui` is root-owned and the node has no passwordless sudo, so I ran two instances as an unprivileged user via the env-overridable paths. Port 8098 was a pristine copy of the deployed tree at `e80305f`; port 8099 was the same tree plus this patch. Same Python 3.11.2, same pydantic 1.10.4, same copies of the real config. The patch applies cleanly to what is deployed today.

Driving a real Chromium at the node, typing `442.2` into receiver latitude and clicking Apply changes:

| | `rx_latitude` class | `rx_latitude` border | `rx_longitude` border |
|---|---|---|---|
| Before | `ds-input mono` | `oklch(0.93 0.005 75)` | `oklch(0.93 0.005 75)` |
| After | `ds-input mono is-invalid` | `oklch(0.62 0.2 25)` = `--danger` | `oklch(0.93 0.005 75)` |

Before, the offending field is pixel-identical to its neighbour. After, only it is marked, with "ensure this value is less than or equal to 90" beneath it.

Server-side A/B on the same pair, covering `rx_latitude` (442.2), `tx_name` (40 chars) and `tx_longitude` (999): before, `is-invalid` count across the whole page is 0 with no message; after it is 1, on the right field, with the message. A valid location still returns 302 and saves.

The tower screen against a stub finder returning one over-long name, one impossible latitude and one clean tower: the wizard's own response stays at 3 towers, the cache goes from 3 to 2 with the name trimmed to 32. Selecting that cached preset and saving goes from an invisible refusal to a 302.

## Tests

`test_save_invalid_latitude` asserted only the banner string and passed for as long as the bug existed. It and its longitude sibling now assert the marked input and the message, and that the neighbouring field is not marked. Added cases for over-length `tx_name` and the transmitter coordinates, plus four cache-screening tests. All eight fail against the unpatched tree and pass with it, so none are vacuous.

The message substrings (`less than or equal to 90`, `at most 32 characters`) are the fragments common to pydantic 1.10.4 and 2.x, confirmed against the node's actual 1.10.4 output during the live run.

Full suite: 855 passed. `ruff check` clean.

## Deliberately unchanged

The partial-location rule still routes to `_form`. Fixing the template frees it to go per-field, but the comment at `src/routes/config.py:185` gives an independent reason to keep it as one sentence, since the rule is about the group rather than any one box.

The tower section, which the ticket lists as unaudited, resolves as not applicable: no `name="tower.*"` inputs exist, `parse_flat_form_data` returns only capture/location/truth/tar1090/retina_tracker, and the block is a client-side preset picker with its own error div.

The ticket's suggested general guard, folding `config_errors` keys that match no rendered field into the banner, is not included. Every key is renderable now, so it would only defend the future, and doing it properly means enumerating renderable field names server-side. Easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
