### PR TITLE
20260903 - Resources, Help, and a flight path simulator on the Summary page

### DIFF
--- a/src/routes/fleet.py
+++ b/src/routes/fleet.py
@@ -38,7 +38,20 @@ def _resource(name, url, icon):
     one of these leaves the device: an owner should be able to see they are
     about to be sent to github.com before they click, not after.
     """
-    return {"name": name, "url": url, "icon": icon, "host": urlsplit(url).netloc}
+    return {"name": name, "url": url, "icon": icon,
+            "host": urlsplit(url).netloc, "external": True}
+
+
+def _mailto(name, address):
+    """A support address, as a card.
+
+    Not marked external: it opens a mail client rather than a page, and the
+    outbound arrow in this interface means "this leaves for another page".
+    The address itself goes where a host would, because it is the thing
+    somebody needs to read, and possibly to type somewhere else.
+    """
+    return {"name": name, "url": "mailto:" + address, "icon": "mail",
+            "host": address, "external": False}
 
 
 # Where the full, driveable primer lives. Empty until it is published: the
@@ -56,6 +69,17 @@ RESOURCES = (
               "book"),
     _resource("Retina Network Map", "https://map.retina.fm", "map"),
     _resource("Retina Dashboard", "https://dash.retina.fm", "chart"),
+)
+
+# Where to go when something is wrong.
+#
+# The Discord is the blah2 project's own community server, and it is named
+# here for what it actually is. Calling it ours would send an owner with a
+# hardware or account problem into a volunteer channel expecting Offworld Labs
+# support, and land that community with questions it cannot answer.
+HELP = (
+    _resource("blah2 Discord", "https://discord.gg/ewNQbeK5Zn", "chat"),
+    _mailto("Email us", "info@offworldlabs.com"),
 )
 
 # The one telemetry state with nothing to say for itself. Everything else gets
@@ -237,6 +261,7 @@ def summary():
                            active_page="summary",
                            cards=[card_view(p) for p in discovered_nodes()],
                            resources=RESOURCES,
+                           help_links=HELP,
                            primer_url=PRIMER_URL,
                            buy_url=BUY_URL)
 

--- a/src/routes/fleet.py
+++ b/src/routes/fleet.py
@@ -20,14 +20,37 @@ nice-to-have, and a nice-to-have that polls the fleet would not be worth
 having.
 """
 
+from urllib.parse import urlsplit
+
 from flask import Blueprint, jsonify, render_template
 
 bp = Blueprint("fleet", __name__)
 
-# Where "Add another node" sends an owner with only one. A stand-in: there is
-# no store URL anywhere in the codebase yet, so this goes where the banner's
-# Server button goes until the real one is known.
-BUY_URL = "https://map.retina.fm"
+# Where "Add another node" sends an owner with only one.
+BUY_URL = "https://retina.fm"
+
+
+def _resource(name, url, icon):
+    """One Resources card.
+
+    The host is derived rather than written out, so the line under the name
+    cannot drift from where the card actually goes. It is there because every
+    one of these leaves the device: an owner should be able to see they are
+    about to be sent to github.com before they click, not after.
+    """
+    return {"name": name, "url": url, "icon": icon, "host": urlsplit(url).netloc}
+
+
+# Fixed links out, ordered by distance from the node: the company, the manual
+# for this box, then the two live views of the wider network.
+RESOURCES = (
+    _resource("Offworld Labs", "https://offworldlabs.com", "globe"),
+    _resource("Retina Wiki",
+              "https://github.com/offworldlabs/owl-os/wiki/4-Troubleshooting-and-Tuning",
+              "book"),
+    _resource("Retina Network Map", "https://map.retina.fm", "map"),
+    _resource("Retina Dashboard", "https://dash.retina.fm", "chart"),
+)
 
 # The one telemetry state with nothing to say for itself. Everything else gets
 # a chip, including states retina-telemetry grows later: an unfamiliar state
@@ -207,6 +230,7 @@ def summary():
     return render_template("summary.html",
                            active_page="summary",
                            cards=[card_view(p) for p in discovered_nodes()],
+                           resources=RESOURCES,
                            buy_url=BUY_URL)
 
 

--- a/src/routes/fleet.py
+++ b/src/routes/fleet.py
@@ -41,6 +41,12 @@ def _resource(name, url, icon):
     return {"name": name, "url": url, "icon": icon, "host": urlsplit(url).netloc}
 
 
+# Where the full, driveable primer lives. Empty until it is published: the
+# branch carrying it is unmerged, and offworldlabs.com/learn/ 404s today. A
+# dead link on an owner's node is worse than no link, so the template omits
+# the line entirely while this is blank, and turning it on is one string.
+PRIMER_URL = ""
+
 # Fixed links out, ordered by distance from the node: the company, the manual
 # for this box, then the two live views of the wider network.
 RESOURCES = (
@@ -231,6 +237,7 @@ def summary():
                            active_page="summary",
                            cards=[card_view(p) for p in discovered_nodes()],
                            resources=RESOURCES,
+                           primer_url=PRIMER_URL,
                            buy_url=BUY_URL)
 
 

--- a/static/common.css
+++ b/static/common.css
@@ -1206,3 +1206,7 @@ h1, h2, h3, h4, h5, h6 {
 .fact p { margin: 0; font-size: 13px; line-height: 1.6; color: var(--ink-2); }
 .facts-more { margin: 18px 0 0; font-size: 12.5px; color: var(--ink-3); }
 .facts-more a { color: var(--accent); text-decoration: none; font-weight: 500; }
+
+/* Help, between the links out and the reading matter. */
+.help-head { margin-top: 28px; }
+.help-lead { margin: -6px 0 12px; font-size: 13px; color: var(--ink-2); max-width: 62ch; }

--- a/static/common.css
+++ b/static/common.css
@@ -1189,3 +1189,20 @@ h1, h2, h3, h4, h5, h6 {
 }
 .link-arrow { flex: none; color: var(--ink-3); transition: transform .12s, color .12s; }
 .link-card:hover .link-arrow { color: var(--ink); transform: translate(1px, -1px); }
+
+/* Five facts about passive radar, below the links. Plain text rather than
+   cards: card-shaped things on this page are clickable, and these are not. */
+.facts-head { margin-top: 28px; }
+.facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+    gap: 20px 32px;
+}
+.fact h4 {
+    margin: 0 0 4px;
+    font-size: 13.5px; font-weight: 600; letter-spacing: -0.005em;
+    color: var(--ink);
+}
+.fact p { margin: 0; font-size: 13px; line-height: 1.6; color: var(--ink-2); }
+.facts-more { margin: 18px 0 0; font-size: 12.5px; color: var(--ink-3); }
+.facts-more a { color: var(--accent); text-decoration: none; font-weight: 500; }

--- a/static/common.css
+++ b/static/common.css
@@ -1200,8 +1200,10 @@ h1, h2, h3, h4, h5, h6 {
    ══════════════════════════════════════════════ */
 
 .sim-head { margin-top: 28px; }
+/* Full width, deliberately: it is the caption for the two panels below it,
+   so it reads as belonging to them rather than as a stray narrow column. */
 .sim-lead { margin: -6px 0 14px; font-size: 13px; line-height: 1.6;
-            color: var(--ink-2); max-width: 64ch; }
+            color: var(--ink-2); }
 
 .sim { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start; }
 @media (max-width: 760px) { .sim { grid-template-columns: 1fr; } }

--- a/static/common.css
+++ b/static/common.css
@@ -1190,23 +1190,58 @@ h1, h2, h3, h4, h5, h6 {
 .link-arrow { flex: none; color: var(--ink-3); transition: transform .12s, color .12s; }
 .link-card:hover .link-arrow { color: var(--ink); transform: translate(1px, -1px); }
 
-/* Five facts about passive radar, below the links. Plain text rather than
-   cards: card-shaped things on this page are clickable, and these are not. */
-.facts-head { margin-top: 28px; }
-.facts {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
-    gap: 20px 32px;
-}
-.fact h4 {
-    margin: 0 0 4px;
-    font-size: 13.5px; font-weight: 600; letter-spacing: -0.005em;
-    color: var(--ink);
-}
-.fact p { margin: 0; font-size: 13px; line-height: 1.6; color: var(--ink-2); }
-.facts-more { margin: 18px 0 0; font-size: 12.5px; color: var(--ink-3); }
-.facts-more a { color: var(--accent); text-decoration: none; font-weight: 500; }
 
 /* Help, between the links out and the reading matter. */
 .help-head { margin-top: 28px; }
 .help-lead { margin: -6px 0 12px; font-size: 13px; color: var(--ink-2); max-width: 62ch; }
+
+/* ══════════════════════════════════════════════
+   How your node sees: the flight path simulator
+   ══════════════════════════════════════════════ */
+
+.sim-head { margin-top: 28px; }
+.sim-lead { margin: -6px 0 14px; font-size: 13px; line-height: 1.6;
+            color: var(--ink-2); max-width: 64ch; }
+
+.sim { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start; }
+@media (max-width: 760px) { .sim { grid-template-columns: 1fr; } }
+
+.sim-panel { background: var(--surface); border: 1px solid var(--line);
+             border-radius: var(--r-md); padding: 10px 10px 8px; }
+.sim-label { margin: 0 0 6px; padding-left: 2px;
+             font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.07em;
+             color: var(--ink-3); font-weight: 600; }
+
+/* touch-action stops a drag across the sky scrolling the page on a phone. */
+.sim-scene { display: block; width: 100%; height: auto; touch-action: none;
+             user-select: none; -webkit-user-select: none; }
+#fs-map { cursor: crosshair; }
+
+.sim-base { stroke: var(--line); stroke-width: 1.4; }
+.sim-beam { fill: var(--accent); opacity: 0.08; }
+.sim-beam-edge { stroke: var(--accent-edge); stroke-width: 1; fill: none; }
+.sim-flightpath { stroke: var(--ink-3); stroke-width: 1.4; fill: none;
+                  stroke-dasharray: 3 3; opacity: 0.75; }
+.sim-track { stroke: var(--accent); stroke-width: 1.8; fill: none;
+             stroke-linecap: round; stroke-linejoin: round; }
+.sim-grid { stroke: var(--line-2); stroke-width: 1; }
+.sim-axis-label { font-family: var(--font-body); font-size: 10px; fill: var(--ink-3); }
+.sim-mark { fill: var(--ink-2); }
+.sim-grab { cursor: grab; }
+.sim-grab:active { cursor: grabbing; }
+
+.sim-controls { display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+                margin-top: 12px; }
+.sim-btn { font: inherit; font-size: 12.5px; font-weight: 500; cursor: pointer;
+           padding: 5px 13px; border-radius: var(--r-sm);
+           border: 1px solid var(--line); background: var(--surface); color: var(--ink-2); }
+.sim-btn:hover { border-color: var(--accent-edge); color: var(--accent); }
+.sim-btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.sim-btn.primary:hover { color: #fff; opacity: 0.92; }
+.sim-spacer { flex: 1; }
+.sim-readout { display: flex; gap: 16px; flex-wrap: wrap; font-size: 12px; }
+.sim-readout > span { display: flex; align-items: baseline; gap: 6px; }
+.sim-readout .k { color: var(--ink-3); }
+.sim-readout .v { font-family: var(--font-mono); font-weight: 500; color: var(--ink);
+                  font-variant-numeric: tabular-nums; }
+.sim-hint { margin: 10px 0 0; font-size: 11.5px; color: var(--ink-3); max-width: 64ch; }

--- a/static/common.css
+++ b/static/common.css
@@ -1141,3 +1141,51 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 14px; font-weight: 600; color: var(--ink);
 }
 .node-invite-sub { display: block; font-size: 12.5px; color: var(--ink-3); margin-top: 1px; }
+
+/* Fixed links out, below the nodes. */
+.resources-head { margin-top: 28px; }
+
+.link-card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    box-shadow: var(--shadow-sm);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color .12s, box-shadow .12s;
+}
+.link-card:hover { border-color: var(--accent-edge); box-shadow: var(--shadow-md); }
+
+.link-icon {
+    width: 34px; height: 34px; flex: none;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+    background: var(--surface-2);
+    display: grid; place-items: center;
+    color: var(--ink-2);
+    transition: color .12s, border-color .12s;
+}
+.link-card:hover .link-icon { color: var(--accent); border-color: var(--accent-edge); }
+
+.link-text { min-width: 0; flex: 1; }
+.link-name {
+    display: block;
+    font-size: 14.5px; font-weight: 600; letter-spacing: -0.005em;
+    color: var(--ink);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* Where the card actually goes, said before the click rather than after. */
+.link-host {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--ink-3);
+    margin-top: 1px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.link-arrow { flex: none; color: var(--ink-3); transition: transform .12s, color .12s; }
+.link-card:hover .link-arrow { color: var(--ink); transform: translate(1px, -1px); }

--- a/static/flight-sim.js
+++ b/static/flight-sim.js
@@ -1,0 +1,267 @@
+(function () {
+    "use strict";
+
+    var map = document.getElementById("fs-map");
+    // Inert anywhere the markup is absent, and on a browser that served the
+    // page but could not run this: the section is a still diagram either way.
+    if (!map || !window.SVGElement || !("PointerEvent" in window)) return;
+
+    var plot = document.getElementById("fs-plot");
+    var beam = document.getElementById("fs-beam"), beamEdge = document.getElementById("fs-beam-edge");
+    var pathEl = document.getElementById("fs-path"), planeEl = document.getElementById("fs-plane");
+    var trackEl = document.getElementById("fs-track"), live = document.getElementById("fs-live");
+    var aimKnob = document.getElementById("fs-aim"), hint = document.getElementById("fs-hint");
+    var playBtn = document.getElementById("fs-play"), clearBtn = document.getElementById("fs-clear");
+    var rOut = document.getElementById("fs-range"), fOut = document.getElementById("fs-doppler"), wOut = document.getElementById("fs-width");
+    var SVG = "http://www.w3.org/2000/svg";
+
+    var T = { x: 34, y: 186 }, N = { x: 212, y: 186 };
+    var aim = -Math.PI / 2, half = Math.PI / 3;      // 120° across, pointing up
+    var BASE = Math.hypot(T.x - N.x, T.y - N.y);
+    var KM = 0.18;                                    // 1 unit ≈ 0.18 km
+
+    // A gentle arc past the node, so the piece says something before anyone
+    // touches it. Redrawing replaces it.
+    var path = (function () {
+        var pts = [];
+        for (var i = 0; i <= 40; i++) {
+            var t = i / 40;
+            pts.push({ x: 20 + t * 265, y: 150 - Math.sin(t * Math.PI) * 96 });
+        }
+        return pts;
+    })();
+
+    var lengths = [], total = 0, travelled = 0, playing = false, raf = 0, last = 0;
+    var segments = [], current = null, drawing = false;
+    var REDUCED = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    function measure() {
+        lengths = [0]; total = 0;
+        for (var i = 1; i < path.length; i++) {
+            total += Math.hypot(path[i].x - path[i - 1].x, path[i].y - path[i - 1].y);
+            lengths.push(total);
+        }
+    }
+
+    function at(d) {
+        // Position and heading a distance d along the drawn path.
+        if (total <= 0) return null;
+        d = d % total;
+        var i = 1;
+        while (i < lengths.length && lengths[i] < d) i++;
+        var a = path[i - 1], b = path[i] || path[i - 1];
+        var span = (lengths[i] || total) - lengths[i - 1];
+        var f = span > 0 ? (d - lengths[i - 1]) / span : 0;
+        var hx = b.x - a.x, hy = b.y - a.y, h = Math.hypot(hx, hy) || 1;
+        return { x: a.x + hx * f, y: a.y + hy * f, hx: hx / h, hy: hy / h };
+    }
+
+    function inBeam(p) {
+        var delta = Math.atan2(p.y - N.y, p.x - N.x) - aim;
+        while (delta > Math.PI) delta -= 2 * Math.PI;
+        while (delta < -Math.PI) delta += 2 * Math.PI;
+        return Math.abs(delta) <= half;
+    }
+
+    // The two numbers the node actually measures.
+    function reading(p) {
+        var d1 = Math.hypot(p.x - T.x, p.y - T.y), d2 = Math.hypot(p.x - N.x, p.y - N.y);
+        var range = d1 + d2 - BASE;
+        // Doppler follows how fast both legs together are changing, so it is
+        // zero when the heading is perpendicular to the sum of the unit legs,
+        // which is not the same as perpendicular to the node.
+        var ux = (p.x - T.x) / d1 + (p.x - N.x) / d2;
+        var uy = (p.y - T.y) / d1 + (p.y - N.y) / d2;
+        return { range: range, hz: -(p.hx * ux + p.hy * uy) * 150 };
+    }
+
+    function drawBeam() {
+        var a1 = aim - half, a2 = aim + half, R = 200;
+        var p1 = { x: N.x + Math.cos(a1) * R, y: N.y + Math.sin(a1) * R };
+        var p2 = { x: N.x + Math.cos(a2) * R, y: N.y + Math.sin(a2) * R };
+        var d = "M" + N.x + " " + N.y + " L" + p1.x.toFixed(1) + " " + p1.y.toFixed(1) +
+                " A" + R + " " + R + " 0 " + (half > Math.PI / 2 ? 1 : 0) + " 1 " +
+                p2.x.toFixed(1) + " " + p2.y.toFixed(1) + " Z";
+        beam.setAttribute("d", d);
+        beamEdge.setAttribute("d", d);
+        aimKnob.setAttribute("transform",
+            "translate(" + (N.x + Math.cos(aim) * 70).toFixed(1) + " " + (N.y + Math.sin(aim) * 70).toFixed(1) + ")");
+        wOut.textContent = Math.round(half * 2 * 180 / Math.PI) + "°";
+    }
+
+    function drawPath() {
+        var d = "";
+        for (var i = 0; i < path.length; i++) d += (i ? "L" : "M") + path[i].x.toFixed(1) + " " + path[i].y.toFixed(1) + " ";
+        pathEl.setAttribute("d", d);
+    }
+
+    function resetTrack() {
+        while (trackEl.firstChild) trackEl.removeChild(trackEl.firstChild);
+        segments = []; current = null; travelled = 0;
+    }
+
+    // range → x, hertz → y, inside the plot box.
+    function place(reading) {
+        return {
+            x: Math.max(44, Math.min(280, 42 + reading.range * 1.35)),
+            y: Math.max(16, Math.min(180, 98 - reading.hz * 0.52))
+        };
+    }
+
+    function paint(p) {
+        var r = reading(p), heard = inBeam(p), xy = place(r);
+
+        planeEl.setAttribute("transform",
+            "translate(" + p.x.toFixed(1) + " " + p.y.toFixed(1) + ") rotate(" +
+            (Math.atan2(p.hy, p.hx) * 180 / Math.PI + 90).toFixed(1) + ")");
+        document.getElementById("fs-plane-body")
+            .setAttribute("fill", heard ? "var(--accent)" : "var(--ink-3)");
+
+        if (heard) {
+            if (!current) {
+                current = document.createElementNS(SVG, "polyline");
+                current.setAttribute("class", "sim-track");
+                trackEl.appendChild(current);
+                segments.push([]);
+            }
+            segments[segments.length - 1].push(xy.x.toFixed(1) + "," + xy.y.toFixed(1));
+            current.setAttribute("points", segments[segments.length - 1].join(" "));
+            live.setAttribute("cx", xy.x); live.setAttribute("cy", xy.y);
+            live.setAttribute("opacity", "1");
+            rOut.textContent = (r.range * KM).toFixed(1) + " km";
+            fOut.textContent = (r.hz >= 0 ? "+" : "") + r.hz.toFixed(0) + " Hz";
+        } else {
+            // A gap in the track is the honest record: nothing was heard, so
+            // nothing is drawn. That break is the point of the beam.
+            current = null;
+            live.setAttribute("opacity", "0");
+            rOut.textContent = "—"; fOut.textContent = "not heard";
+        }
+    }
+
+    // ── The loop, and its fences ───────────────────────────────
+    function frame(now) {
+        if (!playing) return;
+        var dt = Math.min(0.05, (now - last) / 1000);
+        // 30fps is plenty for a track that paints over several seconds, and
+        // halves the work of the only thing on this page that has any.
+        if (dt >= 1 / 30) {
+            last = now;
+            travelled += dt * 62;
+            if (travelled >= total) resetTrack();
+            var p = at(travelled);
+            if (p) paint(p);
+        }
+        raf = requestAnimationFrame(frame);
+    }
+
+    function play() {
+        if (playing || total <= 0) return;
+        playing = true; last = performance.now();
+        playBtn.textContent = "Pause";
+        raf = requestAnimationFrame(frame);
+    }
+
+    function pause() {
+        playing = false;
+        if (raf) cancelAnimationFrame(raf);
+        raf = 0;
+        playBtn.textContent = "Play";
+    }
+
+    playBtn.addEventListener("click", function () { playing ? pause() : play(); });
+
+    // Stopped, not merely invisible: a hidden tab or a scrolled-past section
+    // must not keep a loop alive on somebody's phone.
+    document.addEventListener("visibilitychange", function () {
+        if (document.hidden && playing) pause();
+    });
+    if (window.IntersectionObserver) {
+        new IntersectionObserver(function (entries) {
+            if (!entries[0].isIntersecting && playing) pause();
+        }, { threshold: 0 }).observe(map);
+    }
+
+    // ── Drawing a path ────────────────────────────────────────
+    function svgPoint(svg, evt) {
+        var pt = svg.createSVGPoint();
+        pt.x = evt.clientX; pt.y = evt.clientY;
+        return pt.matrixTransform(svg.getScreenCTM().inverse());
+    }
+
+    map.addEventListener("pointerdown", function (evt) {
+        if (evt.target.closest("#fs-aim")) return;
+        pause(); resetTrack();
+        drawing = true; path = [];
+        map.setPointerCapture(evt.pointerId);
+        var p = svgPoint(map, evt);
+        path.push({ x: p.x, y: p.y });
+        drawPath();
+        hint.textContent = "Keep dragging, then let go to fly it.";
+    });
+
+    map.addEventListener("pointermove", function (evt) {
+        if (!drawing) return;
+        var p = svgPoint(map, evt), lastPt = path[path.length - 1];
+        // Thin the samples: a path is a shape, not a recording of the hand.
+        if (Math.hypot(p.x - lastPt.x, p.y - lastPt.y) < 4) return;
+        path.push({ x: p.x, y: p.y });
+        drawPath();
+    });
+
+    map.addEventListener("pointerup", function (evt) {
+        if (!drawing) return;
+        drawing = false;
+        map.releasePointerCapture(evt.pointerId);
+        if (path.length < 3) { path = []; drawPath(); hint.textContent = "That was a dot. Drag a line across the sky."; return; }
+        measure();
+        hint.textContent = "Drag the blue ring to steer the beam. The track breaks where the aircraft leaves it.";
+        play();
+    });
+
+    // ── The beam knob ─────────────────────────────────────────
+    aimKnob.addEventListener("pointerdown", function (evt) {
+        aimKnob.setPointerCapture(evt.pointerId);
+        evt.stopPropagation();
+    });
+    aimKnob.addEventListener("pointermove", function (evt) {
+        if (!aimKnob.hasPointerCapture(evt.pointerId)) return;
+        var p = svgPoint(map, evt);
+        aim = Math.atan2(p.y - N.y, p.x - N.x);
+        drawBeam(); resetTrack();
+    });
+    aimKnob.addEventListener("pointerup", function (evt) { aimKnob.releasePointerCapture(evt.pointerId); });
+    aimKnob.addEventListener("keydown", function (evt) {
+        if (evt.key !== "ArrowLeft" && evt.key !== "ArrowRight") return;
+        evt.preventDefault();
+        aim += evt.key === "ArrowLeft" ? -0.12 : 0.12;
+        drawBeam(); resetTrack();
+    });
+
+    document.getElementById("fs-narrow").addEventListener("click", function () {
+        half = Math.max(0.2, half - 0.26); drawBeam(); resetTrack();
+    });
+    document.getElementById("fs-wide").addEventListener("click", function () {
+        half = Math.min(1.35, half + 0.26); drawBeam(); resetTrack();
+    });
+    clearBtn.addEventListener("click", function () {
+        pause(); resetTrack(); path = []; drawPath();
+        hint.textContent = "Drag across the sky to draw a flight path.";
+    });
+
+    // ── First paint, standing still ───────────────────────────
+    var controls = document.getElementById("fs-controls");
+    if (controls) controls.hidden = false;
+
+    measure(); drawBeam(); drawPath();
+    var start = at(0);
+    if (start) paint(start);
+    resetTrack();
+    if (start) {
+        planeEl.setAttribute("transform",
+            "translate(" + start.x.toFixed(1) + " " + start.y.toFixed(1) + ")");
+    }
+    // Deliberately not autoplaying, and doubly so when reduced motion is asked
+    // for: a page nobody has touched should not be animating.
+    if (REDUCED) hint.textContent = "Press Play to fly the path, or drag to draw your own.";
+})();

--- a/static/flight-sim.js
+++ b/static/flight-sim.js
@@ -18,7 +18,19 @@
     var T = { x: 34, y: 186 }, N = { x: 212, y: 186 };
     var aim = -Math.PI / 2, half = Math.PI / 3;      // 120° across, pointing up
     var BASE = Math.hypot(T.x - N.x, T.y - N.y);
-    var KM = 0.18;                                    // 1 unit ≈ 0.18 km
+
+    // The scale is chosen so the picture cannot reach its own axes. Drawn into
+    // the furthest corner this scene tops out at 51 km and 242 Hz, inside a
+    // plot that goes to 60 km and 300 Hz, so a track curves away from the edge
+    // instead of flattening along it. A track pinned to a bound is a lie: it
+    // says the aircraft stopped changing when really the plot ran out.
+    var KM = 0.15;                       // 1 unit ≈ 0.15 km, baseline ≈ 27 km
+    var RANGE_MAX = 60;                  // km, the full width of the plot
+    var DOPPLER_MAX = 300;               // Hz, top and bottom of the plot
+
+    // Doppler from the real relation rather than a fudge factor, at the centre
+    // frequency this node actually tunes. 170 m/s is an unremarkable airliner.
+    var FC = 213e6, LAMBDA = 299792458 / FC, SPEED = 170;
 
     // A gentle arc past the node, so the piece says something before anyone
     // touches it. Redrawing replaces it.
@@ -65,14 +77,22 @@
 
     // The two numbers the node actually measures.
     function reading(p) {
-        var d1 = Math.hypot(p.x - T.x, p.y - T.y), d2 = Math.hypot(p.x - N.x, p.y - N.y);
-        var range = d1 + d2 - BASE;
+        // Floored, because a path drawn straight over the tower or the node
+        // gives a zero-length leg, and 0/0 makes the unit vector NaN and the
+        // whole track vanish. Both are visible targets in the middle of the
+        // scene, so somebody will fly over one.
+        var d1 = Math.max(0.5, Math.hypot(p.x - T.x, p.y - T.y));
+        var d2 = Math.max(0.5, Math.hypot(p.x - N.x, p.y - N.y));
         // Doppler follows how fast both legs together are changing, so it is
         // zero when the heading is perpendicular to the sum of the unit legs,
-        // which is not the same as perpendicular to the node.
+        // which is not the same as perpendicular to the node. That sum has a
+        // magnitude of at most 2, which is what caps the plot at 2v/lambda.
         var ux = (p.x - T.x) / d1 + (p.x - N.x) / d2;
         var uy = (p.y - T.y) / d1 + (p.y - N.y) / d2;
-        return { range: range, hz: -(p.hx * ux + p.hy * uy) * 150 };
+        return {
+            km: (d1 + d2 - BASE) * KM,
+            hz: -(p.hx * ux + p.hy * uy) * SPEED / LAMBDA
+        };
     }
 
     function drawBeam() {
@@ -100,12 +120,13 @@
         segments = []; current = null; travelled = 0;
     }
 
-    // range → x, hertz → y, inside the plot box.
-    function place(reading) {
-        return {
-            x: Math.max(44, Math.min(280, 42 + reading.range * 1.35)),
-            y: Math.max(16, Math.min(180, 98 - reading.hz * 0.52))
-        };
+    // range → x, hertz → y. The clamps are a backstop against a stray
+    // coordinate, not a working part: the scale above keeps every reachable
+    // reading well inside the box.
+    function place(r) {
+        var x = 46 + Math.max(0, Math.min(RANGE_MAX, r.km)) / RANGE_MAX * 240;
+        var hz = Math.max(-DOPPLER_MAX, Math.min(DOPPLER_MAX, r.hz));
+        return { x: x, y: 98 - hz / DOPPLER_MAX * 84 };
     }
 
     function paint(p) {
@@ -128,7 +149,7 @@
             current.setAttribute("points", segments[segments.length - 1].join(" "));
             live.setAttribute("cx", xy.x); live.setAttribute("cy", xy.y);
             live.setAttribute("opacity", "1");
-            rOut.textContent = (r.range * KM).toFixed(1) + " km";
+            rOut.textContent = r.km.toFixed(1) + " km";
             fOut.textContent = (r.hz >= 0 ? "+" : "") + r.hz.toFixed(0) + " Hz";
         } else {
             // A gap in the track is the honest record: nothing was heard, so
@@ -183,6 +204,10 @@
     }
 
     // ── Drawing a path ────────────────────────────────────────
+    function inside(p) {
+        return { x: Math.max(4, Math.min(296, p.x)), y: Math.max(4, Math.min(216, p.y)) };
+    }
+
     function svgPoint(svg, evt) {
         var pt = svg.createSVGPoint();
         pt.x = evt.clientX; pt.y = evt.clientY;
@@ -194,18 +219,17 @@
         pause(); resetTrack();
         drawing = true; path = [];
         map.setPointerCapture(evt.pointerId);
-        var p = svgPoint(map, evt);
-        path.push({ x: p.x, y: p.y });
+        path.push(inside(svgPoint(map, evt)));
         drawPath();
         hint.textContent = "Keep dragging, then let go to fly it.";
     });
 
     map.addEventListener("pointermove", function (evt) {
         if (!drawing) return;
-        var p = svgPoint(map, evt), lastPt = path[path.length - 1];
+        var p = inside(svgPoint(map, evt)), lastPt = path[path.length - 1];
         // Thin the samples: a path is a shape, not a recording of the hand.
         if (Math.hypot(p.x - lastPt.x, p.y - lastPt.y) < 4) return;
-        path.push({ x: p.x, y: p.y });
+        path.push(p);
         drawPath();
     });
 

--- a/templates/_fleet_bar.html
+++ b/templates/_fleet_bar.html
@@ -55,7 +55,7 @@
     {# Both of these leave the app, so both carry the outbound arrow. #}
     <a class="ds-btn ghost sm" href="https://map.retina.fm" target="_blank" rel="noopener">
         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h7v7"/><path d="M21 3l-9 9"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>
-        Server
+        Retina Network Map
     </a>
     <a class="ds-btn ghost sm" href="https://dash.retina.fm" target="_blank" rel="noopener">
         <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3h7v7"/><path d="M21 3l-9 9"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -175,62 +175,79 @@
         {% endfor %}
     </div>
 
-    {# Five facts about the thing the owner is looking at, lifted from the
-       passive-radar primer and cut to fit. Deliberately static markup and
-       nothing else: it ships inside a page the browser is already fetching,
-       so it costs the node no request, no disk and no work at render time.
-       The primer earns its keep by being driveable, and none of that can come
-       here — a node's compute belongs to the radar. #}
-    <div class="section-head facts-head"><h2>How your node sees</h2></div>
+    {# The primer's closing simulation, cut down to sit on a node page.
 
-    {# Not cards. Everything card-shaped above is a link you can click, and a
-       paragraph that is not clickable should not borrow the shape. #}
-    <div class="facts">
-        <div class="fact">
-            <h4>It never transmits</h4>
-            <p>
-                Your node sends out nothing at all. It listens to the FM and TV
-                towers already crowding the air around you, and reads the faint
-                echoes that glance off anything flying overhead.
-            </p>
+       Progressive on purpose: everything below is a correct still diagram on
+       its own, with the beam and a flight path already drawn into the markup.
+       /static/flight-sim.js only adds the ability to fly it. No script, no
+       pointer events, or a fetch that fails, and this is still a picture
+       rather than an empty box — which is why the controls ship hidden and
+       are revealed by the script that can drive them. #}
+    <div class="section-head sim-head"><h2>How your node sees</h2></div>
+    <p class="sim-lead">
+        Your node measures two things: how much further the echo travelled than
+        the direct signal, and how fast that distance is changing. Draw a flight
+        path and watch what your node would have recorded.
+    </p>
+
+    <div class="sim">
+        <div class="sim-panel">
+            <p class="sim-label">The sky above your node</p>
+            <svg class="sim-scene" id="fs-map" viewBox="0 0 300 220" role="img" aria-label="A tower, your node, the wedge of sky it hears, and a flight path">
+                <path id="fs-beam" class="sim-beam" d="M212 186 L38.8 86.0 A200 200 0 0 1 385.2 86.0 Z"></path>
+                <path id="fs-beam-edge" class="sim-beam-edge" d="M212 186 L38.8 86.0 A200 200 0 0 1 385.2 86.0 Z"></path>
+                <line class="sim-base" x1="34" y1="186" x2="212" y2="186" stroke-dasharray="3 3"></line>
+                <path id="fs-path" class="sim-flightpath" d="M20.0 150.0 L26.6 142.5 L33.2 135.0 L39.9 127.6 L46.5 120.3 L53.1 113.3 L59.8 106.4 L66.4 99.8 L73.0 93.6 L79.6 87.7 L86.2 82.1 L92.9 77.0 L99.5 72.3 L106.1 68.1 L112.8 64.5 L119.4 61.3 L126.0 58.7 L132.6 56.7 L139.2 55.2 L145.9 54.3 L152.5 54.0 L159.1 54.3 L165.8 55.2 L172.4 56.7 L179.0 58.7 L185.6 61.3 L192.2 64.5 L198.9 68.1 L205.5 72.3 L212.1 77.0 L218.8 82.1 L225.4 87.7 L232.0 93.6 L238.6 99.8 L245.2 106.4 L251.9 113.3 L258.5 120.3 L265.1 127.6 L271.8 135.0 L278.4 142.5 L285.0 150.0"></path>
+                <path class="sim-mark" d="M34 186 l-6 10 h12 z"></path>
+                <line class="sim-base" x1="34" y1="186" x2="34" y2="168"></line>
+                <text class="sim-axis-label" x="34" y="208" text-anchor="middle">tower</text>
+                <circle class="sim-mark" cx="212" cy="186" r="3.5"></circle>
+                <text class="sim-axis-label" x="212" y="208" text-anchor="middle">your node</text>
+                <g id="fs-aim" class="sim-grab" tabindex="0" transform="translate(212 116)">
+                    <circle r="12" fill="transparent"></circle>
+                    <circle r="5" fill="var(--surface)" stroke="var(--accent)" stroke-width="1.5"></circle>
+                </g>
+                <g id="fs-plane" transform="translate(20 150)">
+                    <circle r="8" fill="none" stroke="var(--accent-edge)" stroke-width="1"></circle>
+                    <path id="fs-plane-body" fill="var(--accent)" d="M0 -5.5 L4 3.5 L0 1.4 L-4 3.5 Z"></path>
+                </g>
+            </svg>
         </div>
-        <div class="fact">
-            <h4>Two antennas, two paths</h4>
-            <p>
-                One antenna points at a broadcast tower and hears it head-on.
-                The other faces the open sky and catches that same signal a beat
-                later, after it has glanced off an aircraft. The echo takes the
-                long way round, and that extra distance is the range.
-            </p>
-        </div>
-        <div class="fact">
-            <h4>Every detection is one dot</h4>
-            <p>
-                Distance comes from the delay, speed from the Doppler shift: the
-                same nudge in pitch you hear as an ambulance passes. Plot one
-                against the other and a whole aircraft, in a single instant,
-                lands as one dot.
-            </p>
-        </div>
-        <div class="fact">
-            <h4>It only hears a wedge</h4>
-            <p>
-                The surveillance antenna covers a wedge of sky rather than all of
-                it. Outside that wedge there is no echo to read: the aircraft is
-                still up there, the node simply cannot hear it. A quiet plot
-                usually means nothing flew through the beam.
-            </p>
-        </div>
-        <div class="fact">
-            <h4>One node sees an arc</h4>
-            <p>
-                A single node measures range and speed, not position, so the same
-                reading fits a whole arc of sky. A transponder report, or a second
-                node hearing the same aircraft from another angle, collapses that
-                arc to one aeroplane.
-            </p>
+
+        <div class="sim-panel">
+            <p class="sim-label">What your node records</p>
+            <svg class="sim-scene" id="fs-plot" viewBox="0 0 300 220" role="img" aria-label="A delay-Doppler plot: range across, Doppler up">
+                <rect x="42" y="14" width="240" height="168" fill="var(--surface-2)" stroke="var(--line)"></rect>
+                <line class="sim-grid" x1="42" y1="98" x2="282" y2="98"></line>
+                <line class="sim-grid" x1="102" y1="14" x2="102" y2="182"></line>
+                <line class="sim-grid" x1="162" y1="14" x2="162" y2="182"></line>
+                <line class="sim-grid" x1="222" y1="14" x2="222" y2="182"></line>
+                <g id="fs-track"></g>
+                <circle id="fs-live" r="3.4" fill="var(--accent)" opacity="0"></circle>
+                <text class="sim-axis-label" x="162" y="200" text-anchor="middle">range &#8594;</text>
+                <text class="sim-axis-label" x="36" y="101" text-anchor="end">0 Hz</text>
+                <text class="sim-axis-label" x="36" y="20" text-anchor="end">+</text>
+                <text class="sim-axis-label" x="36" y="180" text-anchor="end">&#8722;</text>
+            </svg>
         </div>
     </div>
+
+    <div class="sim-controls" id="fs-controls" hidden>
+        <button class="sim-btn primary" id="fs-play" type="button">Play</button>
+        <button class="sim-btn" id="fs-clear" type="button">Draw a new path</button>
+        <button class="sim-btn" id="fs-narrow" type="button">Narrow beam</button>
+        <button class="sim-btn" id="fs-wide" type="button">Widen beam</button>
+        <span class="sim-spacer"></span>
+        <span class="sim-readout">
+            <span><span class="k">range</span><span class="v" id="fs-range">&#8212;</span></span>
+            <span><span class="k">doppler</span><span class="v" id="fs-doppler">&#8212;</span></span>
+            <span><span class="k">beam</span><span class="v" id="fs-width">120&#176;</span></span>
+        </span>
+    </div>
+    <p class="sim-hint" id="fs-hint">
+        Drag across the sky to draw your own path. Drag the blue ring to steer the
+        beam. The track breaks wherever the aircraft leaves it.
+    </p>
 
     {% if primer_url %}
     <p class="facts-more">
@@ -239,4 +256,11 @@
     </p>
     {% endif %}
 </main>
+{% endblock %}
+
+{% block scripts %}
+{# Static file rather than inline: a rendered template caches nothing, so an
+   inline copy would re-send on every page load. This comes down once per
+   browser and revalidates after. #}
+<script src="/static/flight-sim.js" defer></script>
 {% endblock %}

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -217,17 +217,23 @@
         <div class="sim-panel">
             <p class="sim-label">What your node records</p>
             <svg class="sim-scene" id="fs-plot" viewBox="0 0 300 220" role="img" aria-label="A delay-Doppler plot: range across, Doppler up">
-                <rect x="42" y="14" width="240" height="168" fill="var(--surface-2)" stroke="var(--line)"></rect>
-                <line class="sim-grid" x1="42" y1="98" x2="282" y2="98"></line>
-                <line class="sim-grid" x1="102" y1="14" x2="102" y2="182"></line>
-                <line class="sim-grid" x1="162" y1="14" x2="162" y2="182"></line>
-                <line class="sim-grid" x1="222" y1="14" x2="222" y2="182"></line>
+                <rect x="46" y="14" width="240" height="168" fill="var(--surface-2)" stroke="var(--line)"></rect>
+                <line class="sim-grid" x1="46" y1="98" x2="286" y2="98"></line>
+                {# 15, 30 and 45 km. #}
+                <line class="sim-grid" x1="106" y1="14" x2="106" y2="182"></line>
+                <line class="sim-grid" x1="166" y1="14" x2="166" y2="182"></line>
+                <line class="sim-grid" x1="226" y1="14" x2="226" y2="182"></line>
                 <g id="fs-track"></g>
                 <circle id="fs-live" r="3.4" fill="var(--accent)" opacity="0"></circle>
-                <text class="sim-axis-label" x="162" y="200" text-anchor="middle">range &#8594;</text>
-                <text class="sim-axis-label" x="36" y="101" text-anchor="end">0 Hz</text>
-                <text class="sim-axis-label" x="36" y="20" text-anchor="end">+</text>
-                <text class="sim-axis-label" x="36" y="180" text-anchor="end">&#8722;</text>
+                {# The axes are labelled with their real limits, because a plot
+                   whose bounds are a mystery teaches the wrong lesson about
+                   where a track sits. #}
+                <text class="sim-axis-label" x="40" y="20" text-anchor="end">+300</text>
+                <text class="sim-axis-label" x="40" y="101" text-anchor="end">0 Hz</text>
+                <text class="sim-axis-label" x="40" y="180" text-anchor="end">&#8722;300</text>
+                <text class="sim-axis-label" x="46" y="198" text-anchor="start">0</text>
+                <text class="sim-axis-label" x="166" y="198" text-anchor="middle">range</text>
+                <text class="sim-axis-label" x="286" y="198" text-anchor="end">60 km</text>
             </svg>
         </div>
     </div>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -143,5 +143,69 @@
         </a>
         {% endfor %}
     </div>
+
+    {# Five facts about the thing the owner is looking at, lifted from the
+       passive-radar primer and cut to fit. Deliberately static markup and
+       nothing else: it ships inside a page the browser is already fetching,
+       so it costs the node no request, no disk and no work at render time.
+       The primer earns its keep by being driveable, and none of that can come
+       here — a node's compute belongs to the radar. #}
+    <div class="section-head facts-head"><h2>How your node sees</h2></div>
+
+    {# Not cards. Everything card-shaped above is a link you can click, and a
+       paragraph that is not clickable should not borrow the shape. #}
+    <div class="facts">
+        <div class="fact">
+            <h4>It never transmits</h4>
+            <p>
+                Your node sends out nothing at all. It listens to the FM and TV
+                towers already crowding the air around you, and reads the faint
+                echoes that glance off anything flying overhead.
+            </p>
+        </div>
+        <div class="fact">
+            <h4>Two antennas, two paths</h4>
+            <p>
+                One antenna points at a broadcast tower and hears it head-on.
+                The other faces the open sky and catches that same signal a beat
+                later, after it has glanced off an aircraft. The echo takes the
+                long way round, and that extra distance is the range.
+            </p>
+        </div>
+        <div class="fact">
+            <h4>Every detection is one dot</h4>
+            <p>
+                Distance comes from the delay, speed from the Doppler shift: the
+                same nudge in pitch you hear as an ambulance passes. Plot one
+                against the other and a whole aircraft, in a single instant,
+                lands as one dot.
+            </p>
+        </div>
+        <div class="fact">
+            <h4>It only hears a wedge</h4>
+            <p>
+                The surveillance antenna covers a wedge of sky rather than all of
+                it. Outside that wedge there is no echo to read: the aircraft is
+                still up there, the node simply cannot hear it. A quiet plot
+                usually means nothing flew through the beam.
+            </p>
+        </div>
+        <div class="fact">
+            <h4>One node sees an arc</h4>
+            <p>
+                A single node measures range and speed, not position, so the same
+                reading fits a whole arc of sky. A transponder report, or a second
+                node hearing the same aircraft from another angle, collapses that
+                arc to one aeroplane.
+            </p>
+        </div>
+    </div>
+
+    {% if primer_url %}
+    <p class="facts-more">
+        All of it, with the parts you can drive:
+        <a href="{{ primer_url }}" target="_blank" rel="noopener">the full primer</a>
+    </p>
+    {% endif %}
 </main>
 {% endblock %}

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -8,6 +8,59 @@
 {% block subnav %}{% endblock %}
 
 {% block content %}
+{# One card for anything that leaves this node: a website, or a mail client.
+   A macro rather than two copies, so the second one cannot quietly drift from
+   the first the way duplicated markup always does. #}
+{% macro link_card(item) %}
+<a class="link-card" href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener"{% endif %}>
+    <span class="link-icon">
+        {% if item.icon == 'globe' %}
+        <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="9"></circle><path d="M3 12h18"></path>
+            <path d="M12 3a15 15 0 0 1 0 18a15 15 0 0 1 0-18"></path>
+        </svg>
+        {% elif item.icon == 'book' %}
+        <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M5 5a2 2 0 0 1 2-2h12v18H7a2 2 0 0 0-2 2z"></path>
+            <path d="M9 7h6"></path><path d="M9 11h6"></path>
+        </svg>
+        {% elif item.icon == 'map' %}
+        <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="m9 4 6 2 5-2v14l-5 2-6-2-5 2V6z"></path>
+            <path d="M9 4v14"></path><path d="M15 6v14"></path>
+        </svg>
+        {% elif item.icon == 'chat' %}
+        <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M20.5 11.8a8 8 0 0 1-8.6 8 8.6 8.6 0 0 1-3.2-.7L4 20.5l1.6-4.4a8 8 0 0 1-1.1-4.3 8 8 0 0 1 8-7.8 8 8 0 0 1 8 7.8z"></path>
+            <path d="M9 11h.01"></path><path d="M12.5 11h.01"></path><path d="M16 11h.01"></path>
+        </svg>
+        {% elif item.icon == 'mail' %}
+        <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="5" width="18" height="14" rx="2"></rect>
+            <path d="m3.5 7 8.5 6 8.5-6"></path>
+        </svg>
+        {% else %}
+        <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4 20h16"></path><path d="M7 20v-6"></path>
+            <path d="M12 20V6"></path><path d="M17 20v-9"></path>
+        </svg>
+        {% endif %}
+    </span>
+    <span class="link-text">
+        <span class="link-name">{{ item.name }}</span>
+        <span class="link-host">{{ item.host }}</span>
+    </span>
+    {# The outbound arrow means "this leaves for another page", which a mail
+       client is not, so a mailto card does not wear one. #}
+    {% if item.external %}
+    <svg class="link-arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M14 3h7v7"></path><path d="M21 3l-9 9"></path>
+        <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"></path>
+    </svg>
+    {% endif %}
+</a>
+{% endmacro %}
+
 <main class="main">
     <div class="section-head"><h2>Nodes on this network</h2></div>
 
@@ -106,41 +159,19 @@
 
     <div class="node-grid">
         {% for resource in resources %}
-        <a class="link-card" href="{{ resource.url }}" target="_blank" rel="noopener">
-            <span class="link-icon">
-                {% if resource.icon == 'globe' %}
-                <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <circle cx="12" cy="12" r="9"></circle><path d="M3 12h18"></path>
-                    <path d="M12 3a15 15 0 0 1 0 18a15 15 0 0 1 0-18"></path>
-                </svg>
-                {% elif resource.icon == 'book' %}
-                <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <path d="M5 5a2 2 0 0 1 2-2h12v18H7a2 2 0 0 0-2 2z"></path>
-                    <path d="M9 7h6"></path><path d="M9 11h6"></path>
-                </svg>
-                {% elif resource.icon == 'map' %}
-                <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <path d="m9 4 6 2 5-2v14l-5 2-6-2-5 2V6z"></path>
-                    <path d="M9 4v14"></path><path d="M15 6v14"></path>
-                </svg>
-                {% else %}
-                <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <path d="M4 20h16"></path><path d="M7 20v-6"></path>
-                    <path d="M12 20V6"></path><path d="M17 20v-9"></path>
-                </svg>
-                {% endif %}
-            </span>
-            <span class="link-text">
-                <span class="link-name">{{ resource.name }}</span>
-                <span class="link-host">{{ resource.host }}</span>
-            </span>
-            {# Every one of these leaves the app, so every one carries the same
-               outbound arrow the banner's buttons do. #}
-            <svg class="link-arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M14 3h7v7"></path><path d="M21 3l-9 9"></path>
-                <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"></path>
-            </svg>
-        </a>
+        {{ link_card(resource) }}
+        {% endfor %}
+    </div>
+
+    {# Kept apart from Resources, and above the reading matter below it: the
+       links above are things to look at, this is what to do when the node is
+       not doing what it should. #}
+    <div class="section-head help-head"><h2>Help</h2></div>
+    <p class="help-lead">If you are running into problems, please reach out.</p>
+
+    <div class="node-grid">
+        {% for item in help_links %}
+        {{ link_card(item) }}
         {% endfor %}
     </div>
 

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -98,5 +98,50 @@
         </a>
         {% endif %}
     </div>
+
+    {# Fixed links out. A separate section rather than more cards in the grid
+       above: those stand for hardware on this network and this one does not,
+       and mixing them would make the antenna mark stop meaning anything. #}
+    <div class="section-head resources-head"><h2>Resources</h2></div>
+
+    <div class="node-grid">
+        {% for resource in resources %}
+        <a class="link-card" href="{{ resource.url }}" target="_blank" rel="noopener">
+            <span class="link-icon">
+                {% if resource.icon == 'globe' %}
+                <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="12" cy="12" r="9"></circle><path d="M3 12h18"></path>
+                    <path d="M12 3a15 15 0 0 1 0 18a15 15 0 0 1 0-18"></path>
+                </svg>
+                {% elif resource.icon == 'book' %}
+                <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M5 5a2 2 0 0 1 2-2h12v18H7a2 2 0 0 0-2 2z"></path>
+                    <path d="M9 7h6"></path><path d="M9 11h6"></path>
+                </svg>
+                {% elif resource.icon == 'map' %}
+                <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="m9 4 6 2 5-2v14l-5 2-6-2-5 2V6z"></path>
+                    <path d="M9 4v14"></path><path d="M15 6v14"></path>
+                </svg>
+                {% else %}
+                <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M4 20h16"></path><path d="M7 20v-6"></path>
+                    <path d="M12 20V6"></path><path d="M17 20v-9"></path>
+                </svg>
+                {% endif %}
+            </span>
+            <span class="link-text">
+                <span class="link-name">{{ resource.name }}</span>
+                <span class="link-host">{{ resource.host }}</span>
+            </span>
+            {# Every one of these leaves the app, so every one carries the same
+               outbound arrow the banner's buttons do. #}
+            <svg class="link-arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M14 3h7v7"></path><path d="M21 3l-9 9"></path>
+                <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"></path>
+            </svg>
+        </a>
+        {% endfor %}
+    </div>
 </main>
 {% endblock %}

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -5,9 +5,13 @@ through real routes rather than calling the helper directly: what matters is
 that it survives base.html inheritance and the blocks pages override.
 """
 
+from pathlib import Path
+
 import pytest
 
 from routes.fleet import RESOURCES, banner_nodes, node_url, peer_view
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
 class FakePeers:
@@ -493,7 +497,7 @@ def resource_strip(body):
 
 def help_strip(body):
     """The Help cards."""
-    return cards_between(body, "help-head", "facts-head")
+    return cards_between(body, "help-head", "sim-head")
 
 
 def test_every_resource_is_offered(app_client, fleet, telemetry):
@@ -539,59 +543,6 @@ def test_the_offer_of_a_second_node_points_at_the_store(app_client, fleet, telem
     assert 'href="https://retina.fm"' in body
 
 
-# ── How your node sees ─────────────────────────────────────────
-
-
-def facts_section(body):
-    return body.split('<div class="section-head facts-head">')[1].split("</main>")[0]
-
-
-def test_the_primer_facts_are_shown(app_client, fleet, telemetry):
-    fleet(node(SELF, is_self=True))
-    facts = facts_section(app_client.get("/summary").data.decode())
-    for heading in ("It never transmits", "Two antennas, two paths",
-                    "Every detection is one dot", "It only hears a wedge",
-                    "One node sees an arc"):
-        assert heading in facts, heading
-
-
-def test_the_facts_cost_the_node_nothing(app_client, fleet, telemetry):
-    """The primer earns its keep by being driveable, and none of that can come
-    here: a node's compute belongs to the radar. Static markup only, so no
-    script and no extra fetch rides in with it."""
-    facts = facts_section(app_client.get("/summary").data.decode())
-    assert "<script" not in facts
-    assert "<img" not in facts and "<canvas" not in facts
-
-
-def test_the_facts_are_not_dressed_as_cards(app_client, fleet, telemetry):
-    """Everything card-shaped on this page is a link. Prose that cannot be
-    clicked must not look like something that can."""
-    facts = facts_section(app_client.get("/summary").data.decode())
-    assert "node-card" not in facts and "link-card" not in facts
-
-
-def test_no_primer_link_until_there_is_somewhere_to_send_people(app_client, fleet,
-                                                               telemetry):
-    """The branch carrying the primer is unmerged and the URL 404s today. A
-    dead link on an owner's node is worse than no link at all."""
-    from routes import fleet as fleet_routes
-
-    assert fleet_routes.PRIMER_URL == "", "turn the link on in the template test too"
-    facts = facts_section(app_client.get("/summary").data.decode())
-    assert "the full primer" not in facts
-
-
-def test_the_primer_link_appears_once_it_has_a_home(app_client, fleet, telemetry,
-                                                    monkeypatch):
-    from routes import fleet as fleet_routes
-
-    monkeypatch.setattr(fleet_routes, "PRIMER_URL", "https://offworldlabs.com/learn/")
-    facts = facts_section(app_client.get("/summary").data.decode())
-    assert 'href="https://offworldlabs.com/learn/"' in facts
-    assert 'rel="noopener"' in facts
-
-
 # ── Help ───────────────────────────────────────────────────────
 
 
@@ -633,3 +584,61 @@ def test_the_discord_is_named_for_whose_it_is(app_client, fleet, telemetry):
     expecting Offworld Labs support."""
     cards = "".join(help_strip(app_client.get("/summary").data.decode()))
     assert "blah2 Discord" in cards
+
+
+# ── How your node sees ─────────────────────────────────────────
+#
+# The primer's closing simulation, cut down. It is the one piece here that
+# needs an animation loop, so what these pin down is mostly the fencing.
+
+
+def sim_section(body):
+    return body.split('<div class="section-head sim-head">')[1].split("</main>")[0]
+
+
+def test_the_simulation_is_a_still_diagram_without_any_script(app_client, fleet,
+                                                              telemetry):
+    """The served markup has to stand on its own. No JavaScript, no pointer
+    events, or a fetch that fails, and this is a picture rather than an empty
+    box, so the beam and a flight path are drawn into the page itself."""
+    sim = sim_section(app_client.get("/summary").data.decode())
+    assert 'id="fs-beam"' in sim and 'd="M212 186' in sim
+    assert 'id="fs-path"' in sim and 'd="M20.0 150.0' in sim
+
+
+def test_the_controls_are_hidden_until_something_can_drive_them(app_client, fleet,
+                                                                telemetry):
+    """A Play button that cannot play is worse than no Play button."""
+    sim = sim_section(app_client.get("/summary").data.decode())
+    controls = sim.split('id="fs-controls"')[1].split(">")[0]
+    assert "hidden" in controls
+
+
+def test_the_simulation_is_not_inlined(app_client, fleet, telemetry):
+    """A rendered template caches nothing, so an inline copy would re-send on
+    every page load. As a static file it comes down once and revalidates."""
+    body = app_client.get("/summary").data.decode()
+    assert '<script src="/static/flight-sim.js"' in body
+    assert "requestAnimationFrame" not in body
+
+
+def test_nothing_moves_until_somebody_asks(app_client, fleet, telemetry):
+    """No autoplay, and the loop is fenced besides: a hidden tab, a section
+    scrolled out of view, or a reader who has asked for reduced motion must
+    not leave an animation running on somebody's phone."""
+    js = (PROJECT_ROOT / "static" / "flight-sim.js").read_text()
+    # Nothing in the first paint starts the loop: it is entered from the Play
+    # button, from finishing a drawn path, and from nowhere else.
+    assert "play()" not in js.split("First paint")[1]
+    assert "visibilitychange" in js
+    assert "IntersectionObserver" in js
+    assert "prefers-reduced-motion" in js
+    # The only loop is entered from play(), never from first paint.
+    assert js.count("requestAnimationFrame(frame)") == 2
+
+
+def test_the_simulation_says_it_is_not_this_node(app_client, fleet, telemetry):
+    """The geometry is real but the tower, the speed and the hertz scale are
+    invented. It must not read as a view of the fleet."""
+    sim = sim_section(app_client.get("/summary").data.decode())
+    assert "would have recorded" in sim

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -7,7 +7,7 @@ that it survives base.html inheritance and the blocks pages override.
 
 import pytest
 
-from routes.fleet import banner_nodes, node_url, peer_view
+from routes.fleet import RESOURCES, banner_nodes, node_url, peer_view
 
 
 class FakePeers:
@@ -473,3 +473,55 @@ def test_a_card_with_nothing_to_say_has_no_divider(app_client, fleet, telemetry)
     fleet(node(SELF, is_self=True), node(OTHER, address=""))
     card = node_cards(app_client.get("/summary").data.decode())[1]
     assert "node-rows" not in card
+
+
+# ── Resources ──────────────────────────────────────────────────
+
+
+def resource_strip(body):
+    """The Resources cards, as raw <a> fragments."""
+    section = body.split('<div class="section-head resources-head">')[1]
+    return ["<a" + frag for frag in section.split("<a")[1:]]
+
+
+def test_every_resource_is_offered(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True))
+    body = app_client.get("/summary").data.decode()
+    for resource in RESOURCES:
+        assert f'href="{resource["url"]}"' in body, resource["name"]
+
+
+def test_a_resource_says_where_it_goes(app_client, fleet, telemetry):
+    """These all leave the device, so an owner should see they are about to be
+    sent to github.com before the click rather than after."""
+    fleet(node(SELF, is_self=True))
+    cards = resource_strip(app_client.get("/summary").data.decode())
+    assert "github.com" in "".join(cards)
+
+
+def test_the_host_is_derived_from_the_url():
+    """So the line under a name cannot drift from where the card really goes."""
+    for resource in RESOURCES:
+        assert resource["host"] in resource["url"]
+
+
+def test_every_resource_opens_away_from_the_page(app_client, fleet, telemetry):
+    """A node's own page is a poor thing to lose to an outbound click, and
+    rel=noopener is the plain safety requirement for target=_blank."""
+    fleet(node(SELF, is_self=True))
+    for card in resource_strip(app_client.get("/summary").data.decode()):
+        assert 'target="_blank"' in card and 'rel="noopener"' in card
+
+
+def test_resources_are_not_mixed_in_with_the_nodes(app_client, fleet, telemetry):
+    """The antenna mark means "this is a node". It stops meaning anything if a
+    link to a website sits in the same grid wearing one."""
+    fleet(node(SELF, is_self=True))
+    for card in node_cards(app_client.get("/summary").data.decode()):
+        assert "link-card" not in card
+
+
+def test_the_offer_of_a_second_node_points_at_the_store(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True))
+    body = app_client.get("/summary").data.decode()
+    assert 'href="https://retina.fm"' in body

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -478,10 +478,22 @@ def test_a_card_with_nothing_to_say_has_no_divider(app_client, fleet, telemetry)
 # ── Resources ──────────────────────────────────────────────────
 
 
+def cards_between(body, start_head, end_head):
+    """The <a> fragments of one section, bounded so a later section's cards
+    cannot be mistaken for this one's."""
+    section = body.split(f'<div class="section-head {start_head}">')[1]
+    section = section.split(f'<div class="section-head {end_head}">')[0]
+    return ["<a" + frag for frag in section.split("<a")[1:]]
+
+
 def resource_strip(body):
     """The Resources cards, as raw <a> fragments."""
-    section = body.split('<div class="section-head resources-head">')[1]
-    return ["<a" + frag for frag in section.split("<a")[1:]]
+    return cards_between(body, "resources-head", "help-head")
+
+
+def help_strip(body):
+    """The Help cards."""
+    return cards_between(body, "help-head", "facts-head")
 
 
 def test_every_resource_is_offered(app_client, fleet, telemetry):
@@ -578,3 +590,46 @@ def test_the_primer_link_appears_once_it_has_a_home(app_client, fleet, telemetry
     facts = facts_section(app_client.get("/summary").data.decode())
     assert 'href="https://offworldlabs.com/learn/"' in facts
     assert 'rel="noopener"' in facts
+
+
+# ── Help ───────────────────────────────────────────────────────
+
+
+def test_both_ways_of_reaching_us_are_offered(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True))
+    cards = "".join(help_strip(app_client.get("/summary").data.decode()))
+    assert "https://discord.gg/ewNQbeK5Zn" in cards
+    assert "mailto:info@offworldlabs.com" in cards
+
+
+def test_the_support_address_is_readable_not_just_clickable(app_client, fleet,
+                                                            telemetry):
+    """Somebody may need to type it somewhere else, or read it down a phone."""
+    cards = "".join(help_strip(app_client.get("/summary").data.decode()))
+    assert "info@offworldlabs.com" in cards.replace("mailto:", "")
+
+
+def test_the_email_card_does_not_open_a_tab(app_client, fleet, telemetry):
+    """It hands off to a mail client. target=_blank would leave an empty tab
+    behind, and the outbound arrow would claim it goes to a page."""
+    cards = help_strip(app_client.get("/summary").data.decode())
+    mail = [c for c in cards if "mailto:" in c]
+    assert len(mail) == 1
+    assert 'target="_blank"' not in mail[0]
+    assert "link-arrow" not in mail[0]
+
+
+def test_the_discord_card_does_open_a_tab(app_client, fleet, telemetry):
+    cards = help_strip(app_client.get("/summary").data.decode())
+    discord = [c for c in cards if "discord.gg" in c]
+    assert len(discord) == 1
+    assert 'target="_blank"' in discord[0] and 'rel="noopener"' in discord[0]
+    assert "link-arrow" in discord[0]
+
+
+def test_the_discord_is_named_for_whose_it_is(app_client, fleet, telemetry):
+    """It is the blah2 project's community server, not ours. Calling it ours
+    would send an owner with a hardware problem into a volunteer channel
+    expecting Offworld Labs support."""
+    cards = "".join(help_strip(app_client.get("/summary").data.decode()))
+    assert "blah2 Discord" in cards

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -152,7 +152,7 @@ def test_the_summary_tab_has_no_node_mark(app_client, fleet):
 def test_the_banner_carries_both_outbound_links(app_client, fleet):
     fleet(node(SELF, is_self=True))
     body = app_client.get("/").data.decode()
-    assert "https://map.retina.fm" in body and "Server" in body
+    assert "https://map.retina.fm" in body and "Retina Network Map" in body
     assert "https://dash.retina.fm" in body and "Retina Dashboard" in body
 
 
@@ -525,3 +525,56 @@ def test_the_offer_of_a_second_node_points_at_the_store(app_client, fleet, telem
     fleet(node(SELF, is_self=True))
     body = app_client.get("/summary").data.decode()
     assert 'href="https://retina.fm"' in body
+
+
+# ── How your node sees ─────────────────────────────────────────
+
+
+def facts_section(body):
+    return body.split('<div class="section-head facts-head">')[1].split("</main>")[0]
+
+
+def test_the_primer_facts_are_shown(app_client, fleet, telemetry):
+    fleet(node(SELF, is_self=True))
+    facts = facts_section(app_client.get("/summary").data.decode())
+    for heading in ("It never transmits", "Two antennas, two paths",
+                    "Every detection is one dot", "It only hears a wedge",
+                    "One node sees an arc"):
+        assert heading in facts, heading
+
+
+def test_the_facts_cost_the_node_nothing(app_client, fleet, telemetry):
+    """The primer earns its keep by being driveable, and none of that can come
+    here: a node's compute belongs to the radar. Static markup only, so no
+    script and no extra fetch rides in with it."""
+    facts = facts_section(app_client.get("/summary").data.decode())
+    assert "<script" not in facts
+    assert "<img" not in facts and "<canvas" not in facts
+
+
+def test_the_facts_are_not_dressed_as_cards(app_client, fleet, telemetry):
+    """Everything card-shaped on this page is a link. Prose that cannot be
+    clicked must not look like something that can."""
+    facts = facts_section(app_client.get("/summary").data.decode())
+    assert "node-card" not in facts and "link-card" not in facts
+
+
+def test_no_primer_link_until_there_is_somewhere_to_send_people(app_client, fleet,
+                                                               telemetry):
+    """The branch carrying the primer is unmerged and the URL 404s today. A
+    dead link on an owner's node is worse than no link at all."""
+    from routes import fleet as fleet_routes
+
+    assert fleet_routes.PRIMER_URL == "", "turn the link on in the template test too"
+    facts = facts_section(app_client.get("/summary").data.decode())
+    assert "the full primer" not in facts
+
+
+def test_the_primer_link_appears_once_it_has_a_home(app_client, fleet, telemetry,
+                                                    monkeypatch):
+    from routes import fleet as fleet_routes
+
+    monkeypatch.setattr(fleet_routes, "PRIMER_URL", "https://offworldlabs.com/learn/")
+    facts = facts_section(app_client.get("/summary").data.decode())
+    assert 'href="https://offworldlabs.com/learn/"' in facts
+    assert 'rel="noopener"' in facts


### PR DESCRIPTION
Follows #79, which filled the blank Summary page with node cards. This adds everything below them. Seven commits, each reviewable on its own.

The page now reads: **Nodes on this network → Resources → Help → How your node sees.**

## Resources

Four fixed links out: the company, the wiki page for troubleshooting and tuning this box, and the two live views of the network.

A section of its own rather than more cards in the grid above. Those cards stand for hardware on this network and wear the antenna mark to say so; a link to a website in the same grid would either wear that mark, which would be a lie, or sit there without one, which would make the mark stop meaning anything.

Each card prints the host under its name, derived from the URL rather than written out, so it cannot drift from where the card actually goes. Every one leaves the device, so an owner should see they are about to be sent to github.com before they click rather than after.

`BUY_URL`, the offer of a second node shown to owners with only one, was a stand-in pointing where the banner's Server button went. It is `retina.fm` now.

## One name for map.retina.fm

The banner button said "Server" while the new Resources card pointing at the same URL said "Retina Network Map". The button takes the card's name, since "Server" said nothing about what is at the other end.

## Help

Two ways out when something is wrong: the Discord, and a support address.

**The Discord is named for whose it is.** The server behind that invite is called blah2. It is the upstream project's community, run by its author, not ours. Labelling it "Offworld Labs Discord" would send an owner with a hardware or account problem into a volunteer channel expecting our support, and hand that community questions it cannot answer.

The email card is not an outbound link: a mailto hands off to a mail client rather than navigating, so it gets neither `target="_blank"`, which would leave an empty tab behind, nor the outbound arrow, which here means "this leaves for another page". The address is printed in full because somebody may need to read it down a phone.

The Resources card markup is now a macro, since Help wears the same card.

## How your node sees

Two commits, and the second replaces the first: five static facts land, then give way to the primer's closing simulation. Both are in the history because the facts were live for a day and the reasoning is worth keeping, but what ships is the simulator.

Draw a flight path across the sky, press play, and watch the track paint on a delay-Doppler plot and break wherever the aircraft leaves the beam. The geometry is real: range is the true bistatic path difference, and the Doppler comes from the sum of the two unit legs, so it is zero when the heading is perpendicular to the ellipse normal rather than perpendicular to the node.

### It is the only piece here that needs a loop, so the loop is fenced

  - it never autoplays; a page nobody has touched does not animate
  - a hidden tab stops it, via `visibilitychange`
  - scrolling it out of view stops it, via `IntersectionObserver`
  - reduced motion is honoured, and it starts paused regardless
  - 30fps, not 60

Stopped in each case, rather than merely invisible.

### Static file, and a still diagram without it

`/static/flight-sim.js` rather than inline: a rendered template caches nothing, so an inline copy would re-send its 12 KB on every page load. The markup ships a correct still diagram, beam and flight path drawn into the page, so no script or a failed fetch leaves a picture rather than an empty box. The controls ship hidden and are revealed by the script that can drive them.

### The plot is scaled so a track cannot flatten on a bound

±300 Hz and 0–60 km, both labelled. The scale is chosen so the scene cannot reach either: drawn into the furthest corner this geometry tops out at 51 km, and the Doppler ceiling is 2v/λ, which at 170 m/s and the 213 MHz this node tunes is 242 Hz. Checked against five extremes — the default arc, a run straight onto the node, a pass along the baseline, a circle, and the four corners — worst case uses 85% of one axis and 81% of the other.

Speed and wavelength are named constants rather than a magic factor, so the numbers can be argued with.

A path drawn exactly over the node or the tower used to break the track: that leg is zero length, so the unit vector was 0/0 and the Doppler NaN. Both are drawn as targets in the middle of the scene, so somebody was always going to fly over one. Legs are floored at half a unit.

## Testing

878 tests pass, ruff clean. Live on a development node throughout.

## Still open, and deliberately not in here

The node's real map is ±1000 Hz over −10 to 400 delay bins, about −1.5 to 60 km at `fs` 2 MHz. The range axis matches it; the Doppler axis is deliberately tighter, because at ±1000 Hz a typical aircraft sits in the middle fifth and a teaching picture that spends four fifths of its height empty teaches nothing. Worth saying "±300 Hz" in the copy so nobody assumes it is the same axis they see in blah2.

`PRIMER_URL` is empty: the branch carrying the full primer is unmerged, `learn.offworldlabs.com` does not resolve and `offworldlabs.com/learn` 404s. A dead link on an owner's node is worse than no link, so the template omits the line while it is blank. Both states are tested.

`map.retina.fm` is now reachable twice from this page, once from the banner and once from a card. Deliberate for now, since the banner buttons are easy to miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
